### PR TITLE
feat: sync upstream marley version-16 commits to biograph-fh

### DIFF
--- a/healthcare/healthcare/doctype/clinical_procedure/clinical_procedure.js
+++ b/healthcare/healthcare/doctype/clinical_procedure/clinical_procedure.js
@@ -174,6 +174,7 @@ frappe.ui.form.on('Clinical Procedure', {
 			frm.add_fetch('procedure_template', 'medical_department', 'medical_department');
 			frm.set_value('start_time', null);
 		}
+		set_defaults(frm);
 	},
 
 	patient: function(frm) {
@@ -504,4 +505,20 @@ let show_procedure_templates = function(frm, result){
 		$(repl('<div class="text-left">%(msg)s</div>', {msg: msg})).appendTo(html_field);
 	}
 	d.show();
+};
+
+let set_defaults = function(frm) {
+	if (frm.is_new()) {
+		frappe.db
+			.get_single_value("Stock Settings", "default_warehouse")
+			.then(value => {
+				frm.set_value("warehouse", value);
+			});
+
+		frappe.db
+			.get_single_value("Selling Settings", "selling_price_list")
+			.then(value => {
+				frm.set_value("price_list", value);
+			});
+	}
 };

--- a/healthcare/healthcare/doctype/clinical_procedure/clinical_procedure.json
+++ b/healthcare/healthcare/doctype/clinical_procedure/clinical_procedure.json
@@ -18,19 +18,24 @@
   "patient_sex",
   "patient_age",
   "inpatient_record",
-  "notes",
   "column_break_7",
   "status",
   "practitioner",
   "practitioner_name",
   "medical_department",
   "service_unit",
+  "sample",
+  "section_break_brtm",
   "start_date",
   "start_time",
-  "sample",
+  "actual_start_datetime",
+  "column_break_mugc",
+  "planned_end_datetime",
+  "actual_end_datetime",
   "consumables_section",
   "consume_stock",
   "warehouse",
+  "price_list",
   "items",
   "section_break_24",
   "invoice_separately_as_consumables",
@@ -38,6 +43,8 @@
   "consumable_total_amount",
   "column_break_27",
   "consumption_details",
+  "section_break_igrj",
+  "notes",
   "medical_coding_section",
   "codification_table",
   "sb_refs",
@@ -144,12 +151,14 @@
    "default": "Today",
    "fieldname": "start_date",
    "fieldtype": "Date",
-   "label": "Start Date"
+   "label": "Start Date",
+   "no_copy": 1
   },
   {
    "fieldname": "start_time",
    "fieldtype": "Time",
-   "label": "Start Time"
+   "label": "Start Time",
+   "no_copy": 1
   },
   {
    "fieldname": "sample",
@@ -313,6 +322,47 @@
    "options": "Service Request",
    "read_only": 1,
    "search_index": 1
+  },
+  {
+   "fieldname": "section_break_igrj",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "planned_end_datetime",
+   "fieldtype": "Datetime",
+   "label": "Planned End Datetime",
+   "no_copy": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "actual_end_datetime",
+   "fieldtype": "Datetime",
+   "label": "Actual End Datetime",
+   "no_copy": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "section_break_brtm",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "actual_start_datetime",
+   "fieldtype": "Datetime",
+   "label": "Actual Start Datetime",
+   "no_copy": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_mugc",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "price_list",
+   "fieldtype": "Link",
+   "label": "Price List",
+   "link_filters": "[[\"Price List\",\"selling\",\"=\",1]]",
+   "mandatory_depends_on": "eval: doc.consume_stock == 1",
+   "options": "Price List"
   }
  ],
  "is_submittable": 1,

--- a/healthcare/healthcare/doctype/patient_appointment/patient_appointment.py
+++ b/healthcare/healthcare/doctype/patient_appointment/patient_appointment.py
@@ -1194,11 +1194,14 @@ def check_sales_invoice_exists(appointment):
 
 
 @frappe.whitelist()
-def get_availability_data(date, practitioner, appointment):
+def get_availability_data(
+	date: str, practitioner: str, appointment: str | dict | "PatientAppointment" | None = None
+):
 	"""
 	Get availability data of 'practitioner' on 'date'
 	:param date: Date to check in schedule
 	:param practitioner: Name of the practitioner
+	:param appointment: Appointment doc to validate fee validity
 	:return: dict containing a list of available slots, list of appointments and time of appointments
 	"""
 

--- a/healthcare/healthcare/doctype/sample_collection/sample_collection.py
+++ b/healthcare/healthcare/doctype/sample_collection/sample_collection.py
@@ -241,7 +241,7 @@ def create_specimen(patient, selected, component_observations):
 		specimen = frappe.new_doc("Specimen")
 		specimen.received_time = now_datetime()
 		specimen.patient = patient
-		specimen.specimen_type = groups[gr][0].get("sample_type")
+		specimen.specimen_type = (groups[gr][0].get("sample") or groups[gr][0].get("sample_type"))
 		specimen.save()
 		for sub_grp in groups[gr]:
 			if component_observations:

