### PR TITLE
fix(patient_quick_entry): add missing phone field to quick entry standard fields

### DIFF
--- a/healthcare/public/js/patient_quick_entry.js
+++ b/healthcare/public/js/patient_quick_entry.js
@@ -113,6 +113,12 @@ frappe.ui.form.PatientQuickEntryForm = class PatientQuickEntryForm extends frapp
 				fieldtype: 'Column Break'
 			},
 			{
+				label: __('Phone'),
+				fieldname: 'phone',
+				fieldtype: 'Data',
+				options: 'Phone'
+			},
+			{
 				label: __('Mobile Number'),
 				fieldname: 'mobile',
 				fieldtype: 'Data',


### PR DESCRIPTION
# fix(patient_quick_entry): add missing phone field to quick entry dialog

## Summary

The Patient Quick Entry dialog crashes with `TypeError: Cannot read properties of undefined (reading '$wrapper')` because `render_dialog()` attaches an input validation handler to `this.dialog.fields_dict.phone`, but the `phone` field was never included in `get_standard_fields()`. This adds the missing `phone` field definition to the standard fields list in the Primary Contact section, resolving the crash.

Closes #237

## Review & Testing Checklist for Human

- [ ] **Open Patient Quick Entry dialog** — verify it renders without errors (this was the original crash)
- [ ] **Enter a phone number** — confirm the numeric-only validation fires correctly and the value is saved to the Patient's `phone` field
- [ ] **Check form layout** — both Phone and Mobile now appear in the right column of the Primary Contact section; verify the visual layout is acceptable

### Notes
- The upstream [earthians/marley version-16](https://github.com/earthians/marley/tree/version-16) `patient_quick_entry.js` does not have the custom input handlers at all (no phone/mobile validation, no name capitalization). These are biograph-specific additions that referenced `phone` before it was added to the field list.
- The `phone` field exists on the Patient DocType (`patient.json` line 222), so data mapping should work correctly.
- This change was not tested in a live Frappe environment — manual QA is required.

Link to Devin run: https://app.devin.ai/sessions/664e598c041e42c4b69376087ac1ccb6
Requested by: @pythonpen