### PR TITLE
External id in patient and Patient Appointment

### DIFF
--- a/healthcare/healthcare/doctype/patient/patient.json
+++ b/healthcare/healthcare/doctype/patient/patient.json
@@ -21,6 +21,7 @@
   "dob",
   "age_html",
   "image",
+  "external_id",
   "column_break_14",
   "status",
   "uid",
@@ -528,6 +529,12 @@
    "fieldname": "family_history",
    "fieldtype": "Small Text",
    "label": "Family History (Legacy)"
+  },
+  {
+   "fieldname": "external_id",
+   "fieldtype": "Data",
+   "label": "External ID",
+   "read_only": 1
   }
  ],
  "grid_page_length": 50,
@@ -535,7 +542,7 @@
  "image_field": "image",
  "links": [],
  "max_attachments": 50,
- "modified": "2025-03-20 13:15:19.144301",
+ "modified": "2025-03-20 22:33:58.807307",
  "modified_by": "Administrator",
  "module": "Healthcare",
  "name": "Patient",

--- a/healthcare/healthcare/doctype/patient/patient.py
+++ b/healthcare/healthcare/doctype/patient/patient.py
@@ -55,6 +55,8 @@ class Patient(Document):
 					"message": result["message"] or "Possible duplicate patient record(s) found",
 					"matches": result["matches"]
 				}
+		if not self.external_id:
+			self.external_id = self.name
 
 	def before_insert(self):
 		self.set_missing_customer_details()

--- a/healthcare/healthcare/doctype/patient_appointment/patient_appointment.json
+++ b/healthcare/healthcare/doctype/patient_appointment/patient_appointment.json
@@ -12,6 +12,7 @@
   "status",
   "appointment_type",
   "appointment_for",
+  "external_id",
   "column_break_1",
   "company",
   "practitioner",
@@ -422,10 +423,16 @@
    "options": "Service Request",
    "read_only": 1,
    "search_index": 1
+  },
+  {
+   "fieldname": "external_id",
+   "fieldtype": "Data",
+   "label": "External ID",
+   "read_only": 1
   }
  ],
  "links": [],
- "modified": "2024-11-20 08:21:29.729408",
+ "modified": "2025-03-20 22:35:01.117803",
  "modified_by": "Administrator",
  "module": "Healthcare",
  "name": "Patient Appointment",

--- a/healthcare/healthcare/doctype/patient_appointment/patient_appointment.py
+++ b/healthcare/healthcare/doctype/patient_appointment/patient_appointment.py
@@ -67,6 +67,9 @@ class PatientAppointment(Document):
 		self.update_event()
 		self.set_postition_in_queue()
 
+		if not self.external_id:
+			self.external_id = self.name
+
 	def before_save(self):
 		# Always ensure duration is set
 		self.ensure_duration_is_set()


### PR DESCRIPTION
## Patient and Patient Appointment

Both the doctype has field `external_id`

if document is created by the API `api/resource/doctype` then you have to pars the ket `external_id : [value]`
other wise system will set the document id in external_id