### PR TITLE
fix: replace ifnull SQL function with Frappe-compatible filter syntax in get_children

### DIFF
--- a/healthcare/healthcare/utils.py
+++ b/healthcare/healthcare/utils.py
@@ -855,7 +855,10 @@ def get_children(doctype, parent=None, company=None, is_root=False):
 	parent_fieldname = "parent_" + doctype.lower().replace(" ", "_")
 	fields = ["name as value", "is_group as expandable", "lft", "rgt"]
 
-	filters = [["ifnull(`{0}`,'')".format(parent_fieldname), "=", "" if is_root else parent]]
+	if is_root:
+		filters = [[parent_fieldname, "in", [None, ""]]]
+	else:
+		filters = [[parent_fieldname, "=", parent]]
 
 	if is_root:
 		fields += ["service_unit_type"] if doctype == "Healthcare Service Unit" else []


### PR DESCRIPTION
# fix: replace ifnull SQL filter with Frappe-compatible syntax in get_children

## Summary
The `get_children` function in `healthcare/utils.py` used raw SQL `ifnull()` syntax inside a `frappe.get_list` filter, which is not supported by Frappe's filter validation. This caused an "Invalid Filter" popup when loading tree views (e.g., Healthcare Service Unit).

Replaced with standard Frappe filter operators:
- **Root nodes**: `[parent_fieldname, "in", [None, ""]]` to match records where parent is NULL or empty
- **Child nodes**: `[parent_fieldname, "=", parent]` to match a specific parent

Fixes #231

## Review & Testing Checklist for Human
- [ ] **Verify Frappe's ORM translation of `"in", [None, ""]`**: In standard SQL, `field IN (NULL, '')` does **not** match NULL rows. Confirm that Frappe special-cases this to generate `(field IS NULL OR field = '')`. If not, root-level nodes with a NULL parent field will silently disappear from the tree. This is the highest-risk item in this PR.
- [ ] **Test the Healthcare Service Unit tree view** on a running instance: navigate to the tree, expand nodes, and confirm both root and child nodes load without the "Invalid Filter" error.
- [ ] **Test any other doctypes** that use `get_children` (the function is generic, constructing `parent_fieldname` dynamically from the doctype name).

### Notes
- If Frappe does not handle `None` inside `"in"` filters correctly, an alternative would be to use `[parent_fieldname, "is", "not set"]` for the root case, which is explicitly designed to match both NULL and empty string in Frappe.
- No automated tests were run; this requires a live Frappe instance to verify.

Link to Devin run: https://app.devin.ai/sessions/0aa334ee03134b6c94ee1a1bd39ed05e
Requested by: @pythonpen
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tacten/biograph/pull/235" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
