### PR TITLE
fix: add missing appointment field to Sample Collection DocType

### DIFF
--- a/healthcare/healthcare/doctype/sample_collection/sample_collection.json
+++ b/healthcare/healthcare/doctype/sample_collection/sample_collection.json
@@ -38,6 +38,7 @@
   "service_request",
   "reference_doc",
   "reference_name",
+  "appointment",
   "amended_from"
  ],
  "fields": [
@@ -287,6 +288,12 @@
    "label": "Referring Practitioner",
    "options": "Healthcare Practitioner",
    "read_only_depends_on": "referring_practitioner"
+  },
+  {
+   "fieldname": "appointment",
+   "fieldtype": "Link",
+   "label": "Appointment",
+   "options": "Patient Appointment"
   },
   {
    "fieldname": "amended_from",

--- a/healthcare/healthcare/doctype/sample_collection/sample_collection.py
+++ b/healthcare/healthcare/doctype/sample_collection/sample_collection.py
@@ -29,8 +29,8 @@ class SampleCollection(Document):
 							},
 						)
 
-		if self.get("appointment"):
-			frappe.db.set_value("Patient Appointment", self.get("appointment"), "status", "Closed")
+		if self.appointment:
+			frappe.db.set_value("Patient Appointment", self.appointment, "status", "Closed")
 
 	def validate(self):
 		if self.observation_sample_collection:

--- a/healthcare/healthcare/doctype/sample_collection/sample_collection.py
+++ b/healthcare/healthcare/doctype/sample_collection/sample_collection.py
@@ -30,7 +30,7 @@ class SampleCollection(Document):
 						)
 
 		if self.get("appointment"):
-			frappe.db.set_value("Patient Appointment", self.appointment, "status", "Closed")
+			frappe.db.set_value("Patient Appointment", self.get("appointment"), "status", "Closed")
 
 	def validate(self):
 		if self.observation_sample_collection:


### PR DESCRIPTION
# fix: add missing appointment field to Sample Collection DocType

## Summary
Fixes `AttributeError: 'SampleCollection' object has no attribute 'appointment'` thrown during `after_insert` when creating a new Sample Collection.

The root cause is that the `appointment` field (Link to Patient Appointment) exists in the upstream [earthians/marley](https://github.com/earthians/marley) `version-16` branch but was missing from the biograph fork's DocType JSON definition. The Python code in `after_insert` references `self.appointment`, which fails because the field was never defined.

### Changes
- **`sample_collection.json`**: Added the `appointment` field (Link → Patient Appointment) to both `field_order` and `fields`, matching upstream.
- **`sample_collection.py`**: Reverted line 32 from `self.get("appointment")` back to `self.appointment` to match upstream. With the field now properly defined, direct access is correct.

Fixes #225

## Review & Testing Checklist for Human
- [ ] **Run `bench migrate` after deploying** — the new field in the JSON needs to be synced to the database schema. Without migration, the column won't exist and queries involving `appointment` may fail.
- [ ] **Test creating a new Sample Collection** — navigate to Sample Collection → New → add observation details → Save. Confirm no server error appears.
- [ ] **Verify the `appointment` field appears on the form** and can be linked to a Patient Appointment record. Test that saving a Sample Collection with an appointment correctly sets the appointment status to "Closed".
- [ ] **Confirm field placement matches upstream** — the `appointment` field should appear in the form layout in the same section as `service_request`, `reference_doc`, and `reference_name`.

### Notes
- The fix aligns with the upstream [earthians/marley version-16](https://github.com/earthians/marley/tree/version-16) implementation.
- Link to Devin run: https://app.devin.ai/sessions/0aa334ee03134b6c94ee1a1bd39ed05e
- Requested by: @pythonpen
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tacten/biograph/pull/236" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
