### PR TITLE
fix: replace happiest_frappe import with local get_available_slots in recurring appointment handler

### DIFF
--- a/healthcare/healthcare/doctype/patient_appointment/recuring_appointment_handler.py
+++ b/healthcare/healthcare/doctype/patient_appointment/recuring_appointment_handler.py
@@ -1,336 +1,339 @@
-import frappe
 import json
-from frappe.utils import getdate, add_days, add_months, add_years, date_diff
-from datetime import timedelta
-from healthcare.healthcare.doctype.patient_appointment.patient_appointment import (
-    check_employee_wise_availability,
-    validate_practitioner_schedules,
-    check_sales_invoice_exists,
-    cancel_sales_invoice
-
-)
 from datetime import datetime, timedelta
-from happiest_frappe.happiest_frappe.api.api import get_available_slots
+
+import frappe
 from frappe.email.doctype.notification.notification import Notification, get_context
+from frappe.utils import add_days, add_months, add_years, date_diff, getdate
+
+from healthcare.healthcare.doctype.patient_appointment.patient_appointment import (
+	cancel_sales_invoice,
+	check_employee_wise_availability,
+	check_sales_invoice_exists,
+	get_available_slots,
+	validate_practitioner_schedules,
+)
 
 
 @frappe.whitelist()
 def create_recurring_appointments(data):
-    data = frappe._dict(json.loads(data))
+	data = frappe._dict(json.loads(data))
 
-    repeat_on = data.repeat_on
-    repeat_interval = data.repeat_interval or 1
-    repeat_till = getdate(data.repeat_till)
-    base_date = getdate(data.from_date)
-    max_occurrences = data.max_occurrences
-    created = []
-    schedule_details = get_recurring_appointment_dates(data)
+	schedule_details = get_recurring_appointment_dates(data)
 
-    if not schedule_details.get("dates"):
-        frappe.throw("Slots are not available")
-    for row in schedule_details.get("dates"):
-        if not row.get("booking_flage"):
-            doc = frappe.get_doc({
-                "doctype" : "Patient Appointment",
-                "appointment_date" : row.get("date"),
-                "patient" : data.patient,
-                "practitioner" : data.practitioner,
-                "appointment_time" : row.get("from_time"),
-                "end_time" : row.get("to_time"),
-                "service_unit" : data.service_unit,
-                "recurring_appointments" : 1,
-                "appointment_type" : data.appointment_type,
-                "therapy_plan" : data.therapy_plan if data.appointment_type == 'Therapy Session' else ''
-            })
+	if not schedule_details.get("dates"):
+		frappe.throw("Slots are not available")
+	for row in schedule_details.get("dates"):
+		if not row.get("booking_flage"):
+			doc = frappe.get_doc(
+				{
+					"doctype": "Patient Appointment",
+					"appointment_date": row.get("date"),
+					"patient": data.patient,
+					"practitioner": data.practitioner,
+					"appointment_time": row.get("from_time"),
+					"end_time": row.get("to_time"),
+					"service_unit": data.service_unit,
+					"recurring_appointments": 1,
+					"appointment_type": data.appointment_type,
+					"therapy_plan": data.therapy_plan if data.appointment_type == "Therapy Session" else "",
+				}
+			)
 
-            if data.appointment_type == 'Therapy Session' and data.therapy_plan:
-                therapy = frappe.get_doc("Therapy Plan", data.therapy_plan)
-                for d in therapy.therapy_plan_details:
-                    doc.append("therapy_types", {
-                        "therapy_type" : d.therapy_type,
-                        "no_of_sessions" : d.no_of_sessions
-                    })
-            doc.insert(ignore_permissions=True)
+			if data.appointment_type == "Therapy Session" and data.therapy_plan:
+				therapy = frappe.get_doc("Therapy Plan", data.therapy_plan)
+				for d in therapy.therapy_plan_details:
+					doc.append(
+						"therapy_types", {"therapy_type": d.therapy_type, "no_of_sessions": d.no_of_sessions}
+					)
+			doc.insert(ignore_permissions=True)
 
