### PR TITLE
fix: add missing allow_discharge_despite_pending_healthcare_services field to Healthcare Settings

### DIFF
--- a/healthcare/healthcare/doctype/healthcare_settings/healthcare_settings.json
+++ b/healthcare/healthcare/doctype/healthcare_settings/healthcare_settings.json
@@ -22,6 +22,9 @@
   "valid_days",
   "inpatient_settings_section",
   "allow_discharge_despite_unbilled_services",
+  "allow_discharge_despite_pending_healthcare_services",
+  "column_break_bkvx",
+  "automatically_generate_billable",
   "do_not_bill_inpatient_encounters",
   "orders_tab",
   "default_intent",
@@ -324,6 +327,23 @@
    "fieldname": "allow_discharge_despite_unbilled_services",
    "fieldtype": "Check",
    "label": "Allow Discharge Despite Unbilled Healthcare Services"
+  },
+  {
+   "default": "0",
+   "fieldname": "allow_discharge_despite_pending_healthcare_services",
+   "fieldtype": "Check",
+   "label": "Allow Discharge Despite Pending Healthcare Services"
+  },
+  {
+   "fieldname": "column_break_bkvx",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "description": "Nightly generate billable from Inpatient Occupancy",
+   "fieldname": "automatically_generate_billable",
+   "fieldtype": "Check",
+   "label": "Automatically Generate Billable"
   },
   {
    "default": "0",


### PR DESCRIPTION
## Summary

Discharging an inpatient (`HLC-INP-*`) throws a `ValidationError` because `inpatient_record.py:validate_incomplete_service_requests()` references the field `allow_discharge_despite_pending_healthcare_services` on `Healthcare Settings`, but the field was never added to the doctype JSON definition.

This PR adds three fields missing from the upstream [marley version-16](https://github.com/earthians/marley/tree/version-16) `Healthcare Settings` doctype:

- **`allow_discharge_despite_pending_healthcare_services`** (Check) — controls whether discharge is blocked when there are incomplete Service Requests
- **`column_break_bkvx`** — layout column break in the Inpatient Settings section
- **`automatically_generate_billable`** (Check) — nightly billable generation from Inpatient Occupancy

No Python code changes; the existing `inpatient_record.py` logic already expects these fields.

## Review & Testing Checklist for Human

- [ ] **Verify discharge logic direction**: The `validate_incomplete_service_requests` function skips validation when the checkbox is *unchecked* (default). When *checked*, it blocks discharge if pending Service Requests exist. Confirm this matches the intended behavior — the label "Allow Discharge Despite Pending..." reads as permissive, but the code behavior is restrictive when enabled.
- [ ] **Run `bench migrate`** on a test site after deploying and confirm the three new fields appear in Healthcare Settings → OP & IP → Inpatient Settings section.
- [ ] **Test end-to-end**: Schedule discharge on an inpatient record (like `HLC-INP-2026-00054`) and confirm the `ValidationError` no longer occurs. Test both with the checkbox checked and unchecked to verify the pending-services validation behavior.
- [ ] **Check `automatically_generate_billable`**: This field is added to match upstream but verify whether the corresponding scheduler job exists in the biograph-fh codebase. If not, the field will be inert (default off), which is safe but worth noting.

### Notes
- The status filter `"completed-Request Status"` in `validate_incomplete_service_requests` differs from upstream's `"Completed"` — this is intentional and consistent with the biograph-fh codebase convention.

Link to Devin session: https://app.devin.ai/sessions/b6d1301c034942fead82274c35dbe0ed
Requested by: @pythonpen