--- a/healthcare/healthcare/doctype/sample_collection/sample_collection.py
+++ b/healthcare/healthcare/doctype/sample_collection/sample_collection.py
@@ -241,7 +241,7 @@ def create_specimen(patient, selected, component_observations):
 		specimen = frappe.new_doc("Specimen")
 		specimen.received_time = now_datetime()
 		specimen.patient = patient
-		specimen.specimen_type = (groups[gr][0].get("sample") or groups[gr][0].get("sample_type"))
+		specimen.specimen_type = groups[gr][0].get("sample") or groups[gr][0].get("sample_type")
 		specimen.save()
 		for sub_grp in groups[gr]:
 			if component_observations:


### PR DESCRIPTION
# feat: sync upstream marley version-16 commits to biograph-fh

## Summary
Syncs relevant commits from [earthians/marley version-16](https://github.com/earthians/marley/tree/version-16) made after the last merged commit (`df9bf5b9`) into `biograph-fh`, while preserving biograph-specific logic (custom service request handling via `update_service_request_status`, unavailability appointment logic, insurance coverage, etc.).

**Cherry-picked cleanly (3 commits):**
- `6f5ca09` + `2a8dd40`: Fix sample collection specimen_type field lookup + linter cleanup
- `4dc4130`: Validate practitioner unavailability against schedule time slots (not just existing availabilities)

**Manually merged (preserving biograph-specific code):**
- `6d75a3a`: Type hints for `get_availability_data` in patient_appointment.py
- `98b1ef1`, `1773b1b`, `6285fdf`, `a160abf`, `814a219`, `858c63c`, `45efec6`, `2a9b321`: Clinical Procedure overhaul — new datetime tracking fields, price list support, refactored stock validation, consolidated db writes

**Skipped (not applicable to biograph-fh):**
- `e851a62`: `slot_details` init — biograph doesn't have the `available_slotes` code path
- `ee07446`: `allow_appointments` → `overlap_appointments` — already correct in biograph
- `0329e61`, `1d6d67a`, `72c61a4`: Semantic release config and version bumps

### Key Clinical Procedure changes:
- New fields: `actual_start_datetime`, `planned_end_datetime`, `actual_end_datetime`, `price_list`
- `start_procedure()` now records `actual_start_datetime` and allows starting without stock consumption requirement
- `complete_procedure()` now records `actual_end_datetime`, validates `price_list` is set, and uses consolidated `db_set()` with dict
- `set_actual_qty()` → `has_required_qty()` with simplified logic (no longer mutates item `actual_qty` during validation)
- New methods: `set_price_list()`, `set_planned_start_date_and_time()`, `set_planned_endtime()`
- JS: Added `set_defaults()` to auto-populate warehouse and price_list on new procedures

## Review & Testing Checklist for Human

**⚠️ CRITICAL - Breaking Change Risk:**
- [ ] **Test existing in-progress Clinical Procedures**: Verify that procedures created before this PR can still be completed. The new code requires `price_list` to be set when completing procedures with consumables. Existing procedures may not have this field populated and will fail with "Price List is mandatory" error.
  - **Mitigation**: May need a migration script to backfill `price_list` on existing procedures, or add fallback logic in `complete_procedure()`.

**🔴 High Priority:**
- [ ] **Test Clinical Procedure workflow end-to-end**: Create a new procedure with consumables, start it, complete it. Verify:
  - `actual_start_datetime` is recorded on start
  - `actual_end_datetime` is recorded on completion
  - `planned_end_datetime` is calculated from template duration
  - Price list defaults are set correctly
  - Stock consumption still works
  - Consumable invoicing still works
- [ ] **Verify `actual_qty` display in UI**: The JS indicator formatter (`doc.qty<=doc.actual_qty`) may show incorrect colors since `actual_qty` is no longer set during validation. Check if the stock indicator still works correctly in the items table.
- [ ] **Test start without stock**: Verify that procedures can now start even when `consume_stock` is unchecked (new behavior). Ensure this doesn't break any workflows that depend on stock validation.

**🟡 Medium Priority:**
- [ ] **Test practitioner unavailability validation**: Create an unavailability block for a practitioner and verify it correctly validates against both existing availabilities AND practitioner schedules (new behavior from `4dc4130`).
- [ ] **Verify biograph-specific service request handling**: Ensure `update_service_request_status()` still works correctly with the restructured `complete_procedure()` and `on_submit()` methods.
- [ ] **Check field reordering impact**: The `notes` field was moved to a different section in the form. Verify this doesn't break any user workflows or customizations.

### Test Plan
1. Create a new Clinical Procedure from a Patient Appointment with consumables
2. Verify price_list is auto-populated
3. Start the procedure and verify `actual_start_datetime` is set
4. Complete the procedure and verify `actual_end_datetime` is set and consumables are invoiced correctly
5. Test with an existing in-progress procedure (if any exist) to verify backward compatibility
6. Test practitioner unavailability creation with schedule overlap validation

### Notes
- All biograph-specific code patterns preserved (e.g., `update_service_request_status`, `therapy_session` variable naming, custom appointment status handling)
- Python 3.10+ required for type hint syntax (`str | dict | ...`)
- No CI configured for this repo — manual testing required
- Link to Devin run: https://app.devin.ai/sessions/664e598c041e42c4b69376087ac1ccb6
- Requested by: @pythonpen