-    return True
+	return True
 
-    
+
 def prepare_payload_for_email(self, doc, context):
-    """Prepare and render the WhatsApp message payload."""
-    payload_template = self.message
-    rendered_payload = frappe.render_template(payload_template, context)
-    payload = rendered_payload
-    return payload
+	"""Prepare and render the WhatsApp message payload."""
+	payload_template = self.message
+	rendered_payload = frappe.render_template(payload_template, context)
+	payload = rendered_payload
+	return payload
+
 
 @frappe.whitelist()
 def book_appointments(data):
-    frappe.enqueue(
-					create_recurring_appointments,
-                    data=data,
-					queue="long",
-					is_async=True,
-					enqueue_after_commit=True
-				)
-    return True
+	frappe.enqueue(
+		create_recurring_appointments, data=data, queue="long", is_async=True, enqueue_after_commit=True
+	)
+	return True
+
 
 @frappe.whitelist()
 def get_recurring_appointment_dates(data):
-    try:
-        data = frappe._dict(json.loads(data))
-    except:
-        data = data
+	try:
+		data = frappe._dict(json.loads(data))
+	except Exception:
+		pass
 
-    time_obj = datetime.strptime(data.get("from_time"), "%H:%M:%S").time()
-    from_time = timedelta(hours=time_obj.hour, minutes=time_obj.minute, seconds=time_obj.second)
-    time_obj = datetime.strptime(data.get("to_time"), "%H:%M:%S").time()
-    to_time = timedelta(hours=time_obj.hour, minutes=time_obj.minute, seconds=time_obj.second)
+	time_obj = datetime.strptime(data.get("from_time"), "%H:%M:%S").time()
+	from_time = timedelta(hours=time_obj.hour, minutes=time_obj.minute, seconds=time_obj.second)
+	time_obj = datetime.strptime(data.get("to_time"), "%H:%M:%S").time()
+	to_time = timedelta(hours=time_obj.hour, minutes=time_obj.minute, seconds=time_obj.second)
 
-    repeat_on = data.repeat_on  # Daily, Weekly, Monthly, Yearly
-    repeat_interval = data.repeat_interval or 1
-    repeat_till = getdate(data.repeat_till) if data.repeat_till else None
-    base_date = getdate(data.from_date) 
-    max_occurrences = data.max_occurrences
-    practitioner_doc = frappe.get_doc("Healthcare Practitioner", data.practitioner)
-    
-    practitioner_schedule_list = []
-    for row in practitioner_doc.practitioner_schedules:
-        if row.service_unit == data.service_unit:
-            practitioner_schedule = frappe.get_doc("Practitioner Schedule", row.schedule)
-            for log in practitioner_schedule.time_slots:
-                practitioner_schedule_list.append(log)
+	repeat_on = data.repeat_on  # Daily, Weekly, Monthly, Yearly
+	repeat_interval = data.repeat_interval or 1
+	repeat_till = getdate(data.repeat_till) if data.repeat_till else None
+	base_date = getdate(data.from_date)
+	max_occurrences = data.max_occurrences
+	practitioner_doc = frappe.get_doc("Healthcare Practitioner", data.practitioner)
 
-    week_checks = ["monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday" ]
-    week_day = {
-        "monday": "Monday", "tuesday": "Tuesday", "wednesday": "Wednesday", "thursday": "Thursday",
-        "friday": "Friday", "saturday": "Saturday", "sunday": "Sunday"
-    }
+	practitioner_schedule_list = []
+	for row in practitioner_doc.practitioner_schedules:
+		if row.service_unit == data.service_unit:
+			practitioner_schedule = frappe.get_doc("Practitioner Schedule", row.schedule)
+			for log in practitioner_schedule.time_slots:
+				practitioner_schedule_list.append(log)
 
