### PR TITLE
New Patch , Create Appointment type at the time of setup a site

### DIFF
--- a/healthcare/patches.txt
+++ b/healthcare/patches.txt
@@ -19,3 +19,4 @@ healthcare.patches.v15_0.setup_basic_code_systems
 healthcare.patches.v15_0.setup_diagnostic_module_codes
 healthcare.patches.v15_0.setup_order_status_codes
 healthcare.patches.v15_0.setup_patient_duplicate_check_rules
+healthcare.patches.v15_0.create_appointment_type

--- a/healthcare/patches/v15_0/create_appointment_type.py
+++ b/healthcare/patches/v15_0/create_appointment_type.py
@@ -1,0 +1,27 @@
+
+import frappe
+
+# Create an Appintment Type at the time of setup
+def execute():
+    appointment_type = [
+        "Consultation",
+        "Therapy Session",
+        "Unavailable",
+        "Block Booking",
+    ]
+
+    color = [
+        "#39E4A5",
+        "#ECAD4B",
+        "#f5001d",
+        "#002df5"
+    ]
+
+    for i, row in enumerate(appointment_type):
+        if not frappe.db.exists("Appointment Type", row):
+            doc = frappe.get_doc({
+                "doctype" : "Appointment Type",
+                "appointment_type" : row,
+                "default_duration" : 20,
+                "color" : color[i]
+            }).save()


### PR DESCRIPTION
There is some code in the app related to Appointment Type, so those Appointment Types should be available during the new site setup.