### PR TITLE
fix: mode of payment amount was not able to fetch in table

### DIFF
--- a/healthcare/public/js/sales_invoice.js
+++ b/healthcare/public/js/sales_invoice.js
@@ -353,15 +353,19 @@ var add_to_item_line = function(frm, checked_values, invoice_healthcare_services
 	if(invoice_healthcare_services){
 		frappe.call({
 			method: "healthcare.healthcare.custom_doctype.sales_invoice.set_healthcare_services",
-			args:{
-				self : frm.doc,
+			args: {
+				self: frm.doc,
 				checked_values: checked_values
 			},
 			callback: function(r) {
-				frm.set_value(r.message)
-				frm.reload_doc()
-			}
-		});
+				frm.set_value(r.message);
+				frm.refresh_fields()
+				setTimeout(() => {
+						cur_frm.cscript.set_total_amount_to_default_mop();
+						}, 300);
+				}
+	});
+
 	}
 	else{
 		for(let i=0; i<checked_values.length; i++){


### PR DESCRIPTION
While Creating a sales invoice for appointment or using a Get Items From Button to fetch a details, system was not updating an amount in Sales Invoice Payment. Table that is fixed