-    # Collect weekly repeat days
-    repeat_week_days = []
-    if repeat_on == "Weekly":
-        for row in week_checks:
-            if data.get(row):
-                repeat_week_days.append(week_day.get(row))
+	week_checks = ["monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"]
+	week_day = {
+		"monday": "Monday",
+		"tuesday": "Tuesday",
+		"wednesday": "Wednesday",
+		"thursday": "Thursday",
+		"friday": "Friday",
+		"saturday": "Saturday",
+		"sunday": "Sunday",
+	}
 
-    scheduled_dates = []
-    next_date = base_date
+	# Collect weekly repeat days
+	repeat_week_days = []
+	if repeat_on == "Weekly":
+		for row in week_checks:
+			if data.get(row):
+				repeat_week_days.append(week_day.get(row))
 
-    # For Weekly repeat, track occurrences per weekday; otherwise use single counter
-    if repeat_on == "Weekly":
-        occurrences = {day: 0 for day in repeat_week_days}
-    else:
-        occurrences = 0
-    
-    total_day_of_booking = len(repeat_week_days)
-    available_any = False
+	scheduled_dates = []
+	next_date = base_date
 
-    max_iterations = 365  
-    iteration_count = 0
-    
-    while True:
-        iteration_count += 1
-        if iteration_count > max_iterations:
-            break  
-            
-        if next_date == getdate() and from_time:
-            datetime_str = f"{next_date} {from_time}"
-            dt = datetime.strptime(datetime_str, "%Y-%m-%d %H:%M:%S")
-            if dt < frappe.utils.get_datetime():
-                next_date += timedelta(days=1)
-                continue
-        # Check if the practitioner's schedule allows this time on this day
-        available = False
-        for row in practitioner_schedule_list:
-            if row.day == next_date.strftime("%A"):
-                # Check if the requested time slot fits inside the available time slot
-                if row.from_time <= from_time < row.to_time:
-                    available = True
-                    available_any = True
-                if row.from_time < to_time <= row.to_time:
-                    available = True
-                    available_any = True
-                if (row.from_time >= from_time < row.to_time and 
-                    row.from_time < to_time > row.to_time):
-                    available = True
-                    available_any = True
-                if (row.from_time >= from_time < row.to_time and 
-                    row.from_time < to_time <= row.to_time):
-                    available = True
-                    available_any = True
+	# For Weekly repeat, track occurrences per weekday; otherwise use single counter
+	if repeat_on == "Weekly":
+		occurrences = {day: 0 for day in repeat_week_days}
+	else:
+		occurrences = 0
 
-        if not available:
-            next_date += timedelta(days=1)
-            if repeat_till and getdate(next_date) >= getdate(repeat_till):
-                print(repeat_till, "repeat_till")
-                break
-            
-            weekday_name = next_date.strftime("%A")
-            if repeat_on == "Weekly" and max_occurrences and occurrences.get(weekday_name, 0) >= max_occurrences:
-                # If all weekdays reached max_occurrences, break
-                if all(occ >= max_occurrences for occ in occurrences.values()):
-                    break
-                next_date += timedelta(days=1)
-                continue
+	total_day_of_booking = len(repeat_week_days)
+	available_any = False
 
-            if repeat_on != "Weekly" and max_occurrences and occurrences >= max_occurrences:
-                break
-            continue
+	max_iterations = 365
+	iteration_count = 0
 
