### PR TITLE
fix: correct argument name in schedule_inpatient call from patient encounter

### DIFF
--- a/healthcare/healthcare/doctype/patient_encounter/patient_encounter.js
+++ b/healthcare/healthcare/doctype/patient_encounter/patient_encounter.js
@@ -1,375 +1,469 @@
 // Copyright (c) 2016, ESS LLP and contributors
 // For license information, please see license.txt
 
-frappe.ui.form.on('Patient Encounter', {
-	onload: function(frm) {
-		if (!frm.doc.__islocal && frm.doc.docstatus === 1 &&
-			frm.doc.inpatient_status == 'Admission Scheduled') {
-				frappe.db.get_value('Inpatient Record', frm.doc.inpatient_record,
-					['admission_encounter', 'status']).then(r => {
-						if (r.message) {
-							if (r.message.admission_encounter == frm.doc.name &&
-								r.message.status == 'Admission Scheduled') {
-									frm.add_custom_button(__('Cancel Admission'), function() {
-										cancel_ip_order(frm);
-									});
-								}
-							if (r.message.status == 'Admitted') {
-								frm.add_custom_button(__('Schedule Discharge'), function() {
-									schedule_discharge(frm);
-								});
-							}
+frappe.ui.form.on("Patient Encounter", {
+	onload: function (frm) {
+		if (
+			!frm.doc.__islocal &&
+			frm.doc.docstatus === 1 &&
+			frm.doc.inpatient_status == "Admission Scheduled"
+		) {
+			frappe.db
+				.get_value("Inpatient Record", frm.doc.inpatient_record, [
+					"admission_encounter",
+					"status",
+				])
+				.then(r => {
+					if (r.message) {
+						if (
+							r.message.admission_encounter == frm.doc.name &&
+							r.message.status == "Admission Scheduled"
+						) {
+							frm.add_custom_button(__("Cancel Admission"), function () {
+								cancel_ip_order(frm);
+							});
 						}
-				})
+						if (r.message.status == "Admitted") {
+							frm.add_custom_button(
+								__("Schedule Discharge"),
+								function () {
+									schedule_discharge(frm);
+								},
+							);
+						}
+					}
+				});
 		}
 		show_clinical_notes(frm);
 		show_orders(frm);
 	},
 
-	patient: function(frm) {
+	patient: function (frm) {
 		// Original functionality
 		frm.events.set_patient_info(frm);
-		
+
 		// New history sync functionality
 		if (frm.doc.patient && frm.doc.__islocal) {
 			// Auto-load patient history when patient is selected for new documents
 			setTimeout(() => {
 				frappe.call({
-					method: 'load_patient_history',
+					method: "load_patient_history",
 					doc: frm.doc,
-					callback: function(r) {
+					callback: function (r) {
 						if (r.message) {
-							console.log(r.message)
+							console.log(r.message);
 
-							frm.set_value(r.message)
+							frm.set_value(r.message);
 							frm.refresh_fields([
-								'patient_madical_history', 
-								'patient_medication_history', 
-								'allergies', 
-								'patient_surgery_history', 
-								'family_medical_history'
+								"patient_madical_history",
+								"patient_medication_history",
+								"allergies",
+								"patient_surgery_history",
+								"family_medical_history",
 							]);
-							frappe.show_alert({
-								message: __('Patient history loaded automatically'),
-								indicator: 'green'
-							}, 3);
+							frappe.show_alert(
+								{
+									message: __("Patient history loaded automatically"),
+									indicator: "green",
+								},
+								3,
+							);
 						}
-					}
+					},
 				});
 			}, 1000); // Slight delay to allow other onchange events to complete
 		}
 	},
 
-	setup: function(frm) {
+	setup: function (frm) {
 		let value = [
-				{
-					"fieldname": "therapy_type",
-					"columns": 2
-				},
-				{
-					"fieldname": "no_of_days",
-					"columns": 2
-				},
-				{
-					"fieldname": "no_of_sessions_per_day",
-					"columns": 2
-				},
-				{
-					"fieldname": "no_of_sessions",
-					"columns": 2
-				},
+			{
+				fieldname: "therapy_type",
+				columns: 2,
+			},
+			{
+				fieldname: "no_of_days",
+				columns: 2,
+			},
+			{
+				fieldname: "no_of_sessions_per_day",
+				columns: 2,
+			},
+			{
+				fieldname: "no_of_sessions",
+				columns: 2,
+			},
 		];
-		frappe.model.user_settings.save("Therapy Plan Detail", "GridView", null).then((r) => {
-			frappe.model.user_settings["Therapy Plan Detail"] = r.message || r;
-		});
-		frappe.model.user_settings.save("Therapy Plan Detail", "GridView", value).then((r) => {
-			frappe.model.user_settings["Therapy Plan Detail"] = r.message || r;
-		});
-		frm.get_field('drug_prescription').grid.editable_fields = [
-			{fieldname: 'drug_code', columns: 2},
-			{fieldname: 'drug_name', columns: 2},
-			{fieldname: 'dosage', columns: 2},
-			{fieldname: 'period', columns: 2},
-			{fieldname: 'dosage_form', columns: 2}
+		frappe.model.user_settings
+			.save("Therapy Plan Detail", "GridView", null)
+			.then(r => {
+				frappe.model.user_settings["Therapy Plan Detail"] = r.message || r;
+			});
+		frappe.model.user_settings
+			.save("Therapy Plan Detail", "GridView", value)
+			.then(r => {
+				frappe.model.user_settings["Therapy Plan Detail"] = r.message || r;
+			});
+		frm.get_field("drug_prescription").grid.editable_fields = [
+			{ fieldname: "drug_code", columns: 2 },
+			{ fieldname: "drug_name", columns: 2 },
+			{ fieldname: "dosage", columns: 2 },
+			{ fieldname: "period", columns: 2 },
+			{ fieldname: "dosage_form", columns: 2 },
 		];
-		if (frappe.meta.get_docfield('Drug Prescription', 'medication').in_list_view === 1) {
-			frm.get_field('drug_prescription').grid.editable_fields.splice(0, 0, {fieldname: 'medication', columns: 3});
-			frm.get_field('drug_prescription').grid.editable_fields.splice(2, 1); // remove item description
+		if (
+			frappe.meta.get_docfield("Drug Prescription", "medication").in_list_view ===
+			1
+		) {
+			frm.get_field("drug_prescription").grid.editable_fields.splice(0, 0, {
+				fieldname: "medication",
+				columns: 3,
+			});
+			frm.get_field("drug_prescription").grid.editable_fields.splice(2, 1); // remove item description
 		}
 	},
 
-	refresh: function(frm) {
-		refresh_field('drug_prescription');
-		refresh_field('lab_test_prescription');
+	refresh: function (frm) {
+		refresh_field("drug_prescription");
+		refresh_field("lab_test_prescription");
 
 		if (!frm.doc.__islocal) {
 			if (frm.doc.docstatus === 1) {
-				if(!['Discharge Scheduled', 'Admission Scheduled', 'Admitted'].includes(frm.doc.inpatient_status)) {
-					frm.add_custom_button(__('Schedule Admission'), function() {
+				if (
+					![
+						"Discharge Scheduled",
+						"Admission Scheduled",
+						"Admitted",
+					].includes(frm.doc.inpatient_status)
+				) {
+					frm.add_custom_button(__("Schedule Admission"), function () {
 						schedule_inpatient(frm);
 					});
 				}
 			}
 
-			frm.add_custom_button(__("Refer Patient"), function() {
-				create_patient_referral(frm);
-			},__("Create"));
+			frm.add_custom_button(
+				__("Refer Patient"),
+				function () {
+					create_patient_referral(frm);
+				},
+				__("Create"),
+			);
 
-			frm.add_custom_button(__('Patient History'), function() {
-				if (frm.doc.patient) {
-					frappe.route_options = {'patient': frm.doc.patient};
-					frappe.set_route('patient_history');
-				} else {
-					frappe.msgprint(__('Please select Patient'));
-				}
-			},__('View'));
+			frm.add_custom_button(
+				__("Patient History"),
+				function () {
+					if (frm.doc.patient) {
+						frappe.route_options = { patient: frm.doc.patient };
+						frappe.set_route("patient_history");
+					} else {
+						frappe.msgprint(__("Please select Patient"));
+					}
+				},
+				__("View"),
+			);
 
-			if (frm.doc.docstatus == 1 && frm.doc.drug_prescription && frm.doc.drug_prescription.length>0) {
-				frm.add_custom_button(__('Medication Request'), function() {
-					create_medication_request(frm);
-				},__('Create'));
+			if (
+				frm.doc.docstatus == 1 &&
+				frm.doc.drug_prescription &&
+				frm.doc.drug_prescription.length > 0
+			) {
+				frm.add_custom_button(
+					__("Medication Request"),
+					function () {
+						create_medication_request(frm);
+					},
+					__("Create"),
+				);
 			}
 
-			if (frm.doc.docstatus == 1 && (
-				(frm.doc.lab_test_prescription && frm.doc.lab_test_prescription.length>0) ||
-				(frm.doc.procedure_prescription && frm.doc.procedure_prescription.length>0) ||
-				(frm.doc.therapies && frm.doc.therapies.length>0)
-				)) {
-				frm.add_custom_button(__('Service Request'), function() {
-					create_service_request(frm);
-				},__('Create'));
+			if (
+				frm.doc.docstatus == 1 &&
+				((frm.doc.lab_test_prescription &&
+					frm.doc.lab_test_prescription.length > 0) ||
+					(frm.doc.procedure_prescription &&
+						frm.doc.procedure_prescription.length > 0) ||
+					(frm.doc.therapies && frm.doc.therapies.length > 0))
+			) {
+				frm.add_custom_button(
+					__("Service Request"),
+					function () {
+						create_service_request(frm);
+					},
+					__("Create"),
+				);
 			}
 
-			frm.add_custom_button(__('Vital Signs'), function() {
-				create_vital_signs(frm);
-			},__('Create'));
+			frm.add_custom_button(
+				__("Vital Signs"),
+				function () {
+					create_vital_signs(frm);
+				},
+				__("Create"),
+			);
 
-			frm.add_custom_button(__('Medical Record'), function() {
-				create_medical_record(frm);
-			},__('Create'));
+			frm.add_custom_button(
+				__("Medical Record"),
+				function () {
+					create_medical_record(frm);
+				},
+				__("Create"),
+			);
 
-			frm.add_custom_button(__('Clinical Procedure'), function() {
-				create_procedure(frm);
-			},__('Create'));
+			frm.add_custom_button(
+				__("Clinical Procedure"),
+				function () {
+					create_procedure(frm);
+				},
+				__("Create"),
+			);
 
-			frm.add_custom_button(__("Clinical Note"), function() {
-				frappe.route_options = {
-					"patient": frm.doc.patient,
-					"reference_doc": "Patient Encounter",
-					"reference_name": frm.doc.name,
-					"practitioner": frm.doc.practitioner
-				}
-				frappe.new_doc("Clinical Note");
-			},__('Create'));
+			frm.add_custom_button(
+				__("Clinical Note"),
+				function () {
+					frappe.route_options = {
+						patient: frm.doc.patient,
+						reference_doc: "Patient Encounter",
+						reference_name: frm.doc.name,
+						practitioner: frm.doc.practitioner,
+					};
+					frappe.new_doc("Clinical Note");
+				},
+				__("Create"),
+			);
 
-
-			if (frm.doc.drug_prescription && frm.doc.inpatient_record && frm.doc.inpatient_status === "Admitted") {
-				frm.add_custom_button(__('Inpatient Medication Order'), function() {
-					frappe.model.open_mapped_doc({
-						method: 'healthcare.healthcare.doctype.patient_encounter.patient_encounter.make_ip_medication_order',
-						frm: frm
-					});
-				},__('Create'));
+			if (
+				frm.doc.drug_prescription &&
+				frm.doc.inpatient_record &&
+				frm.doc.inpatient_status === "Admitted"
+			) {
+				frm.add_custom_button(
+					__("Inpatient Medication Order"),
+					function () {
+						frappe.model.open_mapped_doc({
+							method: "healthcare.healthcare.doctype.patient_encounter.patient_encounter.make_ip_medication_order",
+							frm: frm,
+						});
+					},
+					__("Create"),
+				);
 			}
 
-			frm.add_custom_button(__('Nursing Tasks'), function() {
-				create_nursing_tasks(frm);
-			},__('Create'));
+			frm.add_custom_button(
+				__("Nursing Tasks"),
+				function () {
+					create_nursing_tasks(frm);
+				},
+				__("Create"),
+			);
 		}
 
-		frm.set_query('patient', function() {
+		frm.set_query("patient", function () {
 			return {
-				filters: {'status': 'Active'}
+				filters: { status: "Active" },
 			};
 		});
 
-		frm.set_query('drug_code', 'drug_prescription', function() {
-			return {
-				filters: {
-					is_stock_item: 1
-				}
-			};
-		});
-
-		frm.set_query('lab_test_code', 'lab_test_prescription', function() {
+		frm.set_query("drug_code", "drug_prescription", function () {
 			return {
 				filters: {
-					is_billable: 1
-				}
+					is_stock_item: 1,
+				},
 			};
 		});
 
-		frm.set_query('appointment', function() {
+		frm.set_query("lab_test_code", "lab_test_prescription", function () {
+			return {
+				filters: {
+					is_billable: 1,
+				},
+			};
+		});
+
+		frm.set_query("appointment", function () {
 			return {
 				filters: {
 					//	Scheduled filter for demo ...
-					status:['in',['Open','Scheduled', 'Confirmed']]
-				}
+					status: ["in", ["Open", "Scheduled", "Confirmed"]],
+				},
 			};
 		});
 
-		frm.set_query("code_value", "codification_table", function(doc, cdt, cdn) {
+		frm.set_query("code_value", "codification_table", function (doc, cdt, cdn) {
 			let row = frappe.get_doc(cdt, cdn);
 			if (row.code_system) {
 				return {
 					filters: {
-						code_system: row.code_system
-					}
+						code_system: row.code_system,
+					},
 				};
 			}
 		});
 
-		frm.set_query("medication", "drug_prescription", function() {
+		frm.set_query("medication", "drug_prescription", function () {
 			return {
 				filters: {
-					disabled: false
-				}
+					disabled: false,
+				},
 			};
-		})
+		});
 
-		frm.set_df_property('patient', 'read_only', frm.doc.appointment ? 1 : 0);
+		frm.set_df_property("patient", "read_only", frm.doc.appointment ? 1 : 0);
 
-		if (frm.doc.google_meet_link && frappe.datetime.now_date() <= frm.doc.encounter_date) {
+		if (
+			frm.doc.google_meet_link &&
+			frappe.datetime.now_date() <= frm.doc.encounter_date
+		) {
 			frm.dashboard.set_headline(
 				__("Join video conference with {0}", [
 					`<a target='_blank' href='${frm.doc.google_meet_link}'>Google Meet</a>`,
-				])
+				]),
 			);
 		}
-		if (frappe.meta.get_docfield('Drug Prescription', 'medication').in_list_view === 1) {
-			frm.set_query('drug_code', 'drug_prescription', function(doc, cdt, cdn) {
+		if (
+			frappe.meta.get_docfield("Drug Prescription", "medication").in_list_view ===
+			1
+		) {
+			frm.set_query("drug_code", "drug_prescription", function (doc, cdt, cdn) {
 				let row = frappe.get_doc(cdt, cdn);
 				let filters = { is_stock_item: 1 };
 				if (row.medication) {
 					filters.medication = row.medication;
 				}
 				return {
-					query: 'healthcare.healthcare.doctype.patient_encounter.patient_encounter.get_medications_query',
-					filters: filters
+					query: "healthcare.healthcare.doctype.patient_encounter.patient_encounter.get_medications_query",
+					filters: filters,
 				};
 			});
 		}
-		var table_list =  ["drug_prescription", "lab_test_prescription", "procedure_prescription", "therapies"]
-		apply_code_sm_filter_to_child(frm, "priority", table_list, "Priority")
-		apply_code_sm_filter_to_child(frm, "intent", table_list, "Intent")
+		var table_list = [
+			"drug_prescription",
+			"lab_test_prescription",
+			"procedure_prescription",
+			"therapies",
+		];
+		apply_code_sm_filter_to_child(frm, "priority", table_list, "Priority");
+		apply_code_sm_filter_to_child(frm, "intent", table_list, "Intent");
 
-		frm.fields_dict['doctor_advice_template'].get_query = function(){
+		frm.fields_dict["doctor_advice_template"].get_query = function () {
 			return {
 				query: "healthcare.healthcare.doctype.patient_encounter.patient_encounter.get_filtered_advice_template",
 				filters: {
 					doc: frm.doc,
-				}
+				},
 			};
-		}
+		};
 	},
 
-	appointment: function(frm) {
+	appointment: function (frm) {
 		frm.events.set_appointment_fields(frm);
 	},
 
-
-	practitioner: function(frm) {
+	practitioner: function (frm) {
 		if (!frm.doc.practitioner) {
-			frm.set_value('practitioner_name', '');
+			frm.set_value("practitioner_name", "");
 		}
 	},
-	set_appointment_fields: function(frm) {
+	set_appointment_fields: function (frm) {
 		if (frm.doc.appointment) {
 			frappe.call({
-				method: 'frappe.client.get',
+				method: "frappe.client.get",
 				args: {
-					doctype: 'Patient Appointment',
-					name: frm.doc.appointment
+					doctype: "Patient Appointment",
+					name: frm.doc.appointment,
 				},
-				callback: function(data) {
+				callback: function (data) {
 					let values = {
-						'patient':data.message.patient,
-						'type': data.message.appointment_type,
-						'practitioner': data.message.practitioner,
-						'invoiced': data.message.invoiced,
-						'company': data.message.company
+						patient: data.message.patient,
+						type: data.message.appointment_type,
+						practitioner: data.message.practitioner,
+						invoiced: data.message.invoiced,
+						company: data.message.company,
 					};
 					frm.set_value(values);
-					frm.set_df_property('patient', 'read_only', 1);
-				}
+					frm.set_df_property("patient", "read_only", 1);
+				},
 			});
-		}
-		else {
+		} else {
 			let values = {
-				'patient': '',
-				'patient_name': '',
-				'type': '',
-				'practitioner': '',
-				'invoiced': 0,
-				'patient_sex': '',
-				'patient_age': '',
-				'inpatient_record': '',
-				'inpatient_status': ''
+				patient: "",
+				patient_name: "",
+				type: "",
+				practitioner: "",
+				invoiced: 0,
+				patient_sex: "",
+				patient_age: "",
+				inpatient_record: "",
+				inpatient_status: "",
 			};
 			frm.set_value(values);
-			frm.set_df_property('patient', 'read_only', 0);
+			frm.set_df_property("patient", "read_only", 0);
 		}
-	},
-	
-	doctor_advice_template: function(frm){
-		frm.add_fetch("doctor_advice_template", "doctor_advice", "doctor_advice");
-		frm.refresh_field("doctor_advice")
-		if(frm.doc.doctor_advice_template && !frm.doc.doctor_advice){
-			frappe.model.get_value("Doctor Advice Template", frm.doc.doctor_advice_template, "doctor_advice", r=>{
-				frm.set_value("doctor_advice", r.doctor_advice)
-			})
-		}
-		
 	},
 
-	set_patient_info: async function(frm) {
-		if (frm.doc.patient) {
-			let me = frm
-			frappe.call({
-				method: 'healthcare.healthcare.doctype.patient.patient.get_patient_detail',
-				args: {
-					patient: frm.doc.patient
+	doctor_advice_template: function (frm) {
+		frm.add_fetch("doctor_advice_template", "doctor_advice", "doctor_advice");
+		frm.refresh_field("doctor_advice");
+		if (frm.doc.doctor_advice_template && !frm.doc.doctor_advice) {
+			frappe.model.get_value(
+				"Doctor Advice Template",
+				frm.doc.doctor_advice_template,
+				"doctor_advice",
+				r => {
+					frm.set_value("doctor_advice", r.doctor_advice);
 				},
-				callback: function(data) {
-					let age = '';
+			);
+		}
+	},
+
+	set_patient_info: async function (frm) {
+		if (frm.doc.patient) {
+			let me = frm;
+			frappe.call({
+				method: "healthcare.healthcare.doctype.patient.patient.get_patient_detail",
+				args: {
+					patient: frm.doc.patient,
+				},
+				callback: function (data) {
+					let age = "";
 					if (data.message.dob) {
 						age = calculate_age(data.message.dob);
 					}
 					let values = {
-						'patient_age': age,
-						'patient_name':data.message.patient_name,
-						'patient_sex': data.message.sex,
-						'inpatient_record': data.message.inpatient_record,
-						'inpatient_status': data.message.inpatient_status
+						patient_age: age,
+						patient_name: data.message.patient_name,
+						patient_sex: data.message.sex,
+						inpatient_record: data.message.inpatient_record,
+						inpatient_status: data.message.inpatient_status,
 					};
 
 					frappe.run_serially([
-						()=>frm.set_value(values),
-						()=>show_clinical_notes(frm),
-						()=>show_orders(frm),
+						() => frm.set_value(values),
+						() => show_clinical_notes(frm),
+						() => show_orders(frm),
 					]);
-				}
+				},
 			});
 		} else {
 			let values = {
-				'patient_age': '',
-				'patient_name':'',
-				'patient_sex': '',
-				'inpatient_record': '',
-				'inpatient_status': ''
+				patient_age: "",
+				patient_name: "",
+				patient_sex: "",
+				inpatient_record: "",
+				inpatient_status: "",
 			};
 			frm.set_value(values);
 		}
 	},
 
-	get_applicable_treatment_plans: function(frm) {
+	get_applicable_treatment_plans: function (frm) {
 		frappe.call({
-			method: 'get_applicable_treatment_plans',
+			method: "get_applicable_treatment_plans",
 			doc: frm.doc,
-			args: {'encounter': frm.doc},
+			args: { encounter: frm.doc },
 			freeze: true,
-			freeze_message: __('Fetching Treatment Plans'),
-			callback: function() {
+			freeze_message: __("Fetching Treatment Plans"),
+			callback: function () {
 				new frappe.ui.form.MultiSelectDialog({
 					doctype: "Treatment Plan Template",
 					target: this.cur_frm,
@@ -377,345 +471,421 @@ frappe.ui.form.on('Patient Encounter', {
 						medical_department: "",
 					},
 					action(selections) {
-						frappe.call({
-							method: 'set_treatment_plans',
-							doc: frm.doc,
-							args: selections,
-						}).then(() => {
-							frm.refresh_fields();
-							frm.dirty();
-						});
+						frappe
+							.call({
+								method: "set_treatment_plans",
+								doc: frm.doc,
+								args: selections,
+							})
+							.then(() => {
+								frm.refresh_fields();
+								frm.dirty();
+							});
 						cur_dialog.hide();
-					}
+					},
 				});
-
-
-			}
+			},
 		});
 	},
-
 });
 
-var schedule_inpatient = function(frm) {
+var schedule_inpatient = function (frm) {
 	let service_unit_type = "";
 	var dialog = new frappe.ui.Dialog({
-		title: 'Patient Admission',
+		title: "Patient Admission",
 		fields: [
-			{fieldtype: 'Link', label: 'Medical Department', fieldname: 'medical_department', options: 'Medical Department', reqd: 1},
-			{fieldtype: 'Link', label: 'Healthcare Practitioner (Primary)', fieldname: 'primary_practitioner', options: 'Healthcare Practitioner', reqd: 1},
-			{fieldtype: 'Link', label: 'Healthcare Practitioner (Secondary)', fieldname: 'secondary_practitioner', options: 'Healthcare Practitioner'},
-			{fieldtype: 'Link', label: 'Nursing Checklist Template', fieldname: 'admission_nursing_checklist_template', options: 'Nursing Checklist Template'},
-			{fieldtype: 'Column Break'},
-			{fieldtype: 'Date', label: 'Admission Ordered For', fieldname: 'admission_ordered_for', default: 'Today'},
-			{fieldtype: 'Link', label: 'Service Unit Type', fieldname: 'service_unit_type', options: 'Healthcare Service Unit Type'},
-			{fieldtype: 'Int', label: 'Expected Length of Stay', fieldname: 'expected_length_of_stay'},
-			{fieldtype: 'Section Break'},
-			{fieldtype: 'Long Text', label: 'Admission Instructions', fieldname: 'admission_instruction'}
+			{
+				fieldtype: "Link",
+				label: "Medical Department",
+				fieldname: "medical_department",
+				options: "Medical Department",
+				reqd: 1,
+			},
+			{
+				fieldtype: "Link",
+				label: "Healthcare Practitioner (Primary)",
+				fieldname: "primary_practitioner",
+				options: "Healthcare Practitioner",
+				reqd: 1,
+			},
+			{
+				fieldtype: "Link",
+				label: "Healthcare Practitioner (Secondary)",
+				fieldname: "secondary_practitioner",
+				options: "Healthcare Practitioner",
+			},
+			{
+				fieldtype: "Link",
+				label: "Nursing Checklist Template",
+				fieldname: "admission_nursing_checklist_template",
+				options: "Nursing Checklist Template",
+			},
+			{ fieldtype: "Column Break" },
+			{
+				fieldtype: "Date",
+				label: "Admission Ordered For",
+				fieldname: "admission_ordered_for",
+				default: "Today",
+			},
+			{
+				fieldtype: "Link",
+				label: "Service Unit Type",
+				fieldname: "service_unit_type",
+				options: "Healthcare Service Unit Type",
+			},
+			{
+				fieldtype: "Int",
+				label: "Expected Length of Stay",
+				fieldname: "expected_length_of_stay",
+			},
+			{ fieldtype: "Section Break" },
+			{
+				fieldtype: "Long Text",
+				label: "Admission Instructions",
+				fieldname: "admission_instruction",
+			},
 		],
-		primary_action_label: __('Order Admission'),
-		primary_action : function() {
+		primary_action_label: __("Order Admission"),
+		primary_action: function () {
 			var args = {
 				patient: frm.doc.patient,
 				admission_encounter: frm.doc.name,
 				referring_practitioner: frm.doc.practitioner,
 				company: frm.doc.company,
-				medical_department: dialog.get_value('medical_department'),
-				primary_practitioner: dialog.get_value('primary_practitioner'),
-				secondary_practitioner: dialog.get_value('secondary_practitioner'),
-				admission_ordered_for: dialog.get_value('admission_ordered_for'),
-				admission_service_unit_type: dialog.get_value('service_unit_type'),
-				expected_length_of_stay: dialog.get_value('expected_length_of_stay'),
-				admission_instruction: dialog.get_value('admission_instruction'),
-				admission_nursing_checklist_template: dialog.get_value('admission_nursing_checklist_template')
-			}
+				medical_department: dialog.get_value("medical_department"),
+				primary_practitioner: dialog.get_value("primary_practitioner"),
+				secondary_practitioner: dialog.get_value("secondary_practitioner"),
+				admission_ordered_for: dialog.get_value("admission_ordered_for"),
+				admission_service_unit_type: dialog.get_value("service_unit_type"),
+				expected_length_of_stay: dialog.get_value("expected_length_of_stay"),
+				admission_instruction: dialog.get_value("admission_instruction"),
+				admission_nursing_checklist_template: dialog.get_value(
+					"admission_nursing_checklist_template",
+				),
+			};
 			frappe.call({
-				method: 'healthcare.healthcare.doctype.inpatient_record.inpatient_record.schedule_inpatient',
+				method: "healthcare.healthcare.doctype.inpatient_record.inpatient_record.schedule_inpatient",
 				args: {
-					args: args
+					admission_order: args,
 				},
-				callback: function(data) {
+				callback: function (data) {
 					if (!data.exc) {
 						frm.reload_doc();
 					}
 				},
 				freeze: true,
-				freeze_message: __('Scheduling Patient Admission')
+				freeze_message: __("Scheduling Patient Admission"),
 			});
 			frm.refresh_fields();
 			dialog.hide();
-		}
+		},
 	});
 
 	dialog.set_values({
-		'medical_department': frm.doc.medical_department,
-		'primary_practitioner': frm.doc.practitioner,
+		medical_department: frm.doc.medical_department,
+		primary_practitioner: frm.doc.practitioner,
 	});
 
-	dialog.fields_dict['service_unit_type'].get_query = function() {
+	dialog.fields_dict["service_unit_type"].get_query = function () {
 		return {
 			filters: {
-				'inpatient_occupancy': 1,
-				'allow_appointments': 0
-			}
+				inpatient_occupancy: 1,
+				allow_appointments: 0,
+			},
 		};
 	};
 
 	dialog.fields_dict["service_unit_type"].df.onchange = () => {
-		if (dialog.get_value("service_unit_type") && dialog.get_value("service_unit_type") != service_unit_type) {
+		if (
+			dialog.get_value("service_unit_type") &&
+			dialog.get_value("service_unit_type") != service_unit_type
+		) {
 			service_unit_type = dialog.get_value("service_unit_type");
-			frappe.db.get_value("Healthcare Service Unit Type", {name: dialog.get_value("service_unit_type")}, ["is_billable", "item"])
-			.then(r => {
-				if (r.message.is_billable && !r.message.item) {
-					frappe.msgprint({
-						message: __("Selected service unit type doesn't have any item linked"),
-						title: __("Warning"),
-						indicator: "orange",
-					});
-				}
-			})
+			frappe.db
+				.get_value(
+					"Healthcare Service Unit Type",
+					{ name: dialog.get_value("service_unit_type") },
+					["is_billable", "item"],
+				)
+				.then(r => {
+					if (r.message.is_billable && !r.message.item) {
+						frappe.msgprint({
+							message: __(
+								"Selected service unit type doesn't have any item linked",
+							),
+							title: __("Warning"),
+							indicator: "orange",
+						});
+					}
+				});
 		}
 	};
 
 	dialog.show();
-	dialog.$wrapper.find('.modal-dialog').css('width', '800px');
+	dialog.$wrapper.find(".modal-dialog").css("width", "800px");
 };
 
-var schedule_discharge = function(frm) {
-	var dialog = new frappe.ui.Dialog ({
-		title: 'Inpatient Discharge',
+var schedule_discharge = function (frm) {
+	var dialog = new frappe.ui.Dialog({
+		title: "Inpatient Discharge",
 		fields: [
-			{fieldtype: 'Date', label: 'Discharge Ordered Date', fieldname: 'discharge_ordered_date', default: 'Today', read_only: 1},
-			{fieldtype: 'Date', label: 'Followup Date', fieldname: 'followup_date'},
-			{fieldtype: 'Link', label: 'Nursing Checklist Template', options: 'Nursing Checklist Template', fieldname: 'discharge_nursing_checklist_template'},
-			{fieldtype: 'Column Break'},
-			{fieldtype: 'Small Text', label: 'Discharge Instructions', fieldname: 'discharge_instructions'},
-			{fieldtype: 'Section Break', label:'Discharge Summary'},
-			{fieldtype: 'Long Text', label: 'Discharge Note', fieldname: 'discharge_note'}
+			{
+				fieldtype: "Date",
+				label: "Discharge Ordered Date",
+				fieldname: "discharge_ordered_date",
+				default: "Today",
+				read_only: 1,
+			},
+			{ fieldtype: "Date", label: "Followup Date", fieldname: "followup_date" },
+			{
+				fieldtype: "Link",
+				label: "Nursing Checklist Template",
+				options: "Nursing Checklist Template",
+				fieldname: "discharge_nursing_checklist_template",
+			},
+			{ fieldtype: "Column Break" },
+			{
+				fieldtype: "Small Text",
+				label: "Discharge Instructions",
+				fieldname: "discharge_instructions",
+			},
+			{ fieldtype: "Section Break", label: "Discharge Summary" },
+			{
+				fieldtype: "Long Text",
+				label: "Discharge Note",
+				fieldname: "discharge_note",
+			},
 		],
-		primary_action_label: __('Order Discharge'),
-		primary_action : function() {
+		primary_action_label: __("Order Discharge"),
+		primary_action: function () {
 			var args = {
 				patient: frm.doc.patient,
 				discharge_encounter: frm.doc.name,
 				discharge_practitioner: frm.doc.practitioner,
-				discharge_ordered_date: dialog.get_value('discharge_ordered_date'),
-				followup_date: dialog.get_value('followup_date'),
-				discharge_instructions: dialog.get_value('discharge_instructions'),
-				discharge_note: dialog.get_value('discharge_note'),
-				discharge_nursing_checklist_template: dialog.get_value('discharge_nursing_checklist_template')
-			}
-			frappe.call ({
-				method: 'healthcare.healthcare.doctype.inpatient_record.inpatient_record.schedule_discharge',
-				args: {args},
-				callback: function(data) {
-					if(!data.exc){
+				discharge_ordered_date: dialog.get_value("discharge_ordered_date"),
+				followup_date: dialog.get_value("followup_date"),
+				discharge_instructions: dialog.get_value("discharge_instructions"),
+				discharge_note: dialog.get_value("discharge_note"),
+				discharge_nursing_checklist_template: dialog.get_value(
+					"discharge_nursing_checklist_template",
+				),
+			};
+			frappe.call({
+				method: "healthcare.healthcare.doctype.inpatient_record.inpatient_record.schedule_discharge",
+				args: { args },
+				callback: function (data) {
+					if (!data.exc) {
 						frm.reload_doc();
 					}
 				},
 				freeze: true,
-				freeze_message: 'Scheduling Inpatient Discharge'
+				freeze_message: "Scheduling Inpatient Discharge",
 			});
 			frm.refresh_fields();
 			dialog.hide();
-		}
+		},
 	});
 
 	dialog.show();
-	dialog.$wrapper.find('.modal-dialog').css('width', '800px');
+	dialog.$wrapper.find(".modal-dialog").css("width", "800px");
 };
 
-let create_medical_record = function(frm) {
+let create_medical_record = function (frm) {
 	if (!frm.doc.patient) {
-		frappe.throw(__('Please select patient'));
+		frappe.throw(__("Please select patient"));
 	}
 	frappe.route_options = {
-		'patient': frm.doc.patient,
-		'status': 'Open',
-		'reference_doctype': 'Patient Medical Record',
-		'reference_owner': frm.doc.owner
+		patient: frm.doc.patient,
+		status: "Open",
+		reference_doctype: "Patient Medical Record",
+		reference_owner: frm.doc.owner,
 	};
-	frappe.new_doc('Patient Medical Record');
+	frappe.new_doc("Patient Medical Record");
 };
 
-let create_vital_signs = function(frm) {
+let create_vital_signs = function (frm) {
 	if (!frm.doc.patient) {
-		frappe.throw(__('Please select patient'));
+		frappe.throw(__("Please select patient"));
 	}
 	frappe.route_options = {
-		'patient': frm.doc.patient,
-		'encounter': frm.doc.name,
-		'company': frm.doc.company
+		patient: frm.doc.patient,
+		encounter: frm.doc.name,
+		company: frm.doc.company,
 	};
-	frappe.new_doc('Vital Signs');
+	frappe.new_doc("Vital Signs");
 };
 
-let create_procedure = function(frm) {
+let create_procedure = function (frm) {
 	if (!frm.doc.patient) {
-		frappe.throw(__('Please select patient'));
+		frappe.throw(__("Please select patient"));
 	}
 	frappe.route_options = {
-		'patient': frm.doc.patient,
-		'medical_department': frm.doc.medical_department,
-		'company': frm.doc.company
+		patient: frm.doc.patient,
+		medical_department: frm.doc.medical_department,
+		company: frm.doc.company,
 	};
-	frappe.new_doc('Clinical Procedure');
+	frappe.new_doc("Clinical Procedure");
 };
 
-let create_nursing_tasks = function(frm) {
+let create_nursing_tasks = function (frm) {
 	const d = new frappe.ui.Dialog({
-
-		title: __('Create Nursing Tasks'),
+		title: __("Create Nursing Tasks"),
 
 		fields: [
 			{
-				label: __('Nursing Checklist Template'),
-				fieldtype: 'Link',
-				options: 'Nursing Checklist Template',
-				fieldname: 'template',
+				label: __("Nursing Checklist Template"),
+				fieldtype: "Link",
+				options: "Nursing Checklist Template",
+				fieldname: "template",
 				reqd: 1,
 			},
 			{
-				label: __('Start Time'),
-				fieldtype: 'Datetime',
-				fieldname: 'start_time',
+				label: __("Start Time"),
+				fieldtype: "Datetime",
+				fieldname: "start_time",
 				default: frappe.datetime.now_datetime(),
 				reqd: 1,
 			},
 		],
 
-		primary_action_label: __('Create Nursing Tasks'),
+		primary_action_label: __("Create Nursing Tasks"),
 
 		primary_action: () => {
-
 			let values = d.get_values();
 			frappe.call({
-				method: 'healthcare.healthcare.doctype.nursing_task.nursing_task.create_nursing_tasks_from_template',
+				method: "healthcare.healthcare.doctype.nursing_task.nursing_task.create_nursing_tasks_from_template",
 				args: {
-					'template': values.template,
-					'doc': frm.doc,
-					'start_time': values.start_time
+					template: values.template,
+					doc: frm.doc,
+					start_time: values.start_time,
 				},
-				callback: (r) => {
+				callback: r => {
 					if (r && !r.exc) {
 						frappe.show_alert({
-							message: __('Nursing Tasks Created'),
-							indicator: 'success'
+							message: __("Nursing Tasks Created"),
+							indicator: "success",
 						});
 					}
-				}
+				},
 			});
 
-			d.hide();		frm.set_query('lab_test_code', 'lab_test_prescription', function() {
+			d.hide();
+			frm.set_query("lab_test_code", "lab_test_prescription", function () {
 				return {
 					filters: {
-						is_billable: 1
-					}
+						is_billable: 1,
+					},
 				};
 			});
-		}
+		},
 	});
 
 	d.show();
 };
 
-let calculate_age = function(birth) {
+let calculate_age = function (birth) {
 	let ageMS = Date.parse(Date()) - Date.parse(birth);
 	let age = new Date();
 	age.setTime(ageMS);
-	let years =  age.getFullYear() - 1970;
-	return `${years} ${__('Years(s)')} ${age.getMonth()} ${__('Month(s)')} ${age.getDate()} ${__('Day(s)')}`;
+	let years = age.getFullYear() - 1970;
+	return `${years} ${__("Years(s)")} ${age.getMonth()} ${__(
+		"Month(s)",
+	)} ${age.getDate()} ${__("Day(s)")}`;
 };
 
-let cancel_ip_order = function(frm) {
-	frappe.prompt([
-		{
-			fieldname: 'reason_for_cancellation',
-			label: __('Reason for Cancellation'),
-			fieldtype: 'Small Text',
-			reqd: 1
-		}
-	],
-	function(data) {
-		frappe.call({
-			method: 'healthcare.healthcare.doctype.inpatient_record.inpatient_record.set_ip_order_cancelled',
-			async: false,
-			freeze: true,
-			args: {
-				inpatient_record: frm.doc.inpatient_record,
-				reason: data.reason_for_cancellation,
-				encounter: frm.doc.name
+let cancel_ip_order = function (frm) {
+	frappe.prompt(
+		[
+			{
+				fieldname: "reason_for_cancellation",
+				label: __("Reason for Cancellation"),
+				fieldtype: "Small Text",
+				reqd: 1,
 			},
-			callback: function(r) {
-				if (!r.exc) {
-					frm.reload_doc();
-				}
-			}
-		});
-	}, __('Reason for Cancellation'), __('Submit'));
-}
+		],
+		function (data) {
+			frappe.call({
+				method: "healthcare.healthcare.doctype.inpatient_record.inpatient_record.set_ip_order_cancelled",
+				async: false,
+				freeze: true,
+				args: {
+					inpatient_record: frm.doc.inpatient_record,
+					reason: data.reason_for_cancellation,
+					encounter: frm.doc.name,
+				},
+				callback: function (r) {
+					if (!r.exc) {
+						frm.reload_doc();
+					}
+				},
+			});
+		},
+		__("Reason for Cancellation"),
+		__("Submit"),
+	);
+};
 
-let create_service_request = function(frm) {
+let create_service_request = function (frm) {
 	frappe.call({
 		method: "healthcare.healthcare.doctype.patient_encounter.patient_encounter.create_service_request",
 		freeze: true,
 		args: {
-			encounter: frm.doc.name
+			encounter: frm.doc.name,
 		},
-		callback: function(r) {
+		callback: function (r) {
 			if (r && !r.exc) {
 				frm.reload_doc();
 				frappe.show_alert({
-					message: __('Service Request(s) Created'),
-					indicator: 'success'
+					message: __("Service Request(s) Created"),
+					indicator: "success",
 				});
 			}
-		}
+		},
 	});
 };
 
-let create_medication_request = function(frm) {
+let create_medication_request = function (frm) {
 	frappe.call({
 		method: "healthcare.healthcare.doctype.patient_encounter.patient_encounter.create_medication_request",
 		freeze: true,
 		args: {
-			encounter: frm.doc.name
+			encounter: frm.doc.name,
 		},
-		callback: function(r) {
+		callback: function (r) {
 			if (r && !r.exc) {
 				frm.reload_doc();
 				frappe.show_alert({
-					message: __('Medicaiton Request(s) Created'),
-					indicator: 'success'
+					message: __("Medicaiton Request(s) Created"),
+					indicator: "success",
 				});
 			}
-		}
+		},
 	});
 };
 
-
-frappe.ui.form.on('Drug Prescription', {
-	dosage: function(frm, cdt, cdn){
-		frappe.model.set_value(cdt, cdn, 'update_schedule', 1);
+frappe.ui.form.on("Drug Prescription", {
+	dosage: function (frm, cdt, cdn) {
+		frappe.model.set_value(cdt, cdn, "update_schedule", 1);
 		let child = locals[cdt][cdn];
 		if (child.dosage) {
-			frappe.model.set_value(cdt, cdn, 'interval_uom', 'Day');
-			frappe.model.set_value(cdt, cdn, 'interval', 1);
+			frappe.model.set_value(cdt, cdn, "interval_uom", "Day");
+			frappe.model.set_value(cdt, cdn, "interval", 1);
 		}
 	},
 
-	period: function(frm, cdt, cdn) {
-		frappe.model.set_value(cdt, cdn, 'update_schedule', 1);
+	period: function (frm, cdt, cdn) {
+		frappe.model.set_value(cdt, cdn, "update_schedule", 1);
 	},
 
-	interval_uom: function(frm, cdt, cdn) {
-		frappe.model.set_value(cdt, cdn, 'update_schedule', 1);
+	interval_uom: function (frm, cdt, cdn) {
+		frappe.model.set_value(cdt, cdn, "update_schedule", 1);
 		let child = locals[cdt][cdn];
-		if (child.interval_uom == 'Hour') {
-			frappe.model.set_value(cdt, cdn, 'dosage', null);
+		if (child.interval_uom == "Hour") {
+			frappe.model.set_value(cdt, cdn, "dosage", null);
 		}
 	},
 
-	medication:function(frm, cdt, cdn) {
+	medication: function (frm, cdt, cdn) {
 		// to set drug_code(item) if Medication Item table have only one item
 		let child = locals[cdt][cdn];
 		if (!child.medication) {
@@ -726,38 +896,37 @@ frappe.ui.form.on('Drug Prescription', {
 			method: "healthcare.healthcare.doctype.patient_encounter.patient_encounter.get_medications",
 			freeze: true,
 			args: {
-				medication: child.medication
+				medication: child.medication,
 			},
-			callback: function(r) {
+			callback: function (r) {
 				if (r && !r.exc && r.message) {
-					let data = r.message
+					let data = r.message;
 					if (data.length == 1) {
 						if (data[0].item) {
-							frappe.model.set_value(cdt, cdn, 'drug_code', data[0].item);
+							frappe.model.set_value(cdt, cdn, "drug_code", data[0].item);
 						}
 					} else {
-						frappe.model.set_value(cdt, cdn, 'drug_code', "");
+						frappe.model.set_value(cdt, cdn, "drug_code", "");
 					}
 				}
-			}
+			},
 		});
-	}
+	},
 });
 
-
-var apply_code_sm_filter_to_child = function(frm, field, table_list, code_system) {
-	table_list.forEach(function(table) {
-		frm.set_query(field, table, function() {
+var apply_code_sm_filter_to_child = function (frm, field, table_list, code_system) {
+	table_list.forEach(function (table) {
+		frm.set_query(field, table, function () {
 			return {
 				filters: {
-					code_system: code_system
-				}
+					code_system: code_system,
+				},
 			};
 		});
 	});
 };
 
-var show_clinical_notes = async function(frm) {
+var show_clinical_notes = async function (frm) {
 	if (frm.doc.patient) {
 		const clinical_notes = new healthcare.ClinicalNotes({
 			frm: frm,
@@ -765,9 +934,9 @@ var show_clinical_notes = async function(frm) {
 		});
 		clinical_notes.refresh();
 	}
-}
+};
 
-var show_orders = async function(frm) {
+var show_orders = async function (frm) {
 	if (frm.doc.docstatus == 0 && frm.doc.patient) {
 		const orders = new healthcare.Orders({
 			frm: frm,
@@ -777,10 +946,10 @@ var show_orders = async function(frm) {
 		});
 		orders.refresh();
 	}
-}
+};
 
-let create_patient_referral = function(frm) {
-	var dialog = new frappe.ui.Dialog ({
+let create_patient_referral = function (frm) {
+	var dialog = new frappe.ui.Dialog({
 		title: "Patient Referral",
 		size: "large",
 		fields: [
@@ -792,33 +961,33 @@ let create_patient_referral = function(frm) {
 				data: [],
 				fields: [
 					{
-						"fieldname": "refer_to",
-						"fieldtype": "Link",
-						"label": "Refer To",
-						"options": "Healthcare Practitioner",
-						"in_list_view": 1,
-						"reqd": 1,
+						fieldname: "refer_to",
+						fieldtype: "Link",
+						label: "Refer To",
+						options: "Healthcare Practitioner",
+						in_list_view: 1,
+						reqd: 1,
 						get_query: function () {
 							return {
 								filters: {
-									name: ["!=", frm.doc.practitioner]
+									name: ["!=", frm.doc.practitioner],
 								},
 							};
 						},
 					},
 					{
-						"fieldname": "appointment_type",
-						"fieldtype": "Link",
-						"label": "Appointment Type",
-						"options": "Appointment Type",
-						"in_list_view": 1,
-						"reqd": 1,
+						fieldname: "appointment_type",
+						fieldtype: "Link",
+						label: "Appointment Type",
+						options: "Appointment Type",
+						in_list_view: 1,
+						reqd: 1,
 					},
 					{
-						"fieldname": "referral_note",
-						"fieldtype": "Long Text",
-						"label": "Referral Note",
-						"in_list_view": 1,
+						fieldname: "referral_note",
+						fieldtype: "Long Text",
+						label: "Referral Note",
+						in_list_view: 1,
 					},
 				],
 			},
@@ -841,7 +1010,9 @@ let create_patient_referral = function(frm) {
 				}
 
 				if (hasDuplicate) {
-					frappe.msgprint(__('Duplicate "Refer To" entries are not allowed.'));
+					frappe.msgprint(
+						__('Duplicate "Refer To" entries are not allowed.'),
+					);
 					return;
 				}
 
@@ -858,46 +1029,58 @@ let create_patient_referral = function(frm) {
 							dialog.hide();
 							frm.reload_doc();
 							frappe.show_alert({
-								message: __("Patient referral requests created successfully"),
-								indicator: "success"
+								message: __(
+									"Patient referral requests created successfully",
+								),
+								indicator: "success",
 							});
 						}
-					}
+					},
 				});
 
 				frm.refresh_fields();
 			}
-		}
+		},
 	});
 
 	dialog.show();
 };
 
-frappe.ui.form.on('Therapy Plan Detail', {
-    no_of_days:(frm, cdt, cdn)=>{
-        let d = locals[cdt][cdn]
-		if(d.no_of_days < 1){
-			frappe.model.set_value(cdt, cdn, 'no_of_days', '')
+frappe.ui.form.on("Therapy Plan Detail", {
+	no_of_days: (frm, cdt, cdn) => {
+		let d = locals[cdt][cdn];
+		if (d.no_of_days < 1) {
+			frappe.model.set_value(cdt, cdn, "no_of_days", "");
 		}
-        if(d['no_of_days'] && d['no_of_sessions_per_day']){
-            frappe.model.set_value(cdt, cdn, 'no_of_sessions', d.no_of_days * d.no_of_sessions_per_day)
-            frm.refresh_field("therapies")
-        }else{
-			frappe.model.set_value(cdt, cdn, 'no_of_sessions','')
-            frm.refresh_field("therapies")	
+		if (d["no_of_days"] && d["no_of_sessions_per_day"]) {
+			frappe.model.set_value(
+				cdt,
+				cdn,
+				"no_of_sessions",
+				d.no_of_days * d.no_of_sessions_per_day,
+			);
+			frm.refresh_field("therapies");
+		} else {
+			frappe.model.set_value(cdt, cdn, "no_of_sessions", "");
+			frm.refresh_field("therapies");
 		}
-    },
-    no_of_sessions_per_day:(frm, cdt, cdn)=>{
-        let d = locals[cdt][cdn]
-		if(d.no_of_sessions_per_day < 1){
-			frappe.model.set_value(cdt, cdn, 'no_of_sessions_per_day', '')
+	},
+	no_of_sessions_per_day: (frm, cdt, cdn) => {
+		let d = locals[cdt][cdn];
+		if (d.no_of_sessions_per_day < 1) {
+			frappe.model.set_value(cdt, cdn, "no_of_sessions_per_day", "");
 		}
-        if(d['no_of_days'] && d['no_of_sessions_per_day']){
-            frappe.model.set_value(cdt, cdn, 'no_of_sessions', d.no_of_days * d.no_of_sessions_per_day)
-            frm.refresh_field("therapies")
-        }else{
-			frappe.model.set_value(cdt, cdn, 'no_of_sessions', '')
-            frm.refresh_field("therapies")	
+		if (d["no_of_days"] && d["no_of_sessions_per_day"]) {
+			frappe.model.set_value(
+				cdt,
+				cdn,
+				"no_of_sessions",
+				d.no_of_days * d.no_of_sessions_per_day,
+			);
+			frm.refresh_field("therapies");
+		} else {
+			frappe.model.set_value(cdt, cdn, "no_of_sessions", "");
+			frm.refresh_field("therapies");
 		}
-    }
-})
+	},
+});


### PR DESCRIPTION
## Summary

The `schedule_inpatient` JS function in `patient_encounter.js` was passing the admission order data with the wrong keyword argument name (`args` instead of `admission_order`), causing:

```
TypeError: schedule_inpatient() missing 1 required positional argument: 'admission_order'
```

The Python function signature is `schedule_inpatient(admission_order)`, but the JS client was sending `args: { args: args }` instead of `args: { admission_order: args }`. This matches the upstream marley version-16 implementation and is consistent with how `treatment_counselling.js` already calls the same endpoint.

**The functional change is a single keyword rename on line 434.** The rest of the diff is prettier auto-formatting the entire file (quote style, indentation, trailing commas). No other behavioral changes.

## Review & Testing Checklist for Human

- [ ] **Verify no accidental logic changes in prettier reformat**: The diff is ~2000 lines but only one line is a functional change (`args: args` → `admission_order: args`). Skim the diff to confirm prettier didn't alter any logic (e.g. reordering statements, dropping lines, changing conditionals)
- [ ] **Test scheduling admission from Patient Encounter**: Open a submitted Patient Encounter → click "Schedule Admission" → fill in the dialog → click "Order Admission". Confirm the inpatient record is created without errors
- [ ] **Verify other inpatient scheduling paths still work**: Test scheduling admission from Treatment Counselling as well, since it calls the same backend endpoint (that path was already correct but worth a sanity check)

### Notes
- The `treatment_counselling.js` file already uses the correct `admission_order: args` parameter name — only `patient_encounter.js` had this bug
- Compared against upstream [marley version-16](https://github.com/earthians/marley/tree/version-16) to confirm the fix

Link to Devin session: https://app.devin.ai/sessions/b6d1301c034942fead82274c35dbe0ed
Requested by: @pythonpen
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tacten/biograph/pull/243" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