-        # Check if the date is a holiday
-        holiday_list = frappe.db.sql(f"""
+	while True:
+		iteration_count += 1
+		if iteration_count > max_iterations:
+			break
+
+		if next_date == getdate() and from_time:
+			datetime_str = f"{next_date} {from_time}"
+			dt = datetime.strptime(datetime_str, "%Y-%m-%d %H:%M:%S")
+			if dt < frappe.utils.get_datetime():
+				next_date += timedelta(days=1)
+				continue
+		# Check if the practitioner's schedule allows this time on this day
+		available = False
+		for row in practitioner_schedule_list:
+			if row.day == next_date.strftime("%A"):
+				# Check if the requested time slot fits inside the available time slot
+				if row.from_time <= from_time < row.to_time:
+					available = True
+					available_any = True
+				if row.from_time < to_time <= row.to_time:
+					available = True
+					available_any = True
+				if row.from_time >= from_time < row.to_time and row.from_time < to_time > row.to_time:
+					available = True
+					available_any = True
+				if row.from_time >= from_time < row.to_time and row.from_time < to_time <= row.to_time:
+					available = True
+					available_any = True
+
+		if not available:
+			next_date += timedelta(days=1)
+			if repeat_till and getdate(next_date) >= getdate(repeat_till):
+				print(repeat_till, "repeat_till")
+				break
+
+			weekday_name = next_date.strftime("%A")
+			if (
+				repeat_on == "Weekly"
+				and max_occurrences
+				and occurrences.get(weekday_name, 0) >= max_occurrences
+			):
+				# If all weekdays reached max_occurrences, break
+				if all(occ >= max_occurrences for occ in occurrences.values()):
+					break
+				next_date += timedelta(days=1)
+				continue
+
+			if repeat_on != "Weekly" and max_occurrences and occurrences >= max_occurrences:
+				break
+			continue
+
+		# Check if the date is a holiday
+		holiday_list = frappe.db.sql(
+			f"""
                     Select hdl.name
                     From `tabHoliday List` as hdl
                     Left Join `tabHoliday` as hl ON hl.parent = hdl.name
-                    Where 
-                        hdl.from_date <= '{str(next_date)}' 
-                        and hdl.to_date >= '{str(next_date)}' 
-                        and hl.holiday_date = '{str(next_date)}'
-        """, as_dict=1)
+                    Where
+                        hdl.from_date <= '{next_date!s}'
+                        and hdl.to_date >= '{next_date!s}'
+                        and hl.holiday_date = '{next_date!s}'
+        """,
+			as_dict=1,
+		)
 
-        if holiday_list:
-            next_date += timedelta(days=1)
-            continue
+		if holiday_list:
+			next_date += timedelta(days=1)
+			continue
 
-        if repeat_on == "Weekly":
-            weekday_name = next_date.strftime("%A")
-            if weekday_name not in repeat_week_days:
-                next_date += timedelta(days=1)
-                continue
+		if repeat_on == "Weekly":
+			weekday_name = next_date.strftime("%A")
+			if weekday_name not in repeat_week_days:
+				next_date += timedelta(days=1)
+				continue
 
-            # Check if max occurrences for this weekday reached
-            if max_occurrences and occurrences.get(weekday_name, 0) >= max_occurrences:
-                # If all weekdays reached max_occurrences, break
-                if all(occ >= max_occurrences for occ in occurrences.values()):
-                    break
-                next_date += timedelta(days=1)
-                continue
+			# Check if max occurrences for this weekday reached
+			if max_occurrences and occurrences.get(weekday_name, 0) >= max_occurrences:
+				# If all weekdays reached max_occurrences, break
+				if all(occ >= max_occurrences for occ in occurrences.values()):
+					break
+				next_date += timedelta(days=1)
+				continue
 
-            # Add date if within repeat_till or if no repeat_till
-            if repeat_till and next_date <= repeat_till:
-                scheduled_dates.append(str(next_date))
-                if total_day_of_booking == len(repeat_week_days):
-                    first_week_date = next_date
-                total_day_of_booking -= 1
-                occurrences[weekday_name] += 1
-            elif not repeat_till and max_occurrences:
-                scheduled_dates.append(str(next_date))
-                if total_day_of_booking == len(repeat_week_days):
-                    first_week_date = next_date
-                total_day_of_booking -= 1
-                occurrences[weekday_name] += 1
+			# Add date if within repeat_till or if no repeat_till
+			if repeat_till and next_date <= repeat_till:
+				scheduled_dates.append(str(next_date))
+				if total_day_of_booking == len(repeat_week_days):
+					first_week_date = next_date
+				total_day_of_booking -= 1
+				occurrences[weekday_name] += 1
+			elif not repeat_till and max_occurrences:
+				scheduled_dates.append(str(next_date))
+				if total_day_of_booking == len(repeat_week_days):
+					first_week_date = next_date
+				total_day_of_booking -= 1
+				occurrences[weekday_name] += 1
 
-            if repeat_till and next_date >= repeat_till:
-                break
+			if repeat_till and next_date >= repeat_till:
+				break
 
-            # Break if all weekdays have reached max_occurrences
-            if max_occurrences and all(occ >= max_occurrences for occ in occurrences.values()):
-                break
-            if total_day_of_booking == 0 and repeat_interval != 1:
-                next_date = first_week_date + timedelta(days=7 * repeat_interval)
-                total_day_of_booking = len(repeat_week_days)
-            else:
-                next_date += timedelta(days=1)
+			# Break if all weekdays have reached max_occurrences
+			if max_occurrences and all(occ >= max_occurrences for occ in occurrences.values()):
+				break
+			if total_day_of_booking == 0 and repeat_interval != 1:
+				next_date = first_week_date + timedelta(days=7 * repeat_interval)
+				total_day_of_booking = len(repeat_week_days)
+			else:
+				next_date += timedelta(days=1)
 
-        else:
-            # Non-weekly repeats use a single counter
-            if repeat_till and next_date <= repeat_till:
-                scheduled_dates.append(str(next_date))
-                occurrences += 1
-            elif not repeat_till and max_occurrences:
-                scheduled_dates.append(str(next_date))
-                occurrences += 1
+		else:
+			# Non-weekly repeats use a single counter
+			if repeat_till and next_date <= repeat_till:
+				scheduled_dates.append(str(next_date))
+				occurrences += 1
+			elif not repeat_till and max_occurrences:
+				scheduled_dates.append(str(next_date))
+				occurrences += 1
 
-            if repeat_till and getdate(next_date) >= getdate(repeat_till):
-                break
+			if repeat_till and getdate(next_date) >= getdate(repeat_till):
+				break
 
-            if max_occurrences and occurrences >= max_occurrences:
-                break
+			if max_occurrences and occurrences >= max_occurrences:
+				break
 
-            # Calculate next date
-            if repeat_on == "Daily":
-                next_date += timedelta(days=repeat_interval)
-            elif repeat_on == "Monthly":
-                next_date = add_months(next_date, repeat_interval)
-            elif repeat_on == "Yearly":
-                next_date = add_years(next_date, repeat_interval)
+			# Calculate next date
+			if repeat_on == "Daily":
+				next_date += timedelta(days=repeat_interval)
+			elif repeat_on == "Monthly":
+				next_date = add_months(next_date, repeat_interval)
+			elif repeat_on == "Yearly":
+				next_date = add_years(next_date, repeat_interval)
 
-    scheduled_details = [
-        {"date" : row, "from_time" : data.from_time[:-3], "to_time" : data.to_time[:-3]} for row in scheduled_dates
-        ]
+	scheduled_details = [
+		{"date": row, "from_time": data.from_time[:-3], "to_time": data.to_time[:-3]}
+		for row in scheduled_dates
+	]
 
-    service_unit = data.service_unit
-    scheduled_details = get_availability(scheduled_details, data.practitioner, service_unit=service_unit)
+	service_unit = data.service_unit
+	scheduled_details = get_availability(scheduled_details, data.practitioner, service_unit=service_unit)
 
-    for row in scheduled_details:
-        row.update({'days': getdate(row.get('date')).strftime("%A") })
-    if not scheduled_details:
-        available_any = False
-    return {
-        "total": len(scheduled_details),
-        "dates": scheduled_details,
-        "available" : available_any
-    }
-
+	for row in scheduled_details:
+		row.update({"days": getdate(row.get("date")).strftime("%A")})
+	if not scheduled_details:
+		available_any = False
+	return {"total": len(scheduled_details), "dates": scheduled_details, "available": available_any}
 
 
 @frappe.whitelist()
 def get_availability(scheduled_details, practitioner, service_unit=None):
-    """
-    requirement parameters : date, practitioner, appointment
-    Get availability data of 'practitioner' on 'date'
-    :param date: Date to check in schedule
-    :param practitioner: Name of the practitioner
-    :return: dict containing a list of available slots, list of appointments and time of appointments
-    """
-    for schedule in scheduled_details:
-        date = getdate(schedule.get("date"))
-        weekday = date.strftime("%A")
+	"""
+	requirement parameters : date, practitioner, appointment
+	Get availability data of 'practitioner' on 'date'
+	:param date: Date to check in schedule
+	:param practitioner: Name of the practitioner
+	:return: dict containing a list of available slots, list of appointments and time of appointments
+	"""
+	for schedule in scheduled_details:
+		date = getdate(schedule.get("date"))
 
-        practitioner_doc = frappe.get_doc("Healthcare Practitioner", practitioner)
+		practitioner_doc = frappe.get_doc("Healthcare Practitioner", practitioner)
 
-        check_employee_wise_availability(date, practitioner_doc)
+		check_employee_wise_availability(date, practitioner_doc)
 
-        if practitioner_doc.practitioner_schedules:
-            service_unit = None
-            slot_details = get_available_slots(practitioner_doc, date, service_unit=service_unit)
-        
-        appointments = []
-        for row in slot_details:
-            for d in row.get("appointments"):
-                appointments.append(d)
-        
-        if appointments:
-            booked = False
-            for row in appointments:
-                time_obj = datetime.strptime(schedule.get("from_time"), "%H:%M").time()
-                from_time = timedelta(hours=time_obj.hour, minutes=time_obj.minute, seconds=time_obj.second)
-                time_obj = datetime.strptime(schedule.get("to_time"), "%H:%M").time()
-                to_time = timedelta(hours=time_obj.hour, minutes=time_obj.minute, seconds=time_obj.second)
-                
-                if (from_time <= row.get("appointment_time") < to_time):
-                    booked=True
-                if (from_time < row.get("end_time") <= to_time):
-                    booked=True 
-                if (from_time >= row.get("appointment_time") < to_time and 
-                    from_time < row.get("end_time") > to_time):
-                    booked=True
-                if (from_time >= row.get("appointment_time") < to_time and 
-                    from_time < row.get("end_time") <= to_time):
-                    booked=True
-                if booked:
-                    schedule.update({"booking_flage" : True})
-                    break
-            if not booked:
-                schedule.update({"booking_flage" : False})
-        else:
-            schedule.update({"booking_flage" : False})
-    
-    return scheduled_details
+		if practitioner_doc.practitioner_schedules:
+			slot_details = get_available_slots(practitioner_doc, date)
+
+		appointments = []
+		for row in slot_details:
+			for d in row.get("appointments"):
+				appointments.append(d)
+
+		if appointments:
+			booked = False
+			for row in appointments:
+				time_obj = datetime.strptime(schedule.get("from_time"), "%H:%M").time()
+				from_time = timedelta(hours=time_obj.hour, minutes=time_obj.minute, seconds=time_obj.second)
+				time_obj = datetime.strptime(schedule.get("to_time"), "%H:%M").time()
+				to_time = timedelta(hours=time_obj.hour, minutes=time_obj.minute, seconds=time_obj.second)
+
+				if from_time <= row.get("appointment_time") < to_time:
+					booked = True
+				if from_time < row.get("end_time") <= to_time:
+					booked = True
+				if (
+					from_time >= row.get("appointment_time") < to_time
+					and from_time < row.get("end_time") > to_time
+				):
+					booked = True
+				if (
+					from_time >= row.get("appointment_time") < to_time
+					and from_time < row.get("end_time") <= to_time
+				):
+					booked = True
+				if booked:
+					schedule.update({"booking_flage": True})
+					break
+			if not booked:
+				schedule.update({"booking_flage": False})
+		else:
+			schedule.update({"booking_flage": False})
+
+	return scheduled_details
+
 
 @frappe.whitelist()
 def get_service_unit_values(selected_practitioner):
-    query=frappe.db.sql(
-        "Select service_unit from `tabPractitioner Service Unit Schedule` where parent='{0}'".format(selected_practitioner),as_dict=1
-    )
+	query = frappe.db.sql(
+		f"Select service_unit from `tabPractitioner Service Unit Schedule` where parent='{selected_practitioner}'",
+		as_dict=1,
+	)
 
-    return list(set([item.service_unit for item in query if item.service_unit]))
+	return list(set([item.service_unit for item in query if item.service_unit]))


### PR DESCRIPTION
## Summary

The recurring appointment handler (`recuring_appointment_handler.py`) imported `get_available_slots` from `happiest_frappe.happiest_frappe.api.api`, a module that is not installed, causing a `No module named 'happiest_frappe'` error when clicking "Check Availability / Book Appointments" for recurring appointments.

Replaced with the local `get_available_slots` from `patient_appointment.py`, which is already used elsewhere in the codebase for the same purpose. The `service_unit` kwarg was dropped from the call in `get_availability()` since the local function signature is `(practitioner_doc, date)` — it handles service unit filtering internally via `practitioner_doc.practitioner_schedules`.

Also fixed pre-existing ruff lint errors (unused variables, bare `except`) and applied ruff-format to pass pre-commit hooks.

## Review & Testing Checklist for Human

- [ ] **Verify return format compatibility**: The local `get_available_slots` returns a list of dicts with keys `slot_name`, `service_unit`, `avail_slot`, `appointments`, `allow_overlap`, `service_unit_capacity`, `tele_conf`. The `get_availability()` function in this file iterates over `row.get("appointments")` and checks `appointment_time` / `end_time` fields. Confirm the local function's return shape matches what this code expects (it should, since both are used for the same Patient Appointment flow).
- [ ] **Test recurring appointment creation end-to-end**: Navigate to Patient Appointment → set up a recurring appointment → click "Check Availability / Book Appointments". Verify dates are returned correctly, availability is checked, and appointments can be booked for Daily, Weekly, and Monthly recurrence patterns.
- [ ] **Service unit filtering**: The old `happiest_frappe` version accepted `service_unit` as a kwarg; the local version does not. The local `get_available_slots` filters by service unit internally via practitioner schedule entries. Verify that recurring appointments still respect the selected service unit correctly.
- [ ] **Pre-existing bug — `slot_details` may be unbound**: In `get_availability()`, `slot_details` is only assigned inside `if practitioner_doc.practitioner_schedules:` but used unconditionally afterward. This is pre-existing, not introduced here, but could cause a `NameError` if a practitioner has no schedules.

### Notes
- The `create_recurring_appointments` function had 6 unused local variables (`repeat_on`, `repeat_interval`, `repeat_till`, `base_date`, `max_occurrences`, `created`) that were removed to satisfy ruff. These variables were assigned but never referenced — the actual logic lives in `get_recurring_appointment_dates(data)` which parses `data` independently.
- The diff is large due to ruff-format converting the entire file from 4-space to tab indentation and reformatting string literals/expressions. The functional changes are limited to: (1) the import swap on line 12, (2) dropping unused vars in `create_recurring_appointments`, (3) `except:` → `except Exception:`, and (4) removing `service_unit=service_unit` from the `get_available_slots` call in `get_availability()`.

Link to Devin session: https://app.devin.ai/sessions/b6d1301c034942fead82274c35dbe0ed
Requested by: @pythonpen