### PR TITLE
fix: allow Unavailable appointment type without requiring Patient field

### DIFF
--- a/healthcare/healthcare/doctype/patient_appointment/patient_appointment.js
+++ b/healthcare/healthcare/doctype/patient_appointment/patient_appointment.js
@@ -1,181 +1,224 @@
 // Copyright (c) 2016, ESS LLP and contributors
 // For license information, please see license.txt
-frappe.provide('erpnext.queries');
-frappe.ui.form.on('Patient Appointment', {
-	setup: function(frm) {
+frappe.provide("erpnext.queries");
+frappe.ui.form.on("Patient Appointment", {
+	setup: function (frm) {
 		frm.custom_make_buttons = {
-			'Vital Signs': 'Vital Signs',
-			'Patient Encounter': 'Patient Encounter'
+			"Vital Signs": "Vital Signs",
+			"Patient Encounter": "Patient Encounter",
 		};
 	},
 
-	onload: function(frm) {
+	onload: function (frm) {
 		if (frm.is_new()) {
-			frm.set_value('appointment_time', null);
+			frm.set_value("appointment_time", null);
 			frm.disable_save();
 		}
-		if(frm.doc.therapy_plan && frm.doc.__islocal){
-			frm.set_value("appointment_type", "Therapy Session")
+		if (frm.doc.therapy_plan && frm.doc.__islocal) {
+			frm.set_value("appointment_type", "Therapy Session");
 		}
 	},
 
-	refresh: function(frm) {
+	refresh: function (frm) {
 		if (frm.is_new()) {
-            // Manually set the indicator to "Not Saved"
+			// Manually set the indicator to "Not Saved"
 			frm.page.set_indicator(__("Not Saved"), "orange");
-        }
-		if(frm.doc.therapy_plan && frm.doc.__islocal){
-			frm.set_value("appointment_type", "Therapy Session")
 		}
-		frm.set_query('patient', function() {
+		if (frm.doc.therapy_plan && frm.doc.__islocal) {
+			frm.set_value("appointment_type", "Therapy Session");
+		}
+		frm.set_query("patient", function () {
 			return {
-				filters: { 'status': 'Active' }
+				filters: { status: "Active" },
+			};
+		});
+
+		frm.set_query("appointment_type", function () {
+			return {
+				filters: { name: ["!=", "Unavailable"] },
 			};
 		});
 
 		frm.set_query("therapy_type", "therapy_types", function (doc, cdt, cdn) {
 			let d = locals[cdt][cdn];
 			return {
-				query : "healthcare.healthcare.doctype.patient_appointment.patient_appointment.apply_filter_on_therapy_type",
-				filters : {
-					therapy_plan : doc.therapy_plan
-				}
+				query: "healthcare.healthcare.doctype.patient_appointment.patient_appointment.apply_filter_on_therapy_type",
+				filters: {
+					therapy_plan: doc.therapy_plan,
+				},
 			};
 		});
 
-		frm.set_query('practitioner', function() {
+		frm.set_query("practitioner", function () {
 			if (frm.doc.department) {
 				return {
 					filters: {
-						'department': frm.doc.department
-					}
+						department: frm.doc.department,
+					},
 				};
 			}
 		});
 
-		frm.set_query('service_unit', function() {
+		frm.set_query("service_unit", function () {
 			return {
-				query: 'healthcare.controllers.queries.get_healthcare_service_units',
+				query: "healthcare.controllers.queries.get_healthcare_service_units",
 				filters: {
 					company: frm.doc.company,
 					inpatient_record: frm.doc.inpatient_record,
 					allow_appointments: 1,
-				}
+				},
 			};
 		});
 
-		frm.set_query('therapy_plan', function() {
+		frm.set_query("therapy_plan", function () {
 			return {
 				filters: {
-					'patient': frm.doc.patient
-				}
+					patient: frm.doc.patient,
+				},
 			};
 		});
 
-		frm.set_query('service_request', function() {
+		frm.set_query("service_request", function () {
 			return {
 				filters: {
-					'patient': frm.doc.patient,
-					'status': 'Active',
-					'docstatus': 1,
-					'template_dt': ['in', ['Clinical Procedure', 'Therapy Type']]
-				}
+					patient: frm.doc.patient,
+					status: "Active",
+					docstatus: 1,
+					template_dt: ["in", ["Clinical Procedure", "Therapy Type"]],
+				},
 			};
 		});
 
 		if (frm.is_new()) {
 			frm.page.clear_primary_action();
 			if (frm.doc.appointment_for) {
-				frm.trigger('appointment_for');
+				frm.trigger("appointment_for");
 			}
 		} else {
-			frm.page.set_primary_action(__('Save'), () => frm.save());
+			frm.page.set_primary_action(__("Save"), () => frm.save());
 		}
 
 		// Handle Unavailable appointment - this always returns early
-		if (frm.doc.appointment_type === "Unavailable" && frm.doc.status !== "Cancelled") {
-			frm.add_custom_button(__('Cancel Unavailability'), function() {
-				update_status(frm, 'Cancelled');
+		if (
+			frm.doc.appointment_type === "Unavailable" &&
+			frm.doc.status !== "Cancelled"
+		) {
+			frm.add_custom_button(__("Cancel Unavailability"), function () {
+				update_status(frm, "Cancelled");
 			}).addClass("btn-danger");
-			
+
 			return; // Return early to not add other buttons for this status
 		}
-		
+
 		// Handle Block Booking appointment - add custom cancel button but don't return early
-		if (frm.doc.appointment_type === "Block Booking" && frm.doc.status !== "Cancelled") {
-			frm.add_custom_button(__('Cancel'), function() {
-				update_status(frm, 'Cancelled');
+		if (
+			frm.doc.appointment_type === "Block Booking" &&
+			frm.doc.status !== "Cancelled"
+		) {
+			frm.add_custom_button(__("Cancel"), function () {
+				update_status(frm, "Cancelled");
 			});
 		}
 
 		if (frm.doc.patient) {
-			frm.add_custom_button(__('Patient History'), function() {
-				frappe.route_options = { 'patient': frm.doc.patient };
-				frappe.set_route('patient_history');
-			}, __('View'));
+			frm.add_custom_button(
+				__("Patient History"),
+				function () {
+					frappe.route_options = { patient: frm.doc.patient };
+					frappe.set_route("patient_history");
+				},
+				__("View"),
+			);
 		}
 
 		// Handle appointments with "Needs Rescheduling" status
 		if (frm.doc.status === "Needs Rescheduling") {
-			frm.add_custom_button(__('Reschedule'), function() {
+			frm.add_custom_button(__("Reschedule"), function () {
 				reschedule_appointment(frm);
 			}).addClass("btn-primary");
-			
-			frm.add_custom_button(__('Cancel'), function() {
-				update_status(frm, 'Cancelled');
+
+			frm.add_custom_button(__("Cancel"), function () {
+				update_status(frm, "Cancelled");
 			});
-			
+
 			return; // Return early to not add other buttons for this status
 		}
 
-		if (["Open", "Checked In", "Confirmed"].includes(frm.doc.status) || (frm.doc.status == "Scheduled" && !frm.doc.__islocal)) {
-			frm.add_custom_button(__('Cancel'), function() {
-				update_status(frm, 'Cancelled');
+		if (
+			["Open", "Checked In", "Confirmed"].includes(frm.doc.status) ||
+			(frm.doc.status == "Scheduled" && !frm.doc.__islocal)
+		) {
+			frm.add_custom_button(__("Cancel"), function () {
+				update_status(frm, "Cancelled");
 			});
-			frm.add_custom_button(__("Reschedule"), function() {
+			frm.add_custom_button(__("Reschedule"), function () {
 				if (frm.doc.appointment_for == "Practitioner") {
 					check_and_set_availability(frm);
-				} else{
+				} else {
 					reschedule_dept_or_su(frm);
 				}
 			});
 
 			if (frm.doc.procedure_template) {
-				frm.add_custom_button(__('Clinical Procedure'), function() {
-					frappe.model.open_mapped_doc({
-						method: 'healthcare.healthcare.doctype.clinical_procedure.clinical_procedure.make_procedure',
-						frm: frm,
-					});
-				}, __('Create'));
+				frm.add_custom_button(
+					__("Clinical Procedure"),
+					function () {
+						frappe.model.open_mapped_doc({
+							method: "healthcare.healthcare.doctype.clinical_procedure.clinical_procedure.make_procedure",
+							frm: frm,
+						});
+					},
+					__("Create"),
+				);
 			} else if (frm.doc.therapy_type) {
-				frm.add_custom_button(__('Therapy Session'), function() {
-					frappe.model.open_mapped_doc({
-						method: 'healthcare.healthcare.doctype.therapy_session.therapy_session.create_therapy_session',
-						frm: frm,
-					})
-				}, 'Create');
+				frm.add_custom_button(
+					__("Therapy Session"),
+					function () {
+						frappe.model.open_mapped_doc({
+							method: "healthcare.healthcare.doctype.therapy_session.therapy_session.create_therapy_session",
+							frm: frm,
+						});
+					},
+					"Create",
+				);
 			} else {
-				frm.add_custom_button(__('Patient Encounter'), function() {
-					frappe.model.open_mapped_doc({
-						method: 'healthcare.healthcare.doctype.patient_appointment.patient_appointment.make_encounter',
-						frm: frm,
-					});
-				}, __('Create'));
+				frm.add_custom_button(
+					__("Patient Encounter"),
+					function () {
+						frappe.model.open_mapped_doc({
+							method: "healthcare.healthcare.doctype.patient_appointment.patient_appointment.make_encounter",
+							frm: frm,
+						});
+					},
+					__("Create"),
+				);
 			}
 
-			frm.add_custom_button(__('Vital Signs'), function() {
-				create_vital_signs(frm);
-			}, __('Create'));
+			frm.add_custom_button(
+				__("Vital Signs"),
+				function () {
+					create_vital_signs(frm);
+				},
+				__("Create"),
+			);
 
 			if (["Open", "Scheduled"].includes(frm.doc.status)) {
-				frm.add_custom_button(__("Confirm"), function() {
-					frm.set_value("status", "Confirmed");
-					frm.save();
-				}, __("Status"));
+				frm.add_custom_button(
+					__("Confirm"),
+					function () {
+						frm.set_value("status", "Confirmed");
+						frm.save();
+					},
+					__("Status"),
+				);
 			}
 		}
 
-		if (!frm.doc.__islocal && ["Open", "Confirmed"].includes(frm.doc.status) && frm.doc.appointment_based_on_check_in) {
+		if (
+			!frm.doc.__islocal &&
+			["Open", "Confirmed"].includes(frm.doc.status) &&
+			frm.doc.appointment_based_on_check_in
+		) {
 			frm.add_custom_button(__("Check In"), () => {
 				frm.set_value("status", "Checked In");
 				frm.save();
@@ -184,110 +227,127 @@ frappe.ui.form.on('Patient Appointment', {
 
 		frm.trigger("make_invoice_button");
 		frm.trigger("validate_no_of_session");
-
 	},
-	validate_no_of_session:(frm)=>{
-		if(frm.doc.appointment_type == "Therapy Session" && frm.doc.therapy_plan){
+	validate_no_of_session: frm => {
+		if (frm.doc.appointment_type == "Therapy Session" && frm.doc.therapy_plan) {
 			frappe.call({
-				method : "healthcare.healthcare.doctype.therapy_session.therapy_session.validate_no_of_session",
-				args : {
-					therapy_plan : frm.doc.therapy_plan
+				method: "healthcare.healthcare.doctype.therapy_session.therapy_session.validate_no_of_session",
+				args: {
+					therapy_plan: frm.doc.therapy_plan,
 				},
-				callback : (r) =>{
-					if(r.message){
+				callback: r => {
+					if (r.message) {
 						frm.set_df_property("create_therapy_sessions", "hidden", 1);
 					}
-				}
-			})
+				},
+			});
 		}
 	},
 	make_invoice_button: function (frm) {
 		// add button to invoice when show_payment_popup enabled
 		if (!frm.is_new() && !frm.doc.invoiced && frm.doc.status != "Cancelled") {
-			frappe.db.get_single_value("Healthcare Settings", "show_payment_popup").then(async val => {
-				let fee_validity = (await frappe.call(
-					"healthcare.healthcare.doctype.fee_validity.fee_validity.get_fee_validity",
-					{ "appointment_name": frm.doc.name, "date": frm.doc.appointment_date , "ignore_status": true })).message;
+			frappe.db
+				.get_single_value("Healthcare Settings", "show_payment_popup")
+				.then(async val => {
+					let fee_validity = (
+						await frappe.call(
+							"healthcare.healthcare.doctype.fee_validity.fee_validity.get_fee_validity",
+							{
+								appointment_name: frm.doc.name,
+								date: frm.doc.appointment_date,
+								ignore_status: true,
+							},
+						)
+					).message;
 
-				if (val && !fee_validity.length) {
-					frm.add_custom_button(__("Make Payment"), function () {
-						make_payment(frm, val);
-					});
-				}
-			});
-        }
+					if (val && !fee_validity.length) {
+						frm.add_custom_button(__("Make Payment"), function () {
+							make_payment(frm, val);
+						});
+					}
+				});
+		}
 	},
 
-	appointment_for: function(frm) {
-		if (frm.doc.appointment_for == 'Practitioner') {
+	appointment_for: function (frm) {
+		if (frm.doc.appointment_for == "Practitioner") {
 			if (!frm.doc.practitioner) {
-				frm.set_value('department', '');
+				frm.set_value("department", "");
 			}
-			frm.set_value('service_unit', '');
-			frm.trigger('set_check_availability_action');
-		} else if (frm.doc.appointment_for == 'Service Unit') {
+			frm.set_value("service_unit", "");
+			frm.trigger("set_check_availability_action");
+		} else if (frm.doc.appointment_for == "Service Unit") {
 			frm.set_value({
-				'practitioner': '',
-				'practitioner_name': '',
-				'department': '',
+				practitioner: "",
+				practitioner_name: "",
+				department: "",
 			});
-			frm.trigger('set_book_action');
-		} else if (frm.doc.appointment_for == 'Department') {
+			frm.trigger("set_book_action");
+		} else if (frm.doc.appointment_for == "Department") {
 			frm.set_value({
-				'practitioner': '',
-				'practitioner_name': '',
-				'service_unit': '',
+				practitioner: "",
+				practitioner_name: "",
+				service_unit: "",
 			});
-			frm.trigger('set_book_action');
+			frm.trigger("set_book_action");
 		} else {
-			if (frm.doc.appointment_for == 'Department') {
-				frm.set_value('service_unit', '');
+			if (frm.doc.appointment_for == "Department") {
+				frm.set_value("service_unit", "");
 			}
 			frm.set_value({
-				'practitioner': '',
-				'practitioner_name': '',
-				'department': '',
-				'service_unit': '',
+				practitioner: "",
+				practitioner_name: "",
+				department: "",
+				service_unit: "",
 			});
 			frm.page.clear_primary_action();
 		}
 	},
 
-	set_book_action: function(frm) {
-		frm.page.set_primary_action(__('Book'), async function() {
+	set_book_action: function (frm) {
+		frm.page.set_primary_action(__("Book"), async function () {
 			frm.enable_save();
 			await frm.save();
 			if (!frm.is_new()) {
-				await frappe.db.get_single_value("Healthcare Settings", "show_payment_popup").then(val => {
-					frappe.call({
-						method: "healthcare.healthcare.doctype.fee_validity.fee_validity.check_fee_validity",
-						args: { "appointment": frm.doc },
-						callback: (r) => {
-							if (val && !r.message && !frm.doc.invoiced) {
-								make_payment(frm, val);
-							}
-						}
+				await frappe.db
+					.get_single_value("Healthcare Settings", "show_payment_popup")
+					.then(val => {
+						frappe.call({
+							method: "healthcare.healthcare.doctype.fee_validity.fee_validity.check_fee_validity",
+							args: { appointment: frm.doc },
+							callback: r => {
+								if (val && !r.message && !frm.doc.invoiced) {
+									make_payment(frm, val);
+								}
+							},
+						});
 					});
-				});
 			}
 		});
 	},
 
-	set_check_availability_action: function(frm) {
-		frm.page.set_primary_action(__('Check Availability'), function() {
+	set_check_availability_action: function (frm) {
+		frm.page.set_primary_action(__("Check Availability"), function () {
 			if (!frm.doc.patient) {
 				frappe.utils.scroll_to(frm.get_field("patient").$wrapper, true, 30);
 				frappe.msgprint({
-					title: __('Not Allowed'),
-					message: __('Please select Patient first'),
-					indicator: 'red'
+					title: __("Not Allowed"),
+					message: __("Please select Patient first"),
+					indicator: "red",
 				});
-			} else if ( !frm.doc.therapy_plan && frm.doc.appointment_type == "Therapy Session"){
-				frappe.utils.scroll_to(frm.get_field("therapy_plan").$wrapper, true, 30);
+			} else if (
+				!frm.doc.therapy_plan &&
+				frm.doc.appointment_type == "Therapy Session"
+			) {
+				frappe.utils.scroll_to(
+					frm.get_field("therapy_plan").$wrapper,
+					true,
+					30,
+				);
 				frappe.msgprint({
-					title: __('Not Allowed'),
-					message: __('Please select Therapy Plan first'),
-					indicator: 'red'
+					title: __("Not Allowed"),
+					message: __("Please select Therapy Plan first"),
+					indicator: "red",
 				});
 			} else {
 				check_and_set_availability(frm);
@@ -295,103 +355,129 @@ frappe.ui.form.on('Patient Appointment', {
 		});
 	},
 
-	patient: function(frm) {
+	patient: function (frm) {
 		if (frm.doc.patient) {
-			frm.trigger('toggle_payment_fields');
-			frm.trigger('appointment_for');
+			frm.trigger("toggle_payment_fields");
+			frm.trigger("appointment_for");
 			frappe.call({
-				method: 'frappe.client.get',
+				method: "frappe.client.get",
 				args: {
-					doctype: 'Patient',
-					name: frm.doc.patient
+					doctype: "Patient",
+					name: frm.doc.patient,
 				},
-				callback: function(data) {
+				callback: function (data) {
 					let age = null;
 					if (data.message.dob) {
 						age = calculate_age(data.message.dob);
 					}
-					frappe.model.set_value(frm.doctype, frm.docname, 'patient_age', age);
-				}
+					frappe.model.set_value(
+						frm.doctype,
+						frm.docname,
+						"patient_age",
+						age,
+					);
+				},
 			});
 		} else {
-			frm.set_value('patient_name', '');
-			frm.set_value('patient_sex', '');
-			frm.set_value('patient_age', '');
-			frm.set_value('inpatient_record', '');
+			frm.set_value("patient_name", "");
+			frm.set_value("patient_sex", "");
+			frm.set_value("patient_age", "");
+			frm.set_value("inpatient_record", "");
 		}
 	},
 
-	practitioner: function(frm) {
+	practitioner: function (frm) {
 		if (frm.doc.practitioner) {
 			frm.events.set_payment_details(frm);
 		}
 	},
 
-	appointment_type: function(frm) {
+	appointment_type: function (frm) {
 		if (frm.doc.appointment_type) {
-			if (frm.doc.appointment_for && frm.doc[frappe.scrub(frm.doc.appointment_for)]) {
+			if (
+				frm.doc.appointment_for &&
+				frm.doc[frappe.scrub(frm.doc.appointment_for)]
+			) {
 				frm.events.set_payment_details(frm);
 			}
 		}
 	},
 
-	department: function(frm) {
-		if (frm.doc.department && frm.doc.appointment_for == 'Department') {
+	department: function (frm) {
+		if (frm.doc.department && frm.doc.appointment_for == "Department") {
 			frm.events.set_payment_details(frm);
 			frm.set_value("appointment_based_on_check_in", 1);
 		}
 	},
 
-	service_unit: function(frm) {
-		if (frm.doc.service_unit && frm.doc.appointment_for == 'Service Unit') {
+	service_unit: function (frm) {
+		if (frm.doc.service_unit && frm.doc.appointment_for == "Service Unit") {
 			frm.events.set_payment_details(frm);
 			frm.set_value("appointment_based_on_check_in", 1);
 		}
 	},
 
-	set_payment_details: function(frm) {
-		frappe.db.get_single_value('Healthcare Settings', 'show_payment_popup').then(val => {
-			if (val) {
-				frappe.call({
-					method: 'healthcare.healthcare.utils.get_appointment_billing_item_and_rate',
-					args: {
-						doc: frm.doc
-					},
-					callback: function(data) {
-						if (data.message) {
-							frappe.model.set_value(frm.doctype, frm.docname, 'paid_amount', data.message.practitioner_charge);
-							frappe.model.set_value(frm.doctype, frm.docname, 'billing_item', data.message.service_item);
-						}
-					}
-				});
-			}
-		});
+	set_payment_details: function (frm) {
+		frappe.db
+			.get_single_value("Healthcare Settings", "show_payment_popup")
+			.then(val => {
+				if (val) {
+					frappe.call({
+						method: "healthcare.healthcare.utils.get_appointment_billing_item_and_rate",
+						args: {
+							doc: frm.doc,
+						},
+						callback: function (data) {
+							if (data.message) {
+								frappe.model.set_value(
+									frm.doctype,
+									frm.docname,
+									"paid_amount",
+									data.message.practitioner_charge,
+								);
+								frappe.model.set_value(
+									frm.doctype,
+									frm.docname,
+									"billing_item",
+									data.message.service_item,
+								);
+							}
+						},
+					});
+				}
+			});
 	},
 
-	therapy_plan: function(frm) {
+	therapy_plan: function (frm) {
 		// Clear therapy types when therapy plan changes
-		frm.set_value('therapy_types', []);
-		
+		frm.set_value("therapy_types", []);
+
 		// Auto-fetch therapy types when therapy plan is selected
 		if (frm.doc.therapy_plan) {
-			frm.call('get_therapy_types').then(r => {
-				if(r.message == "Completed"){
-					frm.set_value("therapy_plan", "")
-					frappe.throw("Oops!.. Selected Therapy Plan is Completed")
+			frm.call("get_therapy_types").then(r => {
+				if (r.message == "Completed") {
+					frm.set_value("therapy_plan", "");
+					frappe.throw("Oops!.. Selected Therapy Plan is Completed");
 				}
 				if (r.message && r.message.length) {
 					r.message.forEach(therapy => {
-						let row = frappe.model.add_child(frm.doc, 'Patient Appointment Therapy', 'therapy_types');
+						let row = frappe.model.add_child(
+							frm.doc,
+							"Patient Appointment Therapy",
+							"therapy_types",
+						);
 						row.therapy_type = therapy.therapy_type;
 						row.therapy_name = therapy.therapy_name;
 						row.duration = therapy.duration;
 						row.no_of_sessions = therapy.no_of_sessions;
 					});
-					
-					frm.refresh_field('therapy_types');
+
+					frm.refresh_field("therapy_types");
 					frappe.show_alert({
-						message: __('Therapies for the plan {0} added successfully', [frm.doc.therapy_plan]),
-						indicator: 'green'
+						message: __("Therapies for the plan {0} added successfully", [
+							frm.doc.therapy_plan,
+						]),
+						indicator: "green",
 					});
 				}
 			});
@@ -400,57 +486,61 @@ frappe.ui.form.on('Patient Appointment', {
 		frm.set_query("therapy_type", "therapy_types", function (doc, cdt, cdn) {
 			let d = locals[cdt][cdn];
 			return {
-				query : "healthcare.healthcare.doctype.patient_appointment.patient_appointment.apply_filter_on_therapy_type",
-				filters : {
-					therapy_plan : doc.therapy_plan
-				}
+				query: "healthcare.healthcare.doctype.patient_appointment.patient_appointment.apply_filter_on_therapy_type",
+				filters: {
+					therapy_plan: doc.therapy_plan,
+				},
 			};
 		});
 	},
 
-
-	therapy_type: function(frm) {
+	therapy_type: function (frm) {
 		if (frm.doc.therapy_type) {
-			frappe.db.get_value('Therapy Type', frm.doc.therapy_type, 'default_duration', (r) => {
-				if (r.default_duration) {
-					frm.set_value('duration', r.default_duration)
-				}
-			});
+			frappe.db.get_value(
+				"Therapy Type",
+				frm.doc.therapy_type,
+				"default_duration",
+				r => {
+					if (r.default_duration) {
+						frm.set_value("duration", r.default_duration);
+					}
+				},
+			);
 		}
 	},
 
-	get_procedure_from_encounter: function(frm) {
+	get_procedure_from_encounter: function (frm) {
 		get_prescribed_procedure(frm);
 	},
 
-	toggle_payment_fields: function(frm) {
+	toggle_payment_fields: function (frm) {
 		frappe.call({
-			method: 'healthcare.healthcare.doctype.patient_appointment.patient_appointment.check_payment_reqd',
-			args: { 'patient': frm.doc.patient },
-			callback: function(data) {
+			method: "healthcare.healthcare.doctype.patient_appointment.patient_appointment.check_payment_reqd",
+			args: { patient: frm.doc.patient },
+			callback: function (data) {
 				if (data.message.fee_validity) {
 					// if fee validity exists and show payment popup is enabled,
 					// show payment fields as non-mandatory
-					frm.toggle_display('mode_of_payment', 0);
-					frm.toggle_display('paid_amount', 0);
-					frm.toggle_display('billing_item', 0);
-					frm.toggle_reqd('paid_amount', 0);
-					frm.toggle_reqd('billing_item', 0);
+					frm.toggle_display("mode_of_payment", 0);
+					frm.toggle_display("paid_amount", 0);
+					frm.toggle_display("billing_item", 0);
+					frm.toggle_reqd("paid_amount", 0);
+					frm.toggle_reqd("billing_item", 0);
 				} else if (data.message) {
-					frm.toggle_display('mode_of_payment', 1);
-					frm.toggle_display('paid_amount', 1);
-					frm.toggle_display('billing_item', 1);
-					frm.toggle_reqd('paid_amount', 1);
-					frm.toggle_reqd('billing_item', 1);
+					frm.toggle_display("mode_of_payment", 1);
+					frm.toggle_display("paid_amount", 1);
+					frm.toggle_display("billing_item", 1);
+					frm.toggle_reqd("paid_amount", 1);
+					frm.toggle_reqd("billing_item", 1);
 				} else {
 					// if show payment popup is disabled, hide fields
-					frm.toggle_display('mode_of_payment', data.message ? 1 : 0);
-					frm.toggle_display('paid_amount', data.message ? 1 : 0);
-					frm.toggle_display('billing_item', data.message ? 1 : 0);
-					frm.toggle_reqd('paid_amount', data.message ? 1 : 0);
-					frm.toggle_reqd('billing_item', data.message ? 1 : 0);
+					frm.toggle_display("mode_of_payment", data.message ? 1 : 0);
+					frm.toggle_display("paid_amount", data.message ? 1 : 0);
+					frm.toggle_display("billing_item", data.message ? 1 : 0);
+					frm.toggle_reqd("paid_amount", data.message ? 1 : 0);
+					frm.toggle_reqd("billing_item", data.message ? 1 : 0);
 				}
-			}
+			},
 		});
 	},
 
@@ -475,38 +565,38 @@ frappe.ui.form.on('Patient Appointment', {
 	// 				});
 	// 			}
 	// 		}
-	// 	});	
+	// 	});
 	// },
 
-	create_therapy_sessions: function(frm) {
+	create_therapy_sessions: function (frm) {
 		if (!frm.doc.therapy_types || !frm.doc.therapy_types.length) {
-			frappe.msgprint(__('No therapy types selected'));
+			frappe.msgprint(__("No therapy types selected"));
 			return;
 		}
 
 		frappe.call({
-			method: 'healthcare.healthcare.doctype.patient_appointment.patient_appointment.create_therapy_sessions',
+			method: "healthcare.healthcare.doctype.patient_appointment.patient_appointment.create_therapy_sessions",
 			args: {
 				appointment: frm.doc.name,
-				therapy_types: frm.doc.therapy_types
+				therapy_types: frm.doc.therapy_types,
 			},
 			freeze: true,
-			freeze_message: __('Creating Therapy Sessions...'),
-			callback: function(r) {
+			freeze_message: __("Creating Therapy Sessions..."),
+			callback: function (r) {
 				if (r.message && r.message.length) {
-					console.log(r.message)
+					console.log(r.message);
 					frappe.show_alert({
-						message: __('Therapy Sessions created successfully'),
-						indicator: 'green'
+						message: __("Therapy Sessions created successfully"),
+						indicator: "green",
 					});
 					frm.reload_doc();
 				}
-			}
+			},
 		});
-	}
+	},
 });
 
-let check_and_set_availability = function(frm) {
+let check_and_set_availability = function (frm) {
 	let selected_slot = null;
 	let service_unit = null;
 	let duration = null;
@@ -514,111 +604,150 @@ let check_and_set_availability = function(frm) {
 	let overlap_appointments = null;
 	let appointment_based_on_check_in = false;
 	let is_block_booking = false;
-	let service_unit_values=[]
+	let service_unit_values = [];
 
 	show_availability();
 
 	function show_empty_state(practitioner, appointment_date) {
 		frappe.msgprint({
-			title: __('Not Available'),
-			message: __('Healthcare Practitioner {0} not available on {1}', [practitioner.bold(), appointment_date.bold()]),
-			indicator: 'red'
+			title: __("Not Available"),
+			message: __("Healthcare Practitioner {0} not available on {1}", [
+				practitioner.bold(),
+				appointment_date.bold(),
+			]),
+			indicator: "red",
 		});
 	}
 
 	function show_availability() {
-		let selected_practitioner = '';
+		let selected_practitioner = "";
 		let d = new frappe.ui.Dialog({
-			title: __('Available slots'),
+			title: __("Available slots"),
 			fields: [
-				{ fieldtype: 'Link', options: 'Medical Department', reqd: 1, fieldname: 'department', label: 'Medical Department' },
-				{ fieldtype: 'Column Break' },
-				{ fieldtype: 'Link', options: 'Healthcare Practitioner', reqd: 1, fieldname: 'practitioner', label: 'Healthcare Practitioner' },
-				{ fieldtype: 'Column Break' },
-				{ fieldtype: 'Date', reqd: 1, fieldname: 'appointment_date', label: 'Date', min_date: new Date(frappe.datetime.get_today()) },
-				{ fieldtype: 'Section Break' },
-				{ 
-					fieldtype: 'Check', 
-					fieldname: 'block_booking', 
-					label: 'Block Booking', 
+				{
+					fieldtype: "Link",
+					options: "Medical Department",
+					reqd: 1,
+					fieldname: "department",
+					label: "Medical Department",
+				},
+				{ fieldtype: "Column Break" },
+				{
+					fieldtype: "Link",
+					options: "Healthcare Practitioner",
+					reqd: 1,
+					fieldname: "practitioner",
+					label: "Healthcare Practitioner",
+				},
+				{ fieldtype: "Column Break" },
+				{
+					fieldtype: "Date",
+					reqd: 1,
+					fieldname: "appointment_date",
+					label: "Date",
+					min_date: new Date(frappe.datetime.get_today()),
+				},
+				{ fieldtype: "Section Break" },
+				{
+					fieldtype: "Check",
+					fieldname: "block_booking",
+					label: "Block Booking",
 					default: 0,
-					description: __('Enable to book an appointment for a custom time block instead of predefined slots'),
-					onchange: function() {
+					description: __(
+						"Enable to book an appointment for a custom time block instead of predefined slots",
+					),
+					onchange: function () {
 						is_block_booking = this.get_value();
 						toggle_booking_type(d, is_block_booking);
-					}
+					},
 				},
-				{ fieldtype: 'Section Break', fieldname: 'slots_section' },
-				{ fieldtype: 'Link', options: 'Healthcare Service Unit', reqd: 0, hidden: 1, fieldname: 'service_unit', label: 'Service Unit' },
-				{ 
-					fieldtype: 'Time', 
-					fieldname: 'from_time', 
-					label: 'From Time', 
+				{ fieldtype: "Section Break", fieldname: "slots_section" },
+				{
+					fieldtype: "Link",
+					options: "Healthcare Service Unit",
 					reqd: 0,
 					hidden: 1,
-					default: '09:00:00',
-					description: __('Start time of the block appointment') 
+					fieldname: "service_unit",
+					label: "Service Unit",
 				},
-				{ 
-					fieldtype: 'Time', 
-					fieldname: 'to_time', 
-					label: 'To Time', 
-					reqd: 0, 
+				{
+					fieldtype: "Time",
+					fieldname: "from_time",
+					label: "From Time",
+					reqd: 0,
 					hidden: 1,
-					default: '17:00:00',
-					description: __('End time of the block appointment')
+					default: "09:00:00",
+					description: __("Start time of the block appointment"),
 				},
-				{ fieldtype: 'HTML', fieldname: 'available_slots' },
+				{
+					fieldtype: "Time",
+					fieldname: "to_time",
+					label: "To Time",
+					reqd: 0,
+					hidden: 1,
+					default: "17:00:00",
+					description: __("End time of the block appointment"),
+				},
+				{ fieldtype: "HTML", fieldname: "available_slots" },
 			],
-			primary_action_label: __('Book'),
-			primary_action: async function() {
+			primary_action_label: __("Book"),
+			primary_action: async function () {
 				if (is_block_booking) {
 					let values = d.get_values();
-					frm.doc.service_unit=values.service_unit
-					
+					frm.doc.service_unit = values.service_unit;
+
 					if (!values) return;
-					
+
 					if (values.from_time >= values.to_time) {
 						frappe.throw(__("From Time must be before To Time"));
 						return;
 					}
-					
-					if (values.from_time && typeof values.from_time === 'string') {
-						if (!values.from_time.includes(':')) {
+
+					if (values.from_time && typeof values.from_time === "string") {
+						if (!values.from_time.includes(":")) {
 							values.from_time = values.from_time + ":00";
 						}
-						if (values.from_time.split(':').length === 2) {
+						if (values.from_time.split(":").length === 2) {
 							values.from_time = values.from_time + ":00";
 						}
 					}
-					
-					if (values.to_time && typeof values.to_time === 'string') {
-						if (!values.to_time.includes(':')) {
+
+					if (values.to_time && typeof values.to_time === "string") {
+						if (!values.to_time.includes(":")) {
 							values.to_time = values.to_time + ":00";
 						}
-						if (values.to_time.split(':').length === 2) {
+						if (values.to_time.split(":").length === 2) {
 							values.to_time = values.to_time + ":00";
 						}
 					}
-					
+
 					try {
-						let from_datetime = frappe.datetime.str_to_obj(values.appointment_date + " " + values.from_time);
-						let to_datetime = frappe.datetime.str_to_obj(values.appointment_date + " " + values.to_time);
-						let duration_minutes = (to_datetime - from_datetime) / (1000 * 60);
+						let from_datetime = frappe.datetime.str_to_obj(
+							values.appointment_date + " " + values.from_time,
+						);
+						let to_datetime = frappe.datetime.str_to_obj(
+							values.appointment_date + " " + values.to_time,
+						);
+						let duration_minutes =
+							(to_datetime - from_datetime) / (1000 * 60);
 						values.duration = duration_minutes;
 					} catch (e) {
 						console.error("Error calculating duration:", e);
 					}
-					const inputDateTime = new Date(values.appointment_date + " " + values.from_time);
+					const inputDateTime = new Date(
+						values.appointment_date + " " + values.from_time,
+					);
 					const now = new Date();
 					if (inputDateTime < now) {
-						frappe.throw("<b>Invalid time selection: Appointments cannot be scheduled for a past date and time.</b>")
+						frappe.throw(
+							"<b>Invalid time selection: Appointments cannot be scheduled for a past date and time.</b>",
+						);
 					}
 					frappe.show_alert({
 						message: __("Checking for conflicts..."),
-						indicator: "blue"
+						indicator: "blue",
 					});
-					
+
 					let formValues = {
 						practitioner: values.practitioner,
 						department: values.department,
@@ -626,238 +755,282 @@ let check_and_set_availability = function(frm) {
 						date: values.appointment_date,
 						from_time: values.from_time,
 						to_time: values.to_time,
-						duration: values.duration
+						duration: values.duration,
 					};
-					
+
 					d.hide();
-					
+
 					frappe.call({
 						method: "healthcare.healthcare.doctype.patient_appointment.patient_appointment.check_unavailability_conflicts",
 						args: {
-							filters: formValues
+							filters: formValues,
 						},
-						callback: function(r) {
-							if (r.message 
-								&& Array.isArray(r.message) 
-								&& r.message.length > 0 
-								&& r.message[0].name != frm.doc.name) {
-
-								show_block_booking_conflict_dialog(formValues, r.message);
+						callback: function (r) {
+							if (
+								r.message &&
+								Array.isArray(r.message) &&
+								r.message.length > 0 &&
+								r.message[0].name != frm.doc.name
+							) {
+								show_block_booking_conflict_dialog(
+									formValues,
+									r.message,
+								);
 							} else {
 								create_block_appointment(formValues, frm);
 							}
-						}
+						},
 					});
 				} else {
-					frm.set_value('appointment_time', selected_slot);
-					add_video_conferencing = add_video_conferencing && !d.$wrapper.find(".opt-out-check").is(":checked")
-						&& !overlap_appointments
+					frm.set_value("appointment_time", selected_slot);
+					add_video_conferencing =
+						add_video_conferencing &&
+						!d.$wrapper.find(".opt-out-check").is(":checked") &&
+						!overlap_appointments;
 
-					frm.set_value('add_video_conferencing', add_video_conferencing);
+					frm.set_value("add_video_conferencing", add_video_conferencing);
 					if (!frm.doc.duration) {
-						frm.set_value('duration', duration);
+						frm.set_value("duration", duration);
 					}
 					let practitioner = frm.doc.practitioner;
 
-					frm.set_value('practitioner', d.get_value('practitioner'));
-					frm.set_value('department', d.get_value('department'));
-					frm.set_value('appointment_date', d.get_value('appointment_date'));
-					
+					frm.set_value("practitioner", d.get_value("practitioner"));
+					frm.set_value("department", d.get_value("department"));
+					frm.set_value("appointment_date", d.get_value("appointment_date"));
+
 					if (duration) {
-						let start_time = moment(selected_slot, 'HH:mm:ss');
-						
-						let end_time = moment(start_time).add(duration, 'minutes');
-						
-						let end_time_str = end_time.format('HH:mm:ss');
-						
-						frm.set_value('end_time', end_time_str);
+						let start_time = moment(selected_slot, "HH:mm:ss");
+
+						let end_time = moment(start_time).add(duration, "minutes");
+
+						let end_time_str = end_time.format("HH:mm:ss");
+
+						frm.set_value("end_time", end_time_str);
 					}
-					
-					frm.set_value('appointment_based_on_check_in', appointment_based_on_check_in ? 1 : 0);
+
+					frm.set_value(
+						"appointment_based_on_check_in",
+						appointment_based_on_check_in ? 1 : 0,
+					);
 
 					if (service_unit) {
-						frm.set_value('service_unit', service_unit);
+						frm.set_value("service_unit", service_unit);
 					}
-					
-					if (frm.doc.status === 'Needs Rescheduling') {
-						let appointment_date = moment(d.get_value('appointment_date'));
-						let today = moment().startOf('day');
-						
+
+					if (frm.doc.status === "Needs Rescheduling") {
+						let appointment_date = moment(d.get_value("appointment_date"));
+						let today = moment().startOf("day");
+
 						if (appointment_date.isAfter(today)) {
-							frm.set_value('status', 'Scheduled');
+							frm.set_value("status", "Scheduled");
 						} else if (appointment_date.isSame(today)) {
-							frm.set_value('status', 'Open');
+							frm.set_value("status", "Open");
 						}
 					}
 
 					d.hide();
 					frm.enable_save();
 					await frm.save();
-					if (!frm.is_new() && (!practitioner || practitioner == d.get_value('practitioner'))) {
-						await frappe.db.get_single_value("Healthcare Settings", "show_payment_popup").then(val => {
-							frappe.call({
-								method: "healthcare.healthcare.doctype.fee_validity.fee_validity.check_fee_validity",
-								args: { "appointment": frm.doc },
-								callback: (r) => {
-									if (val && !r.message && !frm.doc.invoiced) {
-										make_payment(frm, val);
-									} else {
-										frappe.call({
-											method: "healthcare.healthcare.doctype.patient_appointment.patient_appointment.update_fee_validity",
-											args: { "appointment": frm.doc }
-										});
-									}
-								}
+					if (
+						!frm.is_new() &&
+						(!practitioner || practitioner == d.get_value("practitioner"))
+					) {
+						await frappe.db
+							.get_single_value(
+								"Healthcare Settings",
+								"show_payment_popup",
+							)
+							.then(val => {
+								frappe.call({
+									method: "healthcare.healthcare.doctype.fee_validity.fee_validity.check_fee_validity",
+									args: { appointment: frm.doc },
+									callback: r => {
+										if (val && !r.message && !frm.doc.invoiced) {
+											make_payment(frm, val);
+										} else {
+											frappe.call({
+												method: "healthcare.healthcare.doctype.patient_appointment.patient_appointment.update_fee_validity",
+												args: { appointment: frm.doc },
+											});
+										}
+									},
+								});
 							});
-						});
 					}
-					d.get_primary_btn().attr('disabled', true);
+					d.get_primary_btn().attr("disabled", true);
 				}
-			}
+			},
 		});
 
 		d.set_values({
-			'department': frm.doc.department,
-			'practitioner': frm.doc.practitioner,
-			'appointment_date': frm.doc.appointment_date,
+			department: frm.doc.department,
+			practitioner: frm.doc.practitioner,
+			appointment_date: frm.doc.appointment_date,
 		});
 
 		let selected_department = frm.doc.department;
 
-		d.fields_dict['department'].df.onchange = () => {
-			if (selected_department != d.get_value('department')) {
+		d.fields_dict["department"].df.onchange = () => {
+			if (selected_department != d.get_value("department")) {
 				d.set_values({
-					'practitioner': ''
+					practitioner: "",
 				});
-				selected_department = d.get_value('department');
+				selected_department = d.get_value("department");
 			}
-			if (d.get_value('department')) {
-				d.fields_dict.practitioner.get_query = function() {
+			if (d.get_value("department")) {
+				d.fields_dict.practitioner.get_query = function () {
 					return {
 						filters: {
-							'department': selected_department
-						}
+							department: selected_department,
+						},
 					};
 				};
 			}
 		};
 
-		d.fields_dict.service_unit.get_query = function() {
+		d.fields_dict.service_unit.get_query = function () {
 			return {
 				filters: {
-					'name': ["in", service_unit_values]
-				}
+					name: ["in", service_unit_values],
+				},
 			};
 		};
 
-		d.get_primary_btn().attr('disabled', true);
+		d.get_primary_btn().attr("disabled", true);
 
 		let fd = d.fields_dict;
 
-		d.fields_dict['appointment_date'].df.onchange = () => {
+		d.fields_dict["appointment_date"].df.onchange = () => {
 			if (is_block_booking) {
-				if (d.get_value('appointment_date') && d.get_value('from_time') && d.get_value('to_time') && 
-				    d.get_value('from_time') < d.get_value('to_time')) {
-					d.get_primary_btn().attr('disabled', null);
+				if (
+					d.get_value("appointment_date") &&
+					d.get_value("from_time") &&
+					d.get_value("to_time") &&
+					d.get_value("from_time") < d.get_value("to_time")
+				) {
+					d.get_primary_btn().attr("disabled", null);
 				}
 			} else {
 				show_slots(d, fd);
 			}
 		};
-		
-		d.fields_dict['from_time'].df.onchange = () => {
-			if (is_block_booking && d.get_value('appointment_date') && 
-			    d.get_value('from_time') && d.get_value('to_time') && 
-			    d.get_value('from_time') < d.get_value('to_time')) {
-				d.get_primary_btn().attr('disabled', null);
+
+		d.fields_dict["from_time"].df.onchange = () => {
+			if (
+				is_block_booking &&
+				d.get_value("appointment_date") &&
+				d.get_value("from_time") &&
+				d.get_value("to_time") &&
+				d.get_value("from_time") < d.get_value("to_time")
+			) {
+				d.get_primary_btn().attr("disabled", null);
 			}
 		};
-		
-		d.fields_dict['to_time'].df.onchange = () => {
-			if (is_block_booking && d.get_value('appointment_date') && 
-			    d.get_value('from_time') && d.get_value('to_time') && 
-			    d.get_value('from_time') < d.get_value('to_time')) {
-				d.get_primary_btn().attr('disabled', null);
+
+		d.fields_dict["to_time"].df.onchange = () => {
+			if (
+				is_block_booking &&
+				d.get_value("appointment_date") &&
+				d.get_value("from_time") &&
+				d.get_value("to_time") &&
+				d.get_value("from_time") < d.get_value("to_time")
+			) {
+				d.get_primary_btn().attr("disabled", null);
 			}
-			if((d.get_value('from_time') > d.get_value('to_time')) || (d.get_value('from_time') == d.get_value('to_time'))) {
-				frappe.throw("<b>From Time must be before to time</b>")
+			if (
+				d.get_value("from_time") > d.get_value("to_time") ||
+				d.get_value("from_time") == d.get_value("to_time")
+			) {
+				frappe.throw("<b>From Time must be before to time</b>");
 			}
 		};
-		
-		d.fields_dict['practitioner'].df.onchange = async () => {
-			if (d.get_value('practitioner') && d.get_value('practitioner') != selected_practitioner) {
-				selected_practitioner = d.get_value('practitioner');
+
+		d.fields_dict["practitioner"].df.onchange = async () => {
+			if (
+				d.get_value("practitioner") &&
+				d.get_value("practitioner") != selected_practitioner
+			) {
+				selected_practitioner = d.get_value("practitioner");
 
 				let r = await frappe.call({
-					doc:frm.doc,
+					doc: frm.doc,
 					method: "get_service_unit_values",
 					args: {
-						selected_practitioner
-					}
+						selected_practitioner,
+					},
 				});
 				service_unit_values = r.message;
 
 				if (!is_block_booking) {
 					show_slots(d, fd);
-				} else if (d.get_value('appointment_date') && 
-				    d.get_value('from_time') && d.get_value('to_time') && 
-				    d.get_value('from_time') < d.get_value('to_time')) {
-					d.get_primary_btn().attr('disabled', null);
+				} else if (
+					d.get_value("appointment_date") &&
+					d.get_value("from_time") &&
+					d.get_value("to_time") &&
+					d.get_value("from_time") < d.get_value("to_time")
+				) {
+					d.get_primary_btn().attr("disabled", null);
 				}
 			}
 		};
 
 		d.show();
 	}
-	
+
 	function toggle_booking_type(d, is_block) {
 		if (is_block) {
-			d.set_df_property('available_slots', 'hidden', 1);
-			d.set_df_property('from_time', 'hidden', 0);
-			d.set_df_property('to_time', 'hidden', 0);
-			if(service_unit_values.length>1){
-				d.set_df_property('service_unit', 'hidden', 0);
-			}else{
-				d.set_value("service_unit",service_unit_values[0])
-			}
-			d.set_df_property('from_time', 'reqd', 1);
-			d.set_df_property('to_time', 'reqd', 1);
-			d.set_df_property('service_unit', 'reqd', 1);
-			
-			selected_slot = null;
-			
-			d.set_title(__('Block Time Booking'));
-			
-			d.fields_dict.available_slots.$wrapper.html('');
-			
-			if (d.get_value('appointment_date') && d.get_value('practitioner') && 
-			    d.get_value('from_time') && d.get_value('to_time') && 
-			    d.get_value('from_time') < d.get_value('to_time')) {
-				d.get_primary_btn().attr('disabled', null);
+			d.set_df_property("available_slots", "hidden", 1);
+			d.set_df_property("from_time", "hidden", 0);
+			d.set_df_property("to_time", "hidden", 0);
+			if (service_unit_values.length > 1) {
+				d.set_df_property("service_unit", "hidden", 0);
 			} else {
-				d.get_primary_btn().attr('disabled', true);
+				d.set_value("service_unit", service_unit_values[0]);
+			}
+			d.set_df_property("from_time", "reqd", 1);
+			d.set_df_property("to_time", "reqd", 1);
+			d.set_df_property("service_unit", "reqd", 1);
+
+			selected_slot = null;
+
+			d.set_title(__("Block Time Booking"));
+
+			d.fields_dict.available_slots.$wrapper.html("");
+
+			if (
+				d.get_value("appointment_date") &&
+				d.get_value("practitioner") &&
+				d.get_value("from_time") &&
+				d.get_value("to_time") &&
+				d.get_value("from_time") < d.get_value("to_time")
+			) {
+				d.get_primary_btn().attr("disabled", null);
+			} else {
+				d.get_primary_btn().attr("disabled", true);
 			}
 		} else {
-			d.set_df_property('available_slots', 'hidden', 0);
-			d.set_df_property('from_time', 'hidden', 1);
-			d.set_df_property('to_time', 'hidden', 1);
-			d.set_df_property('service_unit', 'hidden', 1);
-			d.set_df_property('from_time', 'reqd', 0);
-			d.set_df_property('to_time', 'reqd', 0);
-			d.set_df_property('service_unit', 'reqd', 0);
-			
-			d.set_title(__('Available slots'));
-			
-			if (d.get_value('practitioner') && d.get_value('appointment_date')) {
+			d.set_df_property("available_slots", "hidden", 0);
+			d.set_df_property("from_time", "hidden", 1);
+			d.set_df_property("to_time", "hidden", 1);
+			d.set_df_property("service_unit", "hidden", 1);
+			d.set_df_property("from_time", "reqd", 0);
+			d.set_df_property("to_time", "reqd", 0);
+			d.set_df_property("service_unit", "reqd", 0);
+
+			d.set_title(__("Available slots"));
+
+			if (d.get_value("practitioner") && d.get_value("appointment_date")) {
 				show_slots(d, d.fields_dict);
 			}
 		}
 	}
-	
+
 	function show_block_booking_conflict_dialog(values, conflicts) {
 		let conflict_html = `<div class="conflicts-container">
 			<div class="alert alert-danger">
-				<strong>${__("Cannot book time block appointment!")}</strong> ${__("The following appointments conflict with the selected time:")}
+				<strong>${__("Cannot book time block appointment!")}</strong> ${__(
+					"The following appointments conflict with the selected time:",
+				)}
 			</div>
 			<div class="conflict-list" style="max-height: 300px; overflow-y: auto;">
 				<table class="table table-bordered">
@@ -870,8 +1043,8 @@ let check_and_set_availability = function(frm) {
 						</tr>
 					</thead>
 					<tbody>`;
-		
-		conflicts.forEach(function(conflict) {
+
+		conflicts.forEach(function (conflict) {
 			conflict_html += `<tr>
 				<td>${conflict.patient_name || conflict.patient}</td>
 				<td>${conflict.appointment_time}</td>
@@ -879,7 +1052,7 @@ let check_and_set_availability = function(frm) {
 				<td>${conflict.status}</td>
 			</tr>`;
 		});
-		
+
 		conflict_html += `</tbody>
 				</table>
 			</div>
@@ -887,367 +1060,452 @@ let check_and_set_availability = function(frm) {
 				${__("Total conflicting appointments: ")} <strong>${conflicts.length}</strong>
 			</div>
 			<div class="alert alert-warning">
-				<strong>${__("Important:")}</strong> ${__("You must cancel these appointments before booking a time block appointment for this time.")}
+				<strong>${__("Important:")}</strong> ${__(
+					"You must cancel these appointments before booking a time block appointment for this time.",
+				)}
 			</div>
 		</div>`;
-		
+
 		let d = new frappe.ui.Dialog({
 			title: __("Appointment Conflicts Detected"),
 			fields: [
 				{
 					fieldtype: "HTML",
 					fieldname: "conflicts_html",
-					options: conflict_html
-				}
+					options: conflict_html,
+				},
 			],
 			primary_action_label: __("Go Back"),
-			primary_action: function() {
+			primary_action: function () {
 				d.hide();
 				check_and_set_availability(frm);
-			}
+			},
 		});
-		
+
 		d.show();
 	}
-	
+
 	function create_block_appointment(values, frm) {
 		// Check if patient is selected
 		if (!frm.doc.patient) {
 			frappe.msgprint({
-				title: __('Patient Required'),
-				message: __('Please select a patient before booking a block appointment'),
-				indicator: 'red'
+				title: __("Patient Required"),
+				message: __(
+					"Please select a patient before booking a block appointment",
+				),
+				indicator: "red",
 			});
 			check_and_set_availability(frm); // Reopen the dialog
 			return;
 		}
-		
+
 		frappe.confirm(
 			__("Are you sure you want to book this time block appointment?"),
-			function() {
+			function () {
 				// Calculate duration in minutes based on from and to time
-				let from_time_obj = moment(values.from_time, 'HH:mm:ss');
-				let to_time_obj = moment(values.to_time, 'HH:mm:ss');
-				
+				let from_time_obj = moment(values.from_time, "HH:mm:ss");
+				let to_time_obj = moment(values.to_time, "HH:mm:ss");
+
 				// Ensure to_time is after from_time
 				if (to_time_obj.isBefore(from_time_obj)) {
 					frappe.msgprint({
-						title: __('Invalid Time Range'),
-						message: __('End time must be after start time'),
-						indicator: 'red'
+						title: __("Invalid Time Range"),
+						message: __("End time must be after start time"),
+						indicator: "red",
 					});
 					return;
 				}
-				
+
 				// Calculate duration in minutes
-				let duration_minutes = to_time_obj.diff(from_time_obj, 'minutes');
-				
+				let duration_minutes = to_time_obj.diff(from_time_obj, "minutes");
+
 				console.log("Block appointment details:", {
 					from: values.from_time,
 					to: values.to_time,
-					duration: duration_minutes
+					duration: duration_minutes,
 				});
-				
+
 				// Set the form values from the block booking dialog
-				frm.set_value('appointment_date', values.date);
-				frm.set_value('appointment_time', values.from_time);
-				frm.set_value('end_time', values.to_time);
-				frm.set_value('duration', duration_minutes);
-				
+				frm.set_value("appointment_date", values.date);
+				frm.set_value("appointment_time", values.from_time);
+				frm.set_value("end_time", values.to_time);
+				frm.set_value("duration", duration_minutes);
+
 				// Ensure these fields are also set for completeness
-				frm.set_value('end_time', values.to_time);
-				
+				frm.set_value("end_time", values.to_time);
+
 				// Set the appointment datetime for proper filtering
-				let appointment_datetime = moment(values.date).format('YYYY-MM-DD') + ' ' + values.from_time;
-				frm.set_value('appointment_datetime', appointment_datetime);
-				
-				// Set appointment end datetime 
-				let appointment_end_datetime = moment(values.date).format('YYYY-MM-DD') + ' ' + values.to_time;
-				frm.set_value('appointment_datetime', appointment_end_datetime);
-				
+				let appointment_datetime =
+					moment(values.date).format("YYYY-MM-DD") + " " + values.from_time;
+				frm.set_value("appointment_datetime", appointment_datetime);
+
+				// Set appointment end datetime
+				let appointment_end_datetime =
+					moment(values.date).format("YYYY-MM-DD") + " " + values.to_time;
+				frm.set_value("appointment_datetime", appointment_end_datetime);
+
 				// Set practitioner/department
-				frm.set_value('practitioner', values.practitioner);
+				frm.set_value("practitioner", values.practitioner);
 				if (values.department) {
-					frm.set_value('department', values.department);
+					frm.set_value("department", values.department);
 				}
-				
+
 				// Calculate the status based on the appointment date
 				let appointment_date = moment(values.date);
-				let today = moment().startOf('day');
-				
+				let today = moment().startOf("day");
+
 				if (appointment_date.isAfter(today)) {
-					frm.set_value('status', 'Scheduled');
+					frm.set_value("status", "Scheduled");
 				} else if (appointment_date.isSame(today)) {
-					frm.set_value('status', 'Open');
+					frm.set_value("status", "Open");
 				}
-				
+
 				frm.enable_save();
 				frm.save()
 					.then(() => {
 						// Add a reload to ensure UI is updated properly
 						frm.reload_doc();
-						
-						frappe.show_alert({
-							message: __("Time block appointment for {0} booked successfully from {1} to {2}", [
-								frm.doc.patient_name, 
-								moment(values.from_time, 'HH:mm:ss').format('hh:mm A'),
-								moment(values.to_time, 'HH:mm:ss').format('hh:mm A')
-							]),
-							indicator: "green"
-						}, 5);
-						
+
+						frappe.show_alert(
+							{
+								message: __(
+									"Time block appointment for {0} booked successfully from {1} to {2}",
+									[
+										frm.doc.patient_name,
+										moment(values.from_time, "HH:mm:ss").format(
+											"hh:mm A",
+										),
+										moment(values.to_time, "HH:mm:ss").format(
+											"hh:mm A",
+										),
+									],
+								),
+								indicator: "green",
+							},
+							5,
+						);
+
 						// Refresh any views if needed
 						if (cur_list && cur_list.doctype === "Patient Appointment") {
 							cur_list.refresh();
 						}
 					})
-					.catch((err) => {
+					.catch(err => {
 						console.error("Error saving block appointment:", err);
 						frappe.msgprint({
-							title: __('Error'),
-							message: __('Failed to save block appointment. Please try again.'),
-							indicator: 'red'
+							title: __("Error"),
+							message: __(
+								"Failed to save block appointment. Please try again.",
+							),
+							indicator: "red",
 						});
 					});
-			}
+			},
 		);
 	}
 
 	function show_slots(d, fd) {
-		if (d.get_value('appointment_date') && d.get_value('practitioner')) {
-			fd.available_slots.html('');
+		if (d.get_value("appointment_date") && d.get_value("practitioner")) {
+			fd.available_slots.html("");
 			frappe.call({
-				method: 'healthcare.healthcare.doctype.patient_appointment.patient_appointment.get_availability_data',
+				method: "healthcare.healthcare.doctype.patient_appointment.patient_appointment.get_availability_data",
 				args: {
-					practitioner: d.get_value('practitioner'),
-					date: d.get_value('appointment_date'),
-					appointment: frm.doc
+					practitioner: d.get_value("practitioner"),
+					date: d.get_value("appointment_date"),
+					appointment: frm.doc,
 				},
-				callback: (r) => {
+				callback: r => {
 					let data = r.message;
 					if (data.slot_details.length > 0) {
 						let $wrapper = d.fields_dict.available_slots.$wrapper;
 
-						let slot_html = get_slots(data.slot_details, data.fee_validity, d.get_value('appointment_date'));
+						let slot_html = get_slots(
+							data.slot_details,
+							data.fee_validity,
+							d.get_value("appointment_date"),
+						);
 
 						$wrapper
-							.css('margin-bottom', 0)
-							.addClass('text-center')
+							.css("margin-bottom", 0)
+							.addClass("text-center")
 							.html(slot_html);
 
-						$wrapper.on('click', 'button', function() {
+						$wrapper.on("click", "button", function () {
 							let $btn = $(this);
-							$wrapper.find('button').removeClass('btn-outline-primary');
-							$btn.addClass('btn-outline-primary');
-							selected_slot = $btn.attr('data-name');
-							service_unit = $btn.attr('data-service-unit');
-							appointment_based_on_check_in = $btn.attr('data-day-appointment');
-							duration = $btn.attr('data-duration');
-							add_video_conferencing = parseInt($btn.attr('data-tele-conf'));
-							overlap_appointments = parseInt($btn.attr('data-overlap-appointments'));
-							if ($btn.attr('data-tele-conf') == 1) {
+							$wrapper.find("button").removeClass("btn-outline-primary");
+							$btn.addClass("btn-outline-primary");
+							selected_slot = $btn.attr("data-name");
+							service_unit = $btn.attr("data-service-unit");
+							appointment_based_on_check_in =
+								$btn.attr("data-day-appointment");
+							duration = $btn.attr("data-duration");
+							add_video_conferencing = parseInt(
+								$btn.attr("data-tele-conf"),
+							);
+							overlap_appointments = parseInt(
+								$btn.attr("data-overlap-appointments"),
+							);
+							if ($btn.attr("data-tele-conf") == 1) {
 								if (d.$wrapper.find(".opt-out-conf-div").length) {
 									d.$wrapper.find(".opt-out-conf-div").show();
 								} else {
-									overlap_appointments ?
-										d.footer.prepend(
-											`<div class="opt-out-conf-div ellipsis text-muted" style="vertical-align:text-bottom;">
+									overlap_appointments
+										? d.footer.prepend(
+												`<div class="opt-out-conf-div ellipsis text-muted" style="vertical-align:text-bottom;">
 												<label>
 													<span class="label-area">
 													${__("Video Conferencing disabled for group consultations")}
 													</span>
 												</label>
-											</div>`
-										)
-									:
-										d.footer.prepend(
-											`<div class="opt-out-conf-div ellipsis" style="vertical-align:text-bottom;">
+											</div>`,
+										  )
+										: d.footer.prepend(
+												`<div class="opt-out-conf-div ellipsis" style="vertical-align:text-bottom;">
 											<label>
 												<input type="checkbox" class="opt-out-check"/>
 												<span class="label-area">
 												${__("Do not add Video Conferencing")}
 												</span>
 											</label>
-										</div>`
-										);
+										</div>`,
+										  );
 								}
 							} else {
 								d.$wrapper.find(".opt-out-conf-div").hide();
 							}
 
-							d.get_primary_btn().attr('disabled', null);
+							d.get_primary_btn().attr("disabled", null);
 						});
-
 					} else {
-						show_empty_state(d.get_value('practitioner'), d.get_value('appointment_date'));
+						show_empty_state(
+							d.get_value("practitioner"),
+							d.get_value("appointment_date"),
+						);
 					}
 				},
 				freeze: true,
-				freeze_message: __('Fetching Schedule...')
+				freeze_message: __("Fetching Schedule..."),
 			});
 		} else {
-			fd.available_slots.html(__('Appointment date and Healthcare Practitioner are Mandatory').bold());
+			fd.available_slots.html(
+				__("Appointment date and Healthcare Practitioner are Mandatory").bold(),
+			);
 		}
 	}
 
 	function get_slots(slot_details, fee_validity, appointment_date) {
-		let slot_html = '';
+		let slot_html = "";
 		let appointment_count = 0;
 		let disabled = false;
-		let start_str, slot_start_time, slot_end_time, interval, count, count_class, tool_tip, available_slots;
+		let start_str,
+			slot_start_time,
+			slot_end_time,
+			interval,
+			count,
+			count_class,
+			tool_tip,
+			available_slots;
 
-		slot_details.forEach((slot_info) => {
+		slot_details.forEach(slot_info => {
 			slot_html += `<div class="slot-info">`;
-			if (fee_validity && fee_validity != 'Disabled') {
+			if (fee_validity && fee_validity != "Disabled") {
 				slot_html += `
 					<span style="color:green">
-					${__('Patient has fee validity till')} <b>${moment(fee_validity.valid_till).format('DD-MM-YYYY')}</b>
+					${__("Patient has fee validity till")} <b>${moment(fee_validity.valid_till).format(
+						"DD-MM-YYYY",
+					)}</b>
 					</span><br>`;
-			} else if (fee_validity != 'Disabled') {
+			} else if (fee_validity != "Disabled") {
 				slot_html += `
 					<span style="color:red">
-					${__('Patient has no fee validity')}
+					${__("Patient has no fee validity")}
 					</span><br>`;
 			}
 
 			slot_html += `
 				<span><b>
-				${__('Practitioner Schedule: ')} </b> ${slot_info.slot_name}
-					${slot_info.tele_conf && !slot_info.allow_overlap ? '<i class="fa fa-video-camera fa-1x" aria-hidden="true"></i>' : ''}
+				${__("Practitioner Schedule: ")} </b> ${slot_info.slot_name}
+					${
+						slot_info.tele_conf && !slot_info.allow_overlap
+							? '<i class="fa fa-video-camera fa-1x" aria-hidden="true"></i>'
+							: ""
+					}
 				</span><br>
-				<span><b> ${__('Service Unit: ')} </b> ${slot_info.service_unit}</span>`;
-				if (slot_info.service_unit_capacity) {
-					slot_html += `<br><span> <b> ${__('Maximum Capacity:')} </b> ${slot_info.service_unit_capacity} </span>`;
-				}
+				<span><b> ${__("Service Unit: ")} </b> ${slot_info.service_unit}</span>`;
+			if (slot_info.service_unit_capacity) {
+				slot_html += `<br><span> <b> ${__("Maximum Capacity:")} </b> ${
+					slot_info.service_unit_capacity
+				} </span>`;
+			}
 
-				slot_html += '</div><br>';
+			slot_html += "</div><br>";
 
-				slot_html += slot_info.avail_slot.map(slot => {
-						appointment_count = 0;
-						disabled = false;
-						count_class = tool_tip = '';
-						start_str = slot.from_time;
-						slot_start_time = moment(slot.from_time, 'HH:mm:ss');
-						slot_end_time = moment(slot.to_time, 'HH:mm:ss');
-						interval = (slot_end_time - slot_start_time) / 60000 | 0;
+			slot_html += slot_info.avail_slot
+				.map(slot => {
+					appointment_count = 0;
+					disabled = false;
+					count_class = tool_tip = "";
+					start_str = slot.from_time;
+					slot_start_time = moment(slot.from_time, "HH:mm:ss");
+					slot_end_time = moment(slot.to_time, "HH:mm:ss");
+					interval = ((slot_end_time - slot_start_time) / 60000) | 0;
 
-						let now = moment();
-						let booked_moment = "";
-						if((now.format("YYYY-MM-DD") == appointment_date) && (slot_start_time.isBefore(now) && !slot.maximum_appointments)){
+					let now = moment();
+					let booked_moment = "";
+					if (
+						now.format("YYYY-MM-DD") == appointment_date &&
+						slot_start_time.isBefore(now) &&
+						!slot.maximum_appointments
+					) {
+						disabled = true;
+					} else {
+						slot_info.appointments.forEach(booked => {
+							// Get the start time of the booked appointment
+							booked_moment = moment(booked.appointment_time, "HH:mm:ss");
+
+							// Get the end time - either from explicit end_time or calculated from duration
+							let end_time;
+							if (booked.end_time) {
+								// Use explicit end time if available (block appointments)
+								end_time = moment(booked.end_time, "HH:mm:ss");
+							} else {
+								// Otherwise calculate from duration
+								end_time = booked_moment
+									.clone()
+									.add(booked.duration, "minutes");
+							}
+
+							// Special handling for Unavailable appointments
+							if (
+								booked.status === "Unavailable" &&
+								booked.appointment_type === "Unavailable"
+							) {
+								if (
+									slot_start_time.isBefore(end_time) &&
+									slot_end_time.isAfter(booked_moment)
+								) {
+									disabled = true;
+									tool_tip = __(
+										"Practitioner unavailable at this time",
+									);
+									return false;
+								}
+							}
+
+							// Handle maximum appointments capacity
+							if (slot.maximum_appointments) {
+								if (booked.appointment_date == appointment_date) {
+									appointment_count++;
+								}
+							}
+
+							// Check if the slot time matches exactly with a booked appointment
+							if (
+								booked_moment.isSame(slot_start_time) ||
+								booked_moment.isBetween(slot_start_time, slot_end_time)
+							) {
+								if (booked.duration == 0) {
+									disabled = true;
+									return false;
+								}
+							}
+
+							// Overlap checks
+							if (slot_info.allow_overlap != 1) {
+								// Check if the current slot overlaps with any booked appointment
+								// This handles the case where a block appointment might span multiple slots
+								let slot_overlaps_with_booked =
+									// Slot starts during the booked appointment
+									(slot_start_time.isSameOrAfter(booked_moment) &&
+										slot_start_time.isBefore(end_time)) ||
+									// Slot ends during the booked appointment
+									(slot_end_time.isAfter(booked_moment) &&
+										slot_end_time.isSameOrBefore(end_time)) ||
+									// Slot completely contains the booked appointment
+									(slot_start_time.isSameOrBefore(booked_moment) &&
+										slot_end_time.isSameOrAfter(end_time));
+
+								if (slot_overlaps_with_booked) {
+									disabled = true;
+									return false;
+								}
+							} else {
+								if (
+									slot_start_time.isBefore(end_time) &&
+									slot_end_time.isAfter(booked_moment)
+								) {
+									appointment_count++;
+								}
+								if (
+									appointment_count >= slot_info.service_unit_capacity
+								) {
+									disabled = true;
+									return false;
+								}
+							}
+						});
+					}
+					if (
+						slot_info.allow_overlap == 1 &&
+						slot_info.service_unit_capacity > 1
+					) {
+						available_slots =
+							slot_info.service_unit_capacity - appointment_count;
+						count = `${available_slots > 0 ? available_slots : __("Full")}`;
+						count_class = `${
+							available_slots > 0 ? "badge-success" : "badge-danger"
+						}`;
+						tool_tip = `${available_slots} ${__(
+							"slots available for booking",
+						)}`;
+					}
+
+					if (slot.maximum_appointments) {
+						if (appointment_count >= slot.maximum_appointments) {
 							disabled = true;
 						} else {
-							slot_info.appointments.forEach((booked) => {
-								// Get the start time of the booked appointment
-								booked_moment = moment(booked.appointment_time, 'HH:mm:ss');
-								
-								// Get the end time - either from explicit end_time or calculated from duration
-								let end_time;
-								if (booked.end_time) {
-									// Use explicit end time if available (block appointments)
-									end_time = moment(booked.end_time, 'HH:mm:ss');
-								} else {
-									// Otherwise calculate from duration
-									end_time = booked_moment.clone().add(booked.duration, 'minutes');
-								}
-
-								// Special handling for Unavailable appointments
-								if (booked.status === "Unavailable" && booked.appointment_type === "Unavailable") {
-									if (slot_start_time.isBefore(end_time) && slot_end_time.isAfter(booked_moment)) {
-										disabled = true;
-										tool_tip = __("Practitioner unavailable at this time");
-										return false;
-									}
-								}
-
-								// Handle maximum appointments capacity
-								if (slot.maximum_appointments) {
-									if (booked.appointment_date == appointment_date) {
-										appointment_count++;
-									}
-								}
-								
-								// Check if the slot time matches exactly with a booked appointment
-								if (booked_moment.isSame(slot_start_time) || booked_moment.isBetween(slot_start_time, slot_end_time)) {
-									if (booked.duration == 0) {
-										disabled = true;
-										return false;
-									}
-								}
-
-								// Overlap checks
-								if (slot_info.allow_overlap != 1) {
-									// Check if the current slot overlaps with any booked appointment
-									// This handles the case where a block appointment might span multiple slots
-									let slot_overlaps_with_booked = (
-										// Slot starts during the booked appointment
-										(slot_start_time.isSameOrAfter(booked_moment) && slot_start_time.isBefore(end_time)) ||
-										// Slot ends during the booked appointment
-										(slot_end_time.isAfter(booked_moment) && slot_end_time.isSameOrBefore(end_time)) ||
-										// Slot completely contains the booked appointment
-										(slot_start_time.isSameOrBefore(booked_moment) && slot_end_time.isSameOrAfter(end_time))
-									);
-									
-									if (slot_overlaps_with_booked) {
-										disabled = true;
-										return false;
-									}
-								} else {
-									if (slot_start_time.isBefore(end_time) && slot_end_time.isAfter(booked_moment)) {
-										appointment_count++;
-									}
-									if (appointment_count >= slot_info.service_unit_capacity) {
-										disabled = true;
-										return false;
-									}
-								}
-							});
+							disabled = false;
 						}
-						if (slot_info.allow_overlap == 1 && slot_info.service_unit_capacity > 1) {
-							available_slots = slot_info.service_unit_capacity - appointment_count;
-							count = `${(available_slots > 0 ? available_slots : __('Full'))}`;
-							count_class = `${(available_slots > 0 ? 'badge-success' : 'badge-danger')}`;
-							tool_tip =`${available_slots} ${__('slots available for booking')}`;
-						}
-
-						if (slot.maximum_appointments) {
-							if (appointment_count >= slot.maximum_appointments) {
-								disabled = true;
-							}
-							else {
-								disabled = false;
-							}
-							available_slots = slot.maximum_appointments - appointment_count;
-							count = `${(available_slots > 0 ? available_slots : __('Full'))}`;
-							count_class = `${(available_slots > 0 ? 'badge-success' : 'badge-danger')}`;
-							return `<button class="btn btn-secondary" data-name=${start_str}
-								data-service-unit="${slot_info.service_unit || ''}"
+						available_slots = slot.maximum_appointments - appointment_count;
+						count = `${available_slots > 0 ? available_slots : __("Full")}`;
+						count_class = `${
+							available_slots > 0 ? "badge-success" : "badge-danger"
+						}`;
+						return `<button class="btn btn-secondary" data-name=${start_str}
+								data-service-unit="${slot_info.service_unit || ""}"
 								data-day-appointment=${1}
 								data-duration=${slot.duration}
 								${disabled ? 'disabled="disabled"' : ""}>${slot.from_time} -
-								${slot.to_time} ${slot.maximum_appointments ?
-								`<br><span class='badge ${count_class}'>${count} </span>` : ''}</button>`
-						} else {
-
+								${slot.to_time} ${
+									slot.maximum_appointments
+										? `<br><span class='badge ${count_class}'>${count} </span>`
+										: ""
+								}</button>`;
+					} else {
 						return `
 							<button class="btn btn-secondary" data-name=${start_str}
 								data-duration=${interval}
-								data-service-unit="${slot_info.service_unit || ''}"
+								data-service-unit="${slot_info.service_unit || ""}"
 								data-tele-conf="${slot_info.tele_conf || 0}"
 								data-overlap-appointments="${slot_info.service_unit_capacity || 0}"
 								style="margin: 0 10px 10px 0; width: auto;" ${disabled ? 'disabled="disabled"' : ""}
-								data-toggle="tooltip" title="${tool_tip || ''}">
+								data-toggle="tooltip" title="${tool_tip || ""}">
 								${start_str.substring(0, start_str.length - 3)}
-								${slot_info.service_unit_capacity ? `<br><span class='badge ${count_class}'> ${count} </span>` : ''}
+								${
+									slot_info.service_unit_capacity
+										? `<br><span class='badge ${count_class}'> ${count} </span>`
+										: ""
+								}
 							</button>`;
-
-				}
-			}).join("");
+					}
+				})
+				.join("");
 		});
 		return slot_html;
 	}
 };
 
-let reschedule_dept_or_su = function(frm) {
+let reschedule_dept_or_su = function (frm) {
 	const is_department = frm.doc.appointment_for === "Department";
 
 	const field_config = {
@@ -1255,13 +1513,13 @@ let reschedule_dept_or_su = function(frm) {
 		reqd: 1,
 		options: is_department ? "Medical Department" : "Healthcare Service Unit",
 		fieldname: is_department ? "department" : "service_unit",
-		label: is_department ? "Medical Department" : "Service Unit"
+		label: is_department ? "Medical Department" : "Service Unit",
 	};
 
 	if (!is_department) {
 		field_config.get_query = function () {
 			return {
-				filters: { company: frm.doc.company }
+				filters: { company: frm.doc.company },
 			};
 		};
 	}
@@ -1270,10 +1528,16 @@ let reschedule_dept_or_su = function(frm) {
 		title: __("Reschedule Appointment"),
 		fields: [
 			field_config,
-			{ fieldtype: "Date", reqd: 1, fieldname: "appointment_date", label: "Date", min_date: new Date(frappe.datetime.get_today()) },
+			{
+				fieldtype: "Date",
+				reqd: 1,
+				fieldname: "appointment_date",
+				label: "Date",
+				min_date: new Date(frappe.datetime.get_today()),
+			},
 		],
 		primary_action_label: __("Book"),
-		primary_action: function() {
+		primary_action: function () {
 			const values = d.get_values();
 			if (values) {
 				frm.set_value(field_config.fieldname, values[field_config.fieldname]);
@@ -1283,50 +1547,55 @@ let reschedule_dept_or_su = function(frm) {
 			d.hide();
 			frm.enable_save();
 			frm.save();
-		}
+		},
 	});
 	d.set_value("appointment_date", frm.doc.appointment_date);
 	d.set_value(field_config.fieldname, frm.doc[field_config.fieldname]);
 	d.show();
 };
 
-let get_prescribed_procedure = function(frm) {
+let get_prescribed_procedure = function (frm) {
 	if (frm.doc.patient) {
 		frappe.call({
-			method: 'healthcare.healthcare.doctype.patient_appointment.patient_appointment.get_procedure_prescribed',
+			method: "healthcare.healthcare.doctype.patient_appointment.patient_appointment.get_procedure_prescribed",
 			args: { patient: frm.doc.patient },
-			callback: function(r) {
+			callback: function (r) {
 				if (r.message && r.message.length) {
 					show_procedure_templates(frm, r.message);
 				} else {
 					frappe.msgprint({
-						title: __('Not Found'),
-						message: __('No Prescribed Procedures found for the selected Patient')
+						title: __("Not Found"),
+						message: __(
+							"No Prescribed Procedures found for the selected Patient",
+						),
 					});
 				}
-			}
+			},
 		});
 	} else {
 		frappe.msgprint({
-			title: __('Not Allowed'),
-			message: __('Please select a Patient first')
+			title: __("Not Allowed"),
+			message: __("Please select a Patient first"),
 		});
 	}
 };
 
-let show_procedure_templates = function(frm, result) {
+let show_procedure_templates = function (frm, result) {
 	let d = new frappe.ui.Dialog({
-		title: __('Prescribed Procedures'),
+		title: __("Prescribed Procedures"),
 		fields: [
 			{
-				fieldtype: 'HTML', fieldname: 'procedure_template'
-			}
-		]
+				fieldtype: "HTML",
+				fieldname: "procedure_template",
+			},
+		],
 	});
 	let html_field = d.fields_dict.procedure_template.$wrapper;
 	html_field.empty();
-	$.each(result, function(x, y) {
-		let row = $(repl('<div class="col-xs-12" style="padding-top:12px; text-align:center;" >\
+	$.each(result, function (x, y) {
+		let row = $(
+			repl(
+				'<div class="col-xs-12" style="padding-top:12px; text-align:center;" >\
 		<div class="col-xs-5"> %(encounter)s <br> %(consulting_practitioner)s <br> %(encounter_date)s </div>\
 		<div class="col-xs-5"> %(procedure_template)s <br>%(practitioner)s  <br> %(date)s</div>\
 		<div class="col-xs-2">\
@@ -1334,178 +1603,198 @@ let show_procedure_templates = function(frm, result) {
 		data-encounter="%(encounter)s" data-practitioner="%(practitioner)s"\
 		data-date="%(date)s"  data-department="%(department)s">\
 		<button class="btn btn-default btn-xs">Add\
-		</button></a></div></div><div class="col-xs-12"><hr/><div/>', {
-			name: y[0], procedure_template: y[1],
-			encounter: y[2], consulting_practitioner: y[3], encounter_date: y[4],
-			practitioner: y[5] ? y[5] : '', date: y[6] ? y[6] : '', department: y[7] ? y[7] : ''
-		})).appendTo(html_field);
-		row.find("a").click(function() {
-			frm.doc.procedure_template = $(this).attr('data-procedure-template');
-			frm.doc.procedure_prescription = $(this).attr('data-name');
-			frm.doc.practitioner = $(this).attr('data-practitioner');
-			frm.doc.appointment_date = $(this).attr('data-date');
-			frm.doc.department = $(this).attr('data-department');
-			refresh_field('procedure_template');
-			refresh_field('procedure_prescription');
-			refresh_field('appointment_date');
-			refresh_field('practitioner');
-			refresh_field('department');
+		</button></a></div></div><div class="col-xs-12"><hr/><div/>',
+				{
+					name: y[0],
+					procedure_template: y[1],
+					encounter: y[2],
+					consulting_practitioner: y[3],
+					encounter_date: y[4],
+					practitioner: y[5] ? y[5] : "",
+					date: y[6] ? y[6] : "",
+					department: y[7] ? y[7] : "",
+				},
+			),
+		).appendTo(html_field);
+		row.find("a").click(function () {
+			frm.doc.procedure_template = $(this).attr("data-procedure-template");
+			frm.doc.procedure_prescription = $(this).attr("data-name");
+			frm.doc.practitioner = $(this).attr("data-practitioner");
+			frm.doc.appointment_date = $(this).attr("data-date");
+			frm.doc.department = $(this).attr("data-department");
+			refresh_field("procedure_template");
+			refresh_field("procedure_prescription");
+			refresh_field("appointment_date");
+			refresh_field("practitioner");
+			refresh_field("department");
 			d.hide();
 			return false;
 		});
 	});
 	if (!result) {
-		let msg = __('There are no procedure prescribed for ') + frm.doc.patient;
-		$(repl('<div class="col-xs-12" style="padding-top:20px;" >%(msg)s</div></div>', { msg: msg })).appendTo(html_field);
+		let msg = __("There are no procedure prescribed for ") + frm.doc.patient;
+		$(
+			repl(
+				'<div class="col-xs-12" style="padding-top:20px;" >%(msg)s</div></div>',
+				{ msg: msg },
+			),
+		).appendTo(html_field);
 	}
 	d.show();
 };
 
-let show_therapy_types = function(frm, result) {
+let show_therapy_types = function (frm, result) {
 	var d = new frappe.ui.Dialog({
-		title: __('Prescribed Therapies'),
+		title: __("Prescribed Therapies"),
 		fields: [
 			{
-				fieldtype: 'HTML', 
-				fieldname: 'therapy_type',
-				label: __('Select Therapies')
-			}
+				fieldtype: "HTML",
+				fieldname: "therapy_type",
+				label: __("Select Therapies"),
+			},
 		],
-		primary_action_label: __('Add Selected Therapies'),
-		primary_action: function() {
+		primary_action_label: __("Add Selected Therapies"),
+		primary_action: function () {
 			let selected_therapies = [];
-			$(d.fields_dict.therapy_type.$wrapper).find(':checkbox:checked').each(function() {
-				let therapy_type = $(this).val();
-				let therapy_plan = $(this).data('therapy-plan');
-				let therapy_name = $(this).data('therapy-name');
-				
-				// Check if therapy is already selected
-				let exists = false;
-				if (frm.doc.therapy_types) {
-					frm.doc.therapy_types.forEach(function(t) {
-						if (t.therapy_type === therapy_type) {
-							exists = true;
-						}
-					});
-				}
-				
-				if (!exists) {
-					let therapy = frappe.model.add_child(frm.doc, 'Patient Appointment Therapy', 'therapy_types');
-					therapy.therapy_type = therapy_type;
-					therapy.therapy_name = therapy_name;
-				}
-			});
-			
-			frm.refresh_field('therapy_types');
+			$(d.fields_dict.therapy_type.$wrapper)
+				.find(":checkbox:checked")
+				.each(function () {
+					let therapy_type = $(this).val();
+					let therapy_plan = $(this).data("therapy-plan");
+					let therapy_name = $(this).data("therapy-name");
+
+					// Check if therapy is already selected
+					let exists = false;
+					if (frm.doc.therapy_types) {
+						frm.doc.therapy_types.forEach(function (t) {
+							if (t.therapy_type === therapy_type) {
+								exists = true;
+							}
+						});
+					}
+
+					if (!exists) {
+						let therapy = frappe.model.add_child(
+							frm.doc,
+							"Patient Appointment Therapy",
+							"therapy_types",
+						);
+						therapy.therapy_type = therapy_type;
+						therapy.therapy_name = therapy_name;
+					}
+				});
+
+			frm.refresh_field("therapy_types");
 			d.hide();
-		}
+		},
 	});
-	
+
 	var html_field = d.fields_dict.therapy_type.$wrapper;
 	html_field.empty();
-	
+
 	// Add "Select All" checkbox
-	var select_all = $(`<div class="select-all" style="margin-bottom: 10px; font-weight: bold;">
+	var select_all =
+		$(`<div class="select-all" style="margin-bottom: 10px; font-weight: bold;">
 		<input type="checkbox" id="select_all_therapies" style="margin-right: 5px;">
-		<label for="select_all_therapies">${__('Select All')}</label>
+		<label for="select_all_therapies">${__("Select All")}</label>
 	</div>`);
-	
-	select_all.find('#select_all_therapies').on('change', function() {
-		var checked = $(this).prop('checked');
-		html_field.find('.therapy-checkbox').prop('checked', checked);
+
+	select_all.find("#select_all_therapies").on("change", function () {
+		var checked = $(this).prop("checked");
+		html_field.find(".therapy-checkbox").prop("checked", checked);
 	});
-	
+
 	html_field.append(select_all);
-	
+
 	// Add therapy types with checkboxes
 	var table = $(`<table class="table table-bordered">
 		<thead>
 			<tr>
 				<th style="width: 30px;"></th>
-				<th>${__('Encounter')}</th>
-				<th>${__('Therapy Type')}</th>
-				<th>${__('Therapy Plan')}</th>
+				<th>${__("Encounter")}</th>
+				<th>${__("Therapy Type")}</th>
+				<th>${__("Therapy Plan")}</th>
 			</tr>
 		</thead>
 		<tbody></tbody>
 	</table>`);
-	
+
 	html_field.append(table);
-	
-	$.each(result, function(x, y) {
+
+	$.each(result, function (x, y) {
 		var row = $(`<tr>
 			<td>
-				<input type="checkbox" class="therapy-checkbox" value="${y[0]}" 
+				<input type="checkbox" class="therapy-checkbox" value="${y[0]}"
 				data-therapy-plan="${y[5]}" data-therapy-name="${y[0]}">
 			</td>
 			<td>${y[2]} <br> ${y[3]} <br> ${y[4]}</td>
 			<td>${y[0]}</td>
 			<td>${y[5]}</td>
 		</tr>`);
-		
-		table.find('tbody').append(row);
+
+		table.find("tbody").append(row);
 	});
-	
+
 	d.show();
 };
 
-let create_vital_signs = function(frm) {
+let create_vital_signs = function (frm) {
 	if (!frm.doc.patient) {
-		frappe.throw(__('Please select patient'));
+		frappe.throw(__("Please select patient"));
 	}
 	frappe.route_options = {
-		'patient': frm.doc.patient,
-		'appointment': frm.doc.name,
-		'company': frm.doc.company
+		patient: frm.doc.patient,
+		appointment: frm.doc.name,
+		company: frm.doc.company,
 	};
-	frappe.new_doc('Vital Signs');
+	frappe.new_doc("Vital Signs");
 };
 
-let update_status = function(frm, status) {
+let update_status = function (frm, status) {
 	let doc = frm.doc;
 	let msg = "";
-	
-	if (status === 'Cancelled') {
-		if (doc.appointment_type === 'Unavailable') {
-			msg = __('Are you sure you want to cancel this unavailability record?');
-		} else if (doc.appointment_type === 'Block Booking') {
-			msg = __('Are you sure you want to cancel this time block appointment?');
+
+	if (status === "Cancelled") {
+		if (doc.appointment_type === "Unavailable") {
+			msg = __("Are you sure you want to cancel this unavailability record?");
+		} else if (doc.appointment_type === "Block Booking") {
+			msg = __("Are you sure you want to cancel this time block appointment?");
 		} else {
-			msg = __('Are you sure you want to cancel this appointment?');
+			msg = __("Are you sure you want to cancel this appointment?");
 		}
 	} else {
-		msg = __('Set Status to') + " " + status;
+		msg = __("Set Status to") + " " + status;
 	}
-	
-	frappe.confirm(msg,
-		function() {
-			frappe.call({
-				method: 'healthcare.healthcare.doctype.patient_appointment.patient_appointment.update_status',
-				args: { appointment_id: doc.name, status: status },
-				callback: function(data) {
-					if (!data.exc) {
-						frm.reload_doc();
-					}
+
+	frappe.confirm(msg, function () {
+		frappe.call({
+			method: "healthcare.healthcare.doctype.patient_appointment.patient_appointment.update_status",
+			args: { appointment_id: doc.name, status: status },
+			callback: function (data) {
+				if (!data.exc) {
+					frm.reload_doc();
 				}
-			});
-		}
-	);
+			},
+		});
+	});
 };
 
-let calculate_age = function(birth) {
+let calculate_age = function (birth) {
 	let ageMS = Date.parse(Date()) - Date.parse(birth);
 	let age = new Date();
 	age.setTime(ageMS);
-	let years =  age.getFullYear() - 1970;
-	return `${years} ${__('Years(s)')} ${age.getMonth()} ${__('Month(s)')} ${age.getDate()} ${__('Day(s)')}`;
+	let years = age.getFullYear() - 1970;
+	return `${years} ${__("Years(s)")} ${age.getMonth()} ${__(
+		"Month(s)",
+	)} ${age.getDate()} ${__("Day(s)")}`;
 };
 
 let make_payment = function (frm, automate_invoicing) {
 	if (automate_invoicing) {
-		make_registration (frm, automate_invoicing);
+		make_registration(frm, automate_invoicing);
 	}
 
-	function make_registration (frm, automate_invoicing) {
+	function make_registration(frm, automate_invoicing) {
 		if (automate_invoicing == true && !frm.doc.paid_amount) {
 			frappe.throw({
 				title: __("Not Allowed"),
@@ -1514,7 +1803,9 @@ let make_payment = function (frm, automate_invoicing) {
 		}
 
 		let is_block_booking = frm.doc.appointment_type === "Block Booking";
-		let charge_label = is_block_booking ? "Time Block Appointment Charge" : "Consultation Charge";
+		let charge_label = is_block_booking
+			? "Time Block Appointment Charge"
+			: "Consultation Charge";
 
 		let fields = [
 			{
@@ -1547,7 +1838,7 @@ let make_payment = function (frm, automate_invoicing) {
 			},
 			{
 				label: __("Additional Discount"),
-				fieldtype:"Section Break",
+				fieldtype: "Section Break",
 				collapsible: 1,
 			},
 			{
@@ -1564,7 +1855,7 @@ let make_payment = function (frm, automate_invoicing) {
 				fieldname: "discount_amount",
 				fieldtype: "Currency",
 				default: 0,
-			}
+			},
 		];
 
 		if (frm.doc.appointment_for == "Practitioner") {
@@ -1603,38 +1894,50 @@ let make_payment = function (frm, automate_invoicing) {
 			title: "Enter Payment Details",
 			fields: fields,
 			primary_action_label: "Create Invoice",
-			primary_action: async function(values) {
+			primary_action: async function (values) {
 				if (frm.is_dirty()) {
 					await frm.save();
 				}
 				frappe.call({
 					method: "healthcare.healthcare.doctype.patient_appointment.patient_appointment.invoice_appointment",
 					args: {
-						"appointment_name": frm.doc.name,
-						"discount_percentage": values.discount_percentage,
-						"discount_amount": values.discount_amount
+						appointment_name: frm.doc.name,
+						discount_percentage: values.discount_percentage,
+						discount_amount: values.discount_amount,
 					},
 					callback: async function (data) {
 						if (!data.exc) {
 							await frm.reload_doc();
 							if (frm.doc.ref_sales_invoice) {
-								d.get_field("mode_of_payment").$input.prop("disabled", true);
-								d.get_field("discount_percentage").$input.prop("disabled", true);
-								d.get_field("discount_amount").$input.prop("disabled", true);
+								d.get_field("mode_of_payment").$input.prop(
+									"disabled",
+									true,
+								);
+								d.get_field("discount_percentage").$input.prop(
+									"disabled",
+									true,
+								);
+								d.get_field("discount_amount").$input.prop(
+									"disabled",
+									true,
+								);
 								d.get_primary_btn().attr("disabled", true);
 								d.get_secondary_btn().attr("disabled", false);
 							}
 						}
-					}
+					},
 				});
 			},
 			secondary_action_label: __(`<svg class="icon  icon-sm" style="">
 				<use class="" href="#icon-printer"></use>
 			</svg>`),
 			secondary_action() {
-				window.open("/app/print/Sales Invoice/" + frm.doc.ref_sales_invoice, "_blank");
+				window.open(
+					"/app/print/Sales Invoice/" + frm.doc.ref_sales_invoice,
+					"_blank",
+				);
 				d.hide();
-			}
+			},
 		});
 		d.fields_dict["mode_of_payment"].df.onchange = () => {
 			if (d.get_value("mode_of_payment")) {
@@ -1643,9 +1946,9 @@ let make_payment = function (frm, automate_invoicing) {
 		};
 		d.get_secondary_btn().attr("disabled", true);
 		d.set_values({
-			"patient": frm.doc.patient_name,
-			"consultation_charge": frm.doc.paid_amount,
-			"total_payable": frm.doc.paid_amount,
+			patient: frm.doc.patient_name,
+			consultation_charge: frm.doc.paid_amount,
+			total_payable: frm.doc.paid_amount,
 		});
 
 		if (frm.doc.appointment_for == "Practitioner") {
@@ -1661,8 +1964,10 @@ let make_payment = function (frm, automate_invoicing) {
 		}
 		d.show();
 
-		d.fields_dict["discount_percentage"].df.onchange = () => validate_discount("discount_percentage");
-		d.fields_dict["discount_amount"].df.onchange = () => validate_discount("discount_amount");
+		d.fields_dict["discount_percentage"].df.onchange = () =>
+			validate_discount("discount_percentage");
+		d.fields_dict["discount_amount"].df.onchange = () =>
+			validate_discount("discount_amount");
 
 		function validate_discount(field) {
 			let message = "";
@@ -1683,21 +1988,23 @@ let make_payment = function (frm, automate_invoicing) {
 					discount_amount = consultation_charge * (discount_percentage / 100);
 
 					d.set_values({
-						"discount_amount": discount_amount,
-						"total_payable": consultation_charge - discount_amount,
+						discount_amount: discount_amount,
+						total_payable: consultation_charge - discount_amount,
 					}).then(() => delete frm.via_discount_percentage);
 				}
 			} else if (field === "discount_amount") {
 				if (consultation_charge < discount_amount || discount_amount < 0) {
 					d.get_primary_btn().attr("disabled", true);
-					message = "Discount amount should not be more than Consultation Charge";
+					message =
+						"Discount amount should not be more than Consultation Charge";
 				} else {
 					d.get_primary_btn().attr("disabled", false);
 					if (!frm.via_discount_percentage) {
-						discount_percentage = (discount_amount / consultation_charge) * 100;
+						discount_percentage =
+							(discount_amount / consultation_charge) * 100;
 						d.set_values({
-							"discount_percentage": discount_percentage,
-							"total_payable": consultation_charge - discount_amount,
+							discount_percentage: discount_percentage,
+							total_payable: consultation_charge - discount_amount,
 						});
 					}
 				}
@@ -1707,45 +2014,51 @@ let make_payment = function (frm, automate_invoicing) {
 	}
 };
 
-let show_message = function(d, message, field) {
+let show_message = function (d, message, field) {
 	var field = d.get_field(field);
 	field.df.description = `<div style="color:red;
-		padding:5px 5px 5px 5px">${message}</div>`
+		padding:5px 5px 5px 5px">${message}</div>`;
 	field.refresh();
 };
 
-let reschedule_appointment = function(frm) {
+let reschedule_appointment = function (frm) {
 	let original_status = frm.doc.status;
 	let is_block_booking = frm.doc.appointment_type === "Block Booking";
-	
+
 	check_and_set_availability(frm);
-	
-	let after_save_handler = function() {
+
+	let after_save_handler = function () {
 		if (frm.doc.status === "Needs Rescheduling") {
 			let today = frappe.datetime.get_today();
 			let status = today === frm.doc.appointment_date ? "Open" : "Scheduled";
-			
-			frappe.db.set_value("Patient Appointment", frm.doc.name, "status", status)
+
+			frappe.db
+				.set_value("Patient Appointment", frm.doc.name, "status", status)
 				.then(() => {
 					frappe.show_alert({
-						message: __("Appointment {0} has been rescheduled", [frm.doc.name]),
-						indicator: "green"
+						message: __("Appointment {0} has been rescheduled", [
+							frm.doc.name,
+						]),
+						indicator: "green",
 					});
 					frm.reload_doc();
 				});
 		} else if (is_block_booking) {
 			// For block bookings, show confirmation
-			frappe.show_alert({
-				message: __("Time block appointment has been rescheduled"),
-				indicator: "green"
-			}, 5);
-			
+			frappe.show_alert(
+				{
+					message: __("Time block appointment has been rescheduled"),
+					indicator: "green",
+				},
+				5,
+			);
+
 			// Ensure document is reloaded to reflect changes
 			frm.reload_doc();
 		}
-		
+
 		frm.off("after_save", after_save_handler);
 	};
-	
+
 	frm.on("after_save", after_save_handler);
 };

--- a/healthcare/healthcare/doctype/patient_appointment/patient_appointment.json
+++ b/healthcare/healthcare/doctype/patient_appointment/patient_appointment.json
@@ -82,8 +82,8 @@
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Patient",
+   "mandatory_depends_on": "eval:doc.appointment_type !== 'Unavailable'",
    "options": "Patient",
-   "reqd": 1,
    "search_index": 1,
    "set_only_once": 1
   },

--- a/healthcare/healthcare/doctype/patient_appointment/patient_appointment.py
+++ b/healthcare/healthcare/doctype/patient_appointment/patient_appointment.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2015, ESS LLP and contributors
 # For license information, please see license.txt
 
@@ -11,7 +10,16 @@ from frappe import _
 from frappe.core.doctype.sms_settings.sms_settings import send_sms
 from frappe.model.document import Document
 from frappe.model.mapper import get_mapped_doc
-from frappe.utils import add_to_date, flt, format_date, get_datetime, get_link_to_form, get_time, getdate, today
+from frappe.utils import (
+	add_to_date,
+	flt,
+	format_date,
+	get_datetime,
+	get_link_to_form,
+	get_time,
+	getdate,
+	today,
+)
 
 from erpnext.setup.doctype.employee.employee import is_holiday
 
@@ -43,16 +51,16 @@ class PatientAppointment(Document):
 	def validate(self):
 		# Skip certain validations for unavailability appointments
 		self.is_unavailability = self.appointment_type == "Unavailable"
-		
+
 		# Always ensure duration is set first
 		self.ensure_duration_is_set()
-		
+
 		# Set appointment datetime and end time
 		self.set_appointment_datetime()
-		
+
 		# Validate overlaps for all appointments
 		self.validate_overlaps()
-		
+
 		# Skip all patient-related validations for unavailability appointments
 		if not self.is_unavailability:
 			self.validate_based_on_appointments_for()
@@ -62,21 +70,23 @@ class PatientAppointment(Document):
 			# For unavailability appointments, make sure the status remains "Unavailable"
 			if self.status != "Cancelled" and self.status != "Unavailable":
 				self.status = "Unavailable"
-		
+			# Auto-generate patient_name if not already set
+			if not self.patient_name:
+				self.set_unavailability_patient_name()
+
 		# Service unit validation applies to all appointments
 		self.validate_service_unit()
-		
+
 		# Set status and title
 		self.set_status()
 		self.set_title()
 		self.update_event()
 		self.set_position_in_queue()
 
-
 	def before_save(self):
 		# Always ensure duration is set
 		self.ensure_duration_is_set()
-		
+
 		# Calculate appointment end time
 		self.set_appointment_datetime()
 
@@ -84,7 +94,7 @@ class PatientAppointment(Document):
 		# Skip fee validity updates for unavailability appointments
 		if self.is_unavailability:
 			return
-			
+
 		if (
 			not frappe.db.get_single_value("Healthcare Settings", "show_payment_popup")
 			or not self.practitioner
@@ -109,7 +119,7 @@ class PatientAppointment(Document):
 			self.insert_calendar_event()
 			# Send confirmation only for normal appointments
 			send_confirmation_msg(self)
-		
+
 		self.update_prescription_details()
 		self.set_payment_details()
 
@@ -203,13 +213,11 @@ class PatientAppointment(Document):
 				return
 
 			# Get start time as datetime
-			starts_on = datetime.combine(
-				getdate(self.appointment_date), get_time(self.appointment_time)
-			)
-			
+			starts_on = datetime.combine(getdate(self.appointment_date), get_time(self.appointment_time))
+
 			# For debugging
 			print(f"DEBUG - Appointment start time: {self.appointment_time}")
-			
+
 			# IMPORTANT FIX: Always use appointment_end_time if available, regardless of duration
 			# This prevents the default 60 min duration from the appointment type from overriding
 			if self.appointment_end_time:
@@ -224,16 +232,18 @@ class PatientAppointment(Document):
 
 			# Ensure duration is correct based on start and end times
 			duration_minutes = (ends_on - starts_on).total_seconds() / 60
-			
+
 			# Force the duration to match the time difference regardless of the appointment type's default
 			if abs(duration_minutes - flt(self.duration)) > 1:  # Allow 1 minute tolerance for rounding
 				print(f"DEBUG - Duration mismatch! Stored: {self.duration}, Calculated: {duration_minutes}")
 				# Update the duration to match the actual time difference
 				self.db_set("duration", duration_minutes)
-			
+
 			# Debug output
-			print(f"DEBUG - Creating event from {starts_on} to {ends_on}. Duration: {duration_minutes} minutes")
-			
+			print(
+				f"DEBUG - Creating event from {starts_on} to {ends_on}. Duration: {duration_minutes} minutes"
+			)
+
 			# Use the default calendar
 			google_calendar = None
 			if self.practitioner:
@@ -250,7 +260,7 @@ class PatientAppointment(Document):
 			start_time_str = starts_on.strftime("%H:%M")
 			end_time_str = ends_on.strftime("%H:%M")
 			time_range = f"{start_time_str} - {end_time_str}"
-			
+
 			if self.practitioner:
 				subject = f"UNAVAILABLE: {self.practitioner_name} ({time_range})"
 			elif self.service_unit:
@@ -266,7 +276,7 @@ class PatientAppointment(Document):
 			# IMPORTANT: Store the calculated end time before creating the event
 			# This ensures we have it even if event creation somehow overrides it
 			calculated_end_time = ends_on
-			
+
 			event = frappe.get_doc(
 				{
 					"doctype": "Event",
@@ -284,7 +294,7 @@ class PatientAppointment(Document):
 					"pulled_from_google_calendar": 0,
 				}
 			)
-			
+
 			# Add participants
 			participants = []
 			if self.practitioner:
@@ -299,47 +309,49 @@ class PatientAppointment(Document):
 			event.flags.ignore_validate = True
 			event.flags.ignore_mandatory = True
 			event.insert(ignore_permissions=True)
-			
+
 			# CRITICAL FIX: After event is created, force-set the correct end time in the database
 			# This bypasses any automatic duration calculations from appointment type
 			frappe.db.set_value("Event", event.name, "ends_on", calculated_end_time)
-			
+
 			# Ensure the event document was created properly by reloading it
 			event.reload()
 			print(f"DEBUG - Event created with starts_on: {event.starts_on} and ends_on: {event.ends_on}")
-			
+
 			# Double-check the event duration to make sure it's correct
 			event_duration = (event.ends_on - event.starts_on).total_seconds() / 60
 			print(f"DEBUG - Event duration: {event_duration} minutes")
-			
+
 			# If the event duration still doesn't match our expected duration, fix it again
 			if abs(event_duration - duration_minutes) > 1:  # Allow 1 minute tolerance for rounding
 				print(f"DEBUG - Event duration mismatch! Expected: {duration_minutes}, Got: {event_duration}")
 				# Try one more direct update to the event end time in the database
 				frappe.db.set_value("Event", event.name, "ends_on", calculated_end_time)
 				print(f"DEBUG - Fixed event end time again to {calculated_end_time}")
-				
+
 				# Verify the fix worked
 				event.reload()
 				final_duration = (event.ends_on - event.starts_on).total_seconds() / 60
 				print(f"DEBUG - Final event duration after fix: {final_duration} minutes")
-			
+
 			# Link the event to the appointment and ensure we store the end time
 			update_values = {"event": event.name}
-			
+
 			if not self.appointment_end_time:
 				end_time_str = ends_on.time().strftime("%H:%M:%S")
-				update_values.update({
-					"appointment_end_time": end_time_str,
-					"appointment_end_datetime": ends_on.strftime("%Y-%m-%d %H:%M:%S")
-				})
+				update_values.update(
+					{
+						"appointment_end_time": end_time_str,
+						"appointment_end_datetime": ends_on.strftime("%Y-%m-%d %H:%M:%S"),
+					}
+				)
 				print(f"DEBUG - Updated appointment with end_time: {end_time_str}")
-			
+
 			self.db_set(update_values)
 			self.notify_update()
-			
+
 		except Exception as e:
-			error_msg = f"Error creating calendar event: {str(e)}\n{frappe.get_traceback()}"
+			error_msg = f"Error creating calendar event: {e!s}\n{frappe.get_traceback()}"
 			print(f"ERROR - {error_msg}")
 			frappe.log_error(error_msg, "Unavailability Calendar Event Error")
 
@@ -352,19 +364,15 @@ class PatientAppointment(Document):
 		if not self.appointment_time:
 			return
 
-		starts_on = datetime.combine(
-			getdate(self.appointment_date), get_time(self.appointment_time)
-		)
-		
+		starts_on = datetime.combine(getdate(self.appointment_date), get_time(self.appointment_time))
+
 		# Use end_time if available, otherwise calculate based on duration
 		if self.end_time:
 			ends_on = datetime.combine(getdate(self.appointment_date), get_time(self.end_time))
 		else:
 			ends_on = starts_on + timedelta(minutes=flt(self.duration))
-			
-		google_calendar = frappe.db.get_value(
-			"Healthcare Practitioner", self.practitioner, "google_calendar"
-		)
+
+		google_calendar = frappe.db.get_value("Healthcare Practitioner", self.practitioner, "google_calendar")
 		if not google_calendar:
 			google_calendar = frappe.db.get_single_value("Healthcare Settings", "default_google_calendar")
 
@@ -396,14 +404,14 @@ class PatientAppointment(Document):
 		participants.append(
 			{"reference_doctype": "Healthcare Practitioner", "reference_docname": self.practitioner}
 		)
-		
+
 		if self.patient:
 			participants.append({"reference_doctype": "Patient", "reference_docname": self.patient})
 
 		event.update({"event_participants": participants})
 
 		event.insert(ignore_permissions=True)
-		
+
 		# Link the event to the appointment
 		self.db_set("event", event.name)
 
@@ -414,19 +422,33 @@ class PatientAppointment(Document):
 				indicator="error",
 				alert=True,
 			)
-		
+
 		self.db_set("google_meet_link", event.google_meet_link)
 		self.notify_update()
 
 		if self.service_request:
-			frappe.db.set_value(
-				"Service Request", self.service_request, "status", "completed-Request Status"
-			)
+			frappe.db.set_value("Service Request", self.service_request, "status", "completed-Request Status")
 
 		if self.service_request:
-			frappe.db.set_value(
-				"Service Request", self.service_request, "status", "completed-Request Status"
-			)
+			frappe.db.set_value("Service Request", self.service_request, "status", "completed-Request Status")
+
+	def set_unavailability_patient_name(self):
+		"""Auto-generate patient_name for unavailability appointments when no patient is set."""
+		time_range = ""
+		if self.appointment_time:
+			from_time_str = str(self.appointment_time)[:5]
+			if self.end_time:
+				to_time_str = str(self.end_time)[:5]
+				time_range = f" ({from_time_str} to {to_time_str})"
+			else:
+				time_range = f" ({from_time_str})"
+
+		if self.practitioner_name or self.practitioner:
+			self.patient_name = f"UNAVAILABLE: {self.practitioner_name or self.practitioner}{time_range}"
+		elif self.service_unit:
+			self.patient_name = f"UNAVAILABLE: {self.service_unit}{time_range}"
+		else:
+			self.patient_name = f"UNAVAILABLE{time_range}"
 
 	def set_title(self):
 		if self.is_unavailability:
@@ -442,7 +464,7 @@ class PatientAppointment(Document):
 			)
 
 	def set_status(self):
-		today = getdate()
+		today_date = getdate()
 		appointment_date = getdate(self.appointment_date)
 
 		# If this is an unavailability appointment, always keep it as "Unavailable"
@@ -450,38 +472,41 @@ class PatientAppointment(Document):
 			if self.status != "Cancelled" and self.status != "Unavailable" and self.status != "Closed":
 				self.status = "Unavailable"
 			return
-		
+
 		# For new appointments, set default status based on date
 		if self.is_new():
-			if appointment_date == today:
+			if appointment_date == today_date:
 				self.status = "Confirmed"
-			elif appointment_date > today:
+			elif appointment_date > today_date:
 				self.status = "Scheduled"
 			else:
 				self.status = "No Show"
 			return
-			
+
 		# If appointment is already marked as "Needs Rescheduling", we should check if it has been rescheduled
-		if self.status == "Needs Rescheduling" and self.status != "Cancelled" and self.status != 'Closed':
+		if self.status == "Needs Rescheduling" and self.status != "Cancelled" and self.status != "Closed":
 			# If this has been modified and saved, it means the appointment was rescheduled
 			if self.modified != self.creation:
-				if appointment_date > today:
+				if appointment_date > today_date:
 					self.status = "Scheduled"
-				elif appointment_date == today:
+				elif appointment_date == today_date:
 					self.status = "Confirmed"
 				return
 			return
 		old_doc = self.get_doc_before_save()
 
 		# If appointment is created for today set status as Open else Scheduled
-		if appointment_date == today:
-			if self.status not in ["Checked In", "Checked Out" , "Confirmed", "Cancelled", "Closed"]:
+		if appointment_date == today_date:
+			if self.status not in ["Checked In", "Checked Out", "Confirmed", "Cancelled", "Closed"]:
 				self.status = "Confirmed"
-		elif (appointment_date > today and self.status not in ["Cancelled", "Closed"] and 
-			str(old_doc.appointment_datetime) != str(self.appointment_datetime)):
+		elif (
+			appointment_date > today_date
+			and self.status not in ["Cancelled", "Closed"]
+			and str(old_doc.appointment_datetime) != str(self.appointment_datetime)
+		):
 			self.status = "Scheduled"
 
-		elif appointment_date < today and self.status not in ["No Show", "Cancelled", "Closed"]:
+		elif appointment_date < today_date and self.status not in ["No Show", "Cancelled", "Closed"]:
 			self.status = "No Show"
 
 	def validate_overlaps(self):
@@ -510,9 +535,7 @@ class PatientAppointment(Document):
 		# Calculate end time based on duration or directly from end_time field
 		if self.end_time:
 			# Use the end_time directly if it's set
-			end_time = datetime.combine(
-				getdate(self.appointment_date), get_time(self.end_time)
-			)
+			end_time = datetime.combine(getdate(self.appointment_date), get_time(self.end_time))
 		else:
 			# Otherwise calculate from duration
 			end_time = datetime.combine(
@@ -529,14 +552,14 @@ class PatientAppointment(Document):
 				"appointment_type": "Unavailable",
 				"practitioner": self.practitioner,
 			},
-			fields=["name", "appointment_time", "duration", "end_time"]
+			fields=["name", "appointment_time", "duration", "end_time"],
 		)
-		
+
 		for existing in unavailable_appointments:
 			if not self.status == "Unavailable":  # Only regular appointments need to avoid unavailable slots
 				# Get existing appointment time boundaries
 				existing_start_time = get_time(existing.appointment_time)
-				
+
 				# Calculate or get end time
 				if existing.end_time:
 					existing_end_time = get_time(existing.end_time)
@@ -544,36 +567,35 @@ class PatientAppointment(Document):
 					existing_start_dt = datetime.combine(getdate(self.appointment_date), existing_start_time)
 					existing_end_dt = existing_start_dt + timedelta(minutes=flt(existing.duration or 0))
 					existing_end_time = existing_end_dt.time()
-				
+
 				# Get current appointment time boundaries
 				current_start_time = get_time(self.appointment_time)
 				current_end_time = end_time.time()
-				
+
 				# Check for overlap conditions
 				overlap = False
-				
+
 				# Condition 1: Current appointment starts during existing appointment
-				if (existing_start_time <= current_start_time < existing_end_time):
+				if existing_start_time <= current_start_time < existing_end_time:
 					overlap = True
-				
+
 				# Condition 2: Current appointment ends during existing appointment
-				elif (existing_start_time < current_end_time <= existing_end_time):
+				elif existing_start_time < current_end_time <= existing_end_time:
 					overlap = True
-				
+
 				# Condition 3: Current appointment contains existing appointment
-				elif (current_start_time <= existing_start_time and current_end_time >= existing_end_time):
+				elif current_start_time <= existing_start_time and current_end_time >= existing_end_time:
 					overlap = True
-				
+
 				# Condition 4: Start times are exactly the same
-				elif (current_start_time == existing_start_time):
+				elif current_start_time == existing_start_time:
 					overlap = True
-				
+
 				if overlap:
 					frappe.throw(
-						_("The practitioner {0} is already marked as unavailable during this time (see appointment {1})").format(
-							frappe.bold(self.practitioner),
-							frappe.bold(existing.name)
-						),
+						_(
+							"The practitioner {0} is already marked as unavailable during this time (see appointment {1})"
+						).format(frappe.bold(self.practitioner), frappe.bold(existing.name)),
 						OverlapError,
 					)
 
@@ -650,7 +672,7 @@ class PatientAppointment(Document):
 				"practitioner": self.practitioner,
 				"patient": self.patient,
 				"appointment_time": self.appointment_time,
-				"end_time": end_time.time().strftime("%H:%M:%S")
+				"end_time": end_time.time().strftime("%H:%M:%S"),
 			},
 			as_dict=True,
 		)
@@ -659,23 +681,31 @@ class PatientAppointment(Document):
 			return  # No overlaps, nothing to validate!
 
 		# Check for unavailable appointments specifically
-		unavailable_appointments = [appt for appt in overlapping_appointments 
-									if appt.status == "Unavailable" and appt.appointment_type == "Unavailable"
-									and appt.practitioner == self.practitioner]
-		
+		unavailable_appointments = [
+			appt
+			for appt in overlapping_appointments
+			if appt.status == "Unavailable"
+			and appt.appointment_type == "Unavailable"
+			and appt.practitioner == self.practitioner
+		]
+
 		if unavailable_appointments and self.appointment_type != "Unavailable":
 			# This is a regular appointment overlapping with an unavailability period
 			frappe.throw(
-				_("The practitioner {0} is not available during this time due to an unavailability record {1}").format(
-					frappe.bold(self.practitioner), 
-					frappe.bold(", ".join([appointment["name"] for appointment in unavailable_appointments]))
+				_(
+					"The practitioner {0} is not available during this time due to an unavailability record {1}"
+				).format(
+					frappe.bold(self.practitioner),
+					frappe.bold(", ".join([appointment["name"] for appointment in unavailable_appointments])),
 				),
 				OverlapError,
 			)
 
 		if self.service_unit:  # validate service unit capacity if overlap enabled
 			allow_overlap, service_unit_capacity = frappe.get_value(
-				"Healthcare Service Unit", self.service_unit, ["overlap_appointments", "service_unit_capacity"]
+				"Healthcare Service Unit",
+				self.service_unit,
+				["overlap_appointments", "service_unit_capacity"],
 			)
 			if allow_overlap:
 				service_unit_appointments = list(
@@ -772,26 +802,26 @@ class PatientAppointment(Document):
 
 	def set_appointment_datetime(self):
 		"""Set appointment_datetime field based on appointment date and time."""
-		self.appointment_datetime = "%s %s" % (self.appointment_date, self.appointment_time or "00:00:00")
-		
+		self.appointment_datetime = f"{self.appointment_date} {self.appointment_time or '00:00:00'}"
+
 		# Set the end time based on duration or use existing end_time
 		if self.end_time:
 			# If end_time is already set, use it and ensure other fields are consistent
 			end_time_str = self.end_time
 			if isinstance(self.end_time, datetime):
 				end_time_str = self.end_time.strftime("%H:%M:%S")
-			
+
 			# Make sure appointment_end_time is also set
 			self.appointment_end_time = end_time_str
-			
+
 			# Set appointment_end_datetime
-			self.appointment_end_datetime = "%s %s" % (self.appointment_date, end_time_str)
-			
+			self.appointment_end_datetime = f"{self.appointment_date} {end_time_str}"
+
 			# Calculate and update duration based on end_time for consistency
 			if self.appointment_time:
 				start_time = get_time(self.appointment_time)
 				end_time = get_time(end_time_str)
-				
+
 				if end_time > start_time:
 					start_dt = datetime.combine(getdate(), start_time)
 					end_dt = datetime.combine(getdate(), end_time)
@@ -801,12 +831,12 @@ class PatientAppointment(Document):
 			start_time = get_time(self.appointment_time)
 			end_time = add_to_date(datetime.combine(getdate(), start_time), minutes=self.duration)
 			end_time_str = end_time.time().strftime("%H:%M:%S")
-			
+
 			# Set both appointment_end_time and end_time
 			self.appointment_end_time = end_time_str
 			self.end_time = end_time_str
-			
-			self.appointment_end_datetime = "%s %s" % (self.appointment_date, end_time_str)
+
+			self.appointment_end_datetime = f"{self.appointment_date} {end_time_str}"
 
 	def set_payment_details(self):
 		if frappe.db.get_single_value("Healthcare Settings", "show_payment_popup"):
@@ -819,7 +849,7 @@ class PatientAppointment(Document):
 		if frappe.db.get_single_value("Healthcare Settings", "show_payment_popup"):
 			if not frappe.db.get_value("Patient", self.patient, "customer"):
 				msg = _("Please set a Customer linked to the Patient")
-				msg += " <b><a href='/app/Form/Patient/{0}'>{0}</a></b>".format(self.patient)
+				msg += f" <b><a href='/app/Form/Patient/{self.patient}'>{self.patient}</a></b>"
 				frappe.throw(msg, title=_("Customer Not Found"))
 
 	def update_prescription_details(self):
@@ -837,9 +867,7 @@ class PatientAppointment(Document):
 	def update_event(self):
 		if self.event and self.appointment_time:
 			event_doc = frappe.get_doc("Event", self.event)
-			starts_on = datetime.combine(
-				getdate(self.appointment_date), get_time(self.appointment_time)
-			)
+			starts_on = datetime.combine(getdate(self.appointment_date), get_time(self.appointment_time))
 			ends_on = starts_on + timedelta(minutes=flt(self.duration))
 			if (
 				starts_on != event_doc.starts_on
@@ -887,28 +915,28 @@ class PatientAppointment(Document):
 
 	def ensure_duration_is_set(self):
 		"""Ensure that appointment duration is properly set based on appointment type or slot"""
-		
+
 		# First check if we have both appointment_time and end_time set - this takes highest priority
 		if self.appointment_time and self.end_time:
 			start_time = get_time(self.appointment_time)
 			end_time = get_time(self.end_time)
-			
+
 			# Ensure end time is after start time
 			if end_time > start_time:
 				start_dt = datetime.combine(getdate(), start_time)
 				end_dt = datetime.combine(getdate(), end_time)
 				duration_minutes = (end_dt - start_dt).total_seconds() / 60
-				
+
 				# Set the duration based on the time difference
 				self.duration = duration_minutes
 				print(f"Set duration to {duration_minutes} minutes based on end_time")
 				return
-			
+
 		# If a duration is already set, respect it
 		if self.duration:
 			print(f"Using existing duration: {self.duration} minutes")
 			return
-			
+
 		# Next try to get duration from schedule slot if it's available
 		if self.practitioner and self.appointment_date and self.appointment_time:
 			# Get the practitioner's schedule
@@ -917,44 +945,50 @@ class PatientAppointment(Document):
 				appointment_date = getdate(self.appointment_date)
 				weekday = appointment_date.strftime("%A")
 				appointment_time = get_time(self.appointment_time)
-				
+
 				# Look through all schedules and find the matching slot
 				for schedule_entry in practitioner_doc.practitioner_schedules:
 					if schedule_entry.schedule:
 						try:
 							schedule_doc = frappe.get_doc("Practitioner Schedule", schedule_entry.schedule)
-							
+
 							for time_slot in schedule_doc.time_slots:
 								if time_slot.day == weekday:
 									slot_start = get_time(time_slot.from_time)
 									slot_end = get_time(time_slot.to_time)
-									
+
 									# Check if appointment time matches this slot
 									if slot_start <= appointment_time < slot_end:
 										# Calculate slot duration in minutes
 										slot_start_dt = datetime.combine(appointment_date, slot_start)
 										slot_end_dt = datetime.combine(appointment_date, slot_end)
 										slot_duration = (slot_end_dt - slot_start_dt).total_seconds() / 60
-										
+
 										# Use this slot's duration
 										self.duration = slot_duration
-										print(f"Set duration to {slot_duration} minutes based on practitioner schedule slot")
+										print(
+											f"Set duration to {slot_duration} minutes based on practitioner schedule slot"
+										)
 										return
 						except Exception as e:
-							print(f"Error getting schedule: {str(e)}")
+							print(f"Error getting schedule: {e!s}")
 							continue
-		
+
 		# If no schedule slot found, get duration from appointment type
 		if self.appointment_type:
-			default_duration = frappe.db.get_value("Appointment Type", self.appointment_type, "default_duration")
+			default_duration = frappe.db.get_value(
+				"Appointment Type", self.appointment_type, "default_duration"
+			)
 			if default_duration:
 				self.duration = default_duration
-				print(f"Set duration to {default_duration} minutes based on appointment type {self.appointment_type}")
+				print(
+					f"Set duration to {default_duration} minutes based on appointment type {self.appointment_type}"
+				)
 				return
-		
+
 		# If all else fails, set a default duration
 		self.duration = 15
-		print(f"Set default duration to 15 minutes as no other duration source was found")
+		print("Set default duration to 15 minutes as no other duration source was found")
 
 	@frappe.whitelist()
 	def get_therapy_types(self):
@@ -963,12 +997,12 @@ class PatientAppointment(Document):
 
 		therapy_types = []
 		therapy_plan_doc = frappe.get_doc("Therapy Plan", self.therapy_plan)
-		if(therapy_plan_doc.status == "Completed"):
+		if therapy_plan_doc.status == "Completed":
 			return "Completed"
 		for entry in therapy_plan_doc.therapy_plan_details:
 			therapy_type_name = entry.therapy_type
 			therapy_type_doc = frappe.get_doc("Therapy Type", therapy_type_name)
-			
+
 			# Check if this therapy type is already in the appointment's therapy_types table
 			already_added = False
 			if self.therapy_types:
@@ -976,22 +1010,25 @@ class PatientAppointment(Document):
 					if t.therapy_type == therapy_type_name:
 						already_added = True
 						break
-						
+
 			# If not already added, add it to the return list
 			if not already_added:
-				therapy_types.append({
-					"therapy_type": therapy_type_name,
-					"therapy_name": therapy_type_doc.therapy_type,  # The display name
-					"duration": therapy_type_doc.default_duration or 45,
-					"no_of_sessions" : entry.no_of_sessions
-				})
-		
+				therapy_types.append(
+					{
+						"therapy_type": therapy_type_name,
+						"therapy_name": therapy_type_doc.therapy_type,  # The display name
+						"duration": therapy_type_doc.default_duration or 45,
+						"no_of_sessions": entry.no_of_sessions,
+					}
+				)
+
 		return therapy_types
-	
+
 	@frappe.whitelist()
-	def get_service_unit_values(self,selected_practitioner):
-		query=frappe.db.sql(
-			"Select service_unit from `tabPractitioner Service Unit Schedule` where parent='{0}'".format(selected_practitioner),as_dict=1
+	def get_service_unit_values(self, selected_practitioner):
+		query = frappe.db.sql(
+			f"Select service_unit from `tabPractitioner Service Unit Schedule` where parent='{selected_practitioner}'",
+			as_dict=1,
 		)
 
 		return [item.service_unit for item in query]
@@ -1138,9 +1175,7 @@ def cancel_appointment(appointment_id):
 		coverage.cancel()
 
 	if appointment.service_request:
-		frappe.db.set_value(
-			"Service Request", appointment.service_request, "status", "active-Request Status"
-		)
+		frappe.db.set_value("Service Request", appointment.service_request, "status", "active-Request Status")
 
 	if appointment.invoiced:
 		sales_invoice = check_sales_invoice_exists(appointment)
@@ -1161,7 +1196,9 @@ def cancel_appointment(appointment_id):
 		fee_validity = manage_fee_validity(appointment)
 		msg = _("Appointment Cancelled.")
 		if fee_validity:
-			msg += _(" <b>{0}</b> updated.").format(get_link_to_form("Fee Validity",fee_validity.name, "Fee Validity"))
+			msg += _(" <b>{0}</b> updated.").format(
+				get_link_to_form("Fee Validity", fee_validity.name, "Fee Validity")
+			)
 
 	if appointment.event:
 		event_doc = frappe.get_doc("Event", appointment.event)
@@ -1254,7 +1291,7 @@ def check_employee_wise_availability(date, practitioner_doc):
 	if employee:
 		# check holiday
 		if is_holiday(employee, date):
-			frappe.throw(_("{0} is a holiday".format(date)), title=_("Not Available"))
+			frappe.throw(_(f"{date} is a holiday"), title=_("Not Available"))
 
 		# check leave status
 		if "hrms" in frappe.get_installed_apps():
@@ -1273,7 +1310,8 @@ def check_employee_wise_availability(date, practitioner_doc):
 					)
 				else:
 					frappe.throw(
-						_("{0} is on Leave on {1}").format(practitioner_doc.name, date), title=_("Not Available")
+						_("{0} is on Leave on {1}").format(practitioner_doc.name, date),
+						title=_("Not Available"),
 					)
 
 
@@ -1323,10 +1361,17 @@ def get_available_slots(practitioner_doc, date):
 				appointments = frappe.get_all(
 					"Patient Appointment",
 					filters=filters,
-					fields=["name", "appointment_time", "duration", "status", 
-					        "appointment_date", "appointment_type", "end_time"],
+					fields=[
+						"name",
+						"appointment_time",
+						"duration",
+						"status",
+						"appointment_date",
+						"appointment_type",
+						"end_time",
+					],
 				)
-				
+
 				# Now also fetch any unavailability appointments for this practitioner
 				# This is critical - we need to ensure unavailable time slots are not shown as available
 				unavailable_appointments = frappe.get_all(
@@ -1335,12 +1380,19 @@ def get_available_slots(practitioner_doc, date):
 						"practitioner": practitioner,
 						"appointment_date": date,
 						"status": "Unavailable",
-						"appointment_type": "Unavailable"
+						"appointment_type": "Unavailable",
 					},
-					fields=["name", "appointment_time", "duration", "status", 
-					        "appointment_date", "appointment_type", "end_time"]
+					fields=[
+						"name",
+						"appointment_time",
+						"duration",
+						"status",
+						"appointment_date",
+						"appointment_type",
+						"end_time",
+					],
 				)
-				
+
 				# Also get any block-based appointments that might overlap this practitioner's slots
 				block_appointments = frappe.get_all(
 					"Patient Appointment",
@@ -1348,16 +1400,23 @@ def get_available_slots(practitioner_doc, date):
 						"practitioner": practitioner,
 						"appointment_date": date,
 						"status": ["not in", ["Cancelled"]],
-						"end_time": ["is", "set"]
+						"end_time": ["is", "set"],
 					},
-					fields=["name", "appointment_time", "duration", "status", 
-					        "appointment_date", "appointment_type", "end_time"]
+					fields=[
+						"name",
+						"appointment_time",
+						"duration",
+						"status",
+						"appointment_date",
+						"appointment_type",
+						"end_time",
+					],
 				)
-				
+
 				# Combine with regular appointments - include all types of appointments
 				# that could affect slot availability
 				appointments.extend(unavailable_appointments)
-				
+
 				# Add block appointments that aren't already in the list
 				existing_names = [app.name for app in appointments]
 				for block_app in block_appointments:
@@ -1404,7 +1463,7 @@ def validate_practitioner_schedules(schedule_entry, practitioner):
 def update_status(appointment_id, status):
 	appointment_doc = frappe.get_doc("Patient Appointment", appointment_id)
 	appointment_doc.status = "Cancelled"
-	
+
 	# Different handling based on appointment type
 	if status == "Cancelled":
 		if appointment_doc.appointment_type == "Unavailable":
@@ -1418,7 +1477,7 @@ def update_status(appointment_id, status):
 				event_doc = frappe.get_doc("Event", appointment_doc.event)
 				event_doc.status = "Cancelled"
 				event_doc.save(ignore_permissions=True)
-			
+
 			frappe.msgprint(_("Unavailability record cancelled successfully"), alert=True)
 			return
 		else:
@@ -1511,7 +1570,7 @@ def send_message(doc, message):
 		number = [patient_mobile]
 		try:
 			send_sms(number, message)
-		except Exception as e:
+		except Exception:
 			frappe.msgprint(_("SMS not sent, please check SMS Settings"), alert=True)
 
 
@@ -1533,7 +1592,7 @@ def get_events(start, end, filters=None):
 		conditions += "and" + match_conditions
 
 	data = frappe.db.sql(
-		"""
+		f"""
 		select
 		`tabPatient Appointment`.name, `tabPatient Appointment`.patient,
 		`tabPatient Appointment`.practitioner, `tabPatient Appointment`.practitioner_name,
@@ -1547,9 +1606,7 @@ def get_events(start, end, filters=None):
 		left join `tabAppointment Type` on `tabPatient Appointment`.appointment_type=`tabAppointment Type`.name
 		where
 		(`tabPatient Appointment`.appointment_date between %(start)s and %(end)s)
-		and `tabPatient Appointment`.status != 'Cancelled' and `tabPatient Appointment`.docstatus < 2 {conditions}""".format(
-			conditions=conditions
-		),
+		and `tabPatient Appointment`.status != 'Cancelled' and `tabPatient Appointment`.docstatus < 2 {conditions}""",
 		{"start": start, "end": end},
 		as_dict=True,
 		update={"allDay": 0},
@@ -1557,15 +1614,15 @@ def get_events(start, end, filters=None):
 
 	for item in data:
 		item.end = item.start + timedelta(minutes=item.duration)
-		
+
 		# Special handling for unavailability appointments
 		if item.appointment_type == "Unavailable":
 			# Force color to be red for unavailability
 			item.color = "#ff5858"
-			
+
 			# Set a special patient value for the calendar view to identify these
 			item.patient = "UNAVAILABLE-BLOCK"
-			
+
 			# Ensure title is set to "Unavailable" if patient_name is null
 			if not item.patient_name:
 				item.patient_name = "UNAVAILABLE"
@@ -1595,13 +1652,13 @@ def get_procedure_prescribed(patient):
 # def get_prescribed_therapies(patient, therapy_plan):
 # 	therapy_plan_details = frappe.db.sql(
 # 		f"""
-# 		SELECT 
+# 		SELECT
 # 			tpd.therapy_type, tpd.no_of_sessions, tpd.sessions_completed, tpd.custom_default_duration
-# 		FROM 
+# 		FROM
 # 			`tabTherapy Plan Detail`  tpd
-# 		Left Join 
+# 		Left Join
 # 			`tabTherapy Plan` tp ON tp.name = tpd.parent
-# 		Where 
+# 		Where
 # 			tpd.parent = '{therapy_plan}' and
 # 			tp.patient = '{patient}'
 # 		""", as_dict=1
@@ -1613,17 +1670,18 @@ def get_procedure_prescribed(patient):
 def create_therapy_sessions(appointment, therapy_types):
 	"""
 	Create Therapy Sessions from a Patient Appointment
-	
+
 	:param appointment: Name of the Patient Appointment
 	:param therapy_types: List of Therapy Types to create sessions for
 	:returns: List of created Therapy Sessions
 	"""
 	if isinstance(therapy_types, str):
 		therapy_types = json.loads(therapy_types)
-		
+
 	appointment_doc = frappe.get_doc("Patient Appointment", appointment)
 	created_sessions = []
 	duration = 0
+	end_time = None
 	for idx, therapy_type in enumerate(therapy_types):
 		therapy_type = frappe._dict(therapy_type)
 		# Skip if session already created
@@ -1643,28 +1701,32 @@ def create_therapy_sessions(appointment, therapy_types):
 		therapy_session.start_time = appointment_doc.appointment_time if idx == 0 else end_time
 		therapy_session.service_unit = appointment_doc.service_unit
 		therapy_session.start_date = appointment_doc.appointment_date
-		
+
 		# Set end time based on duration
 		if appointment_doc.appointment_time:
-			appointment_time = datetime.combine(
-				getdate(appointment_doc.appointment_date),
-				datetime.strptime(str(appointment_doc.appointment_time), '%H:%M:%S').time()
-			) if idx == 0 else datetime.combine(
-				getdate(appointment_doc.appointment_date),
-				datetime.strptime(str(end_time), '%H:%M:%S').time()
+			appointment_time = (
+				datetime.combine(
+					getdate(appointment_doc.appointment_date),
+					datetime.strptime(str(appointment_doc.appointment_time), "%H:%M:%S").time(),
+				)
+				if idx == 0
+				else datetime.combine(
+					getdate(appointment_doc.appointment_date),
+					datetime.strptime(str(end_time), "%H:%M:%S").time(),
+				)
 			)
 			appointment_time += timedelta(minutes=therapy_type.duration or duration or 20)
-			therapy_session.end_time = appointment_time.strftime('%H:%M:%S')
+			therapy_session.end_time = appointment_time.strftime("%H:%M:%S")
 			duration = therapy_type.duration or duration or 20
-			end_time = appointment_time.strftime('%H:%M:%S')
-		
+			end_time = appointment_time.strftime("%H:%M:%S")
+
 		therapy_session.save()
-		
+
 		# Update the therapy in the appointment
 		frappe.db.set_value(therapy_type.doctype, therapy_type.name, "session_created", 1)
 		frappe.db.set_value(therapy_type.doctype, therapy_type.name, "therapy_session", therapy_session.name)
 		created_sessions.append(therapy_session.name)
-		
+
 	if not created_sessions:
 		frappe.msgprint("Therapy Sessions are already exists")
 	return created_sessions
@@ -1672,61 +1734,68 @@ def create_therapy_sessions(appointment, therapy_types):
 
 def update_appointment_status():
 	def set_status(appointment_doc):
-		today = getdate()
+		today_date = getdate()
 		appointment_date = getdate(appointment_doc.appointment_date)
 
 		# If this is an unavailability appointment, always keep it as "Unavailable"
 		if appointment_doc.appointment_type == "Unavailable":
 			if appointment_doc.status != "Cancelled" and appointment_doc.status != "Unavailable":
-				return"Unavailable"
+				return "Unavailable"
 			return
-		
+
 		# For new appointments, set default status based on date
 		if appointment_doc.is_new():
-			if appointment_date == today:
+			if appointment_date == today_date:
 				return "Confirmed"
-			elif appointment_date > today:
+			elif appointment_date > today_date:
 				return "Scheduled"
 			else:
 				return "No Show"
-			return
-			
+
 		# If appointment is already marked as "Needs Rescheduling", we should check if it has been rescheduled
-		if appointment_doc.status == "Needs Rescheduling" and appointment_doc.status != "Cancelled" and appointment_doc.status != 'Closed':
+		if (
+			appointment_doc.status == "Needs Rescheduling"
+			and appointment_doc.status != "Cancelled"
+			and appointment_doc.status != "Closed"
+		):
 			# If this has been modified and saved, it means the appointment was rescheduled
 			if appointment_doc.modified != appointment_doc.creation:
-				if appointment_date > today:
+				if appointment_date > today_date:
 					return "Scheduled"
-				elif appointment_date == today:
+				elif appointment_date == today_date:
 					return "Confirmed"
 				return
 			return
 
 		# If appointment is created for today set status as Open else Scheduled
-		if appointment_date == today and appointment_doc.status != 'Closed':
+		if appointment_date == today_date and appointment_doc.status != "Closed":
 			return "Confirmed"
 
-		elif appointment_date > today and appointment_doc.status not in ["Scheduled", "Confirmed", "Cancelled"]:
+		elif appointment_date > today_date and appointment_doc.status not in [
+			"Scheduled",
+			"Confirmed",
+			"Cancelled",
+		]:
 			return "Scheduled"
 
-		elif appointment_date < today and appointment_doc.status not in ["No Show", "Cancelled"]:
+		elif appointment_date < today_date and appointment_doc.status not in ["No Show", "Cancelled"]:
 			return "No Show"
 
-	
 	# update the status of appointments daily
 	appointments = frappe.get_all(
-		"Patient Appointment", {"status": ("not in", ["Closed", "Cancelled", "Needs Rescheduling", "Unavailable"])}
+		"Patient Appointment",
+		{"status": ("not in", ["Closed", "Cancelled", "Needs Rescheduling", "Unavailable"])},
 	)
 
 	for appointment in appointments:
 		appointment_doc = frappe.get_doc("Patient Appointment", appointment.name)
 		status = set_status(appointment_doc)
 		if status:
-			appointment_doc.db_set("status" , status, update_modified=False)
+			appointment_doc.db_set("status", status, update_modified=False)
 
-	
 
 # Unavailability related methods
+
 
 @frappe.whitelist()
 def check_unavailability_conflicts(filters):
@@ -1736,15 +1805,15 @@ def check_unavailability_conflicts(filters):
 	"""
 	filters = frappe.parse_json(filters)
 	print(f"Check unavailability conflicts with filters: {filters}")
-	
+
 	if not filters:
 		return []
-	
+
 	# Parse date and times
 	appointment_date = getdate(filters.get("date"))
 	from_time = get_time(filters.get("from_time"))
 	to_time = get_time(filters.get("to_time"))
-	
+
 	# Create base filters
 	appointment_filters = {
 		"status": ["not in", ["Cancelled", "Needs Rescheduling", "Closed"]],
@@ -1760,30 +1829,38 @@ def check_unavailability_conflicts(filters):
 	elif filters.get("unavailability_for") == "Service Unit":
 		if filters.get("service_unit"):
 			appointment_filters["service_unit"] = filters.get("service_unit")
-	
+
 	print(f"Appointment filters: {appointment_filters}")
-	
+
 	# Get all appointments for the date
 	appointments = frappe.get_all(
 		"Patient Appointment",
 		filters=appointment_filters,
-		fields=["name", "patient", "patient_name", "appointment_time", "appointment_type", "status", "duration"]
+		fields=[
+			"name",
+			"patient",
+			"patient_name",
+			"appointment_time",
+			"appointment_type",
+			"status",
+			"duration",
+		],
 	)
-	
+
 	print(f"Found {len(appointments)} appointments on that date")
-	
+
 	# Define unavailability period
 	unavailable_start = datetime.combine(appointment_date, from_time)
 	unavailable_end = datetime.combine(appointment_date, to_time)
-	
+
 	conflicts = []
-	
+
 	# Check each appointment for time conflicts
 	for appointment in appointments:
 		# Skip appointments that are already marked as unavailable
 		# if appointment.get("appointment_type") == "Unavailable":
 		# 	continue
-		
+
 		# Get appointment time as datetime object for comparison
 		if isinstance(appointment.appointment_time, str):
 			appt_time_str = appointment.appointment_time
@@ -1802,34 +1879,36 @@ def check_unavailability_conflicts(filters):
 		else:
 			print(f"Unexpected appointment_time type: {type(appointment.appointment_time)}")
 			continue
-		
+
 		# Calculate appointment start and end datetimes
 		appt_start = datetime.combine(appointment_date, appt_time)
 		appt_end = appt_start + timedelta(minutes=appointment.duration or 15)
-		
+
 		# Check for overlap
 		# An overlap exists if:
 		# - Appointment starts during unavailability period
 		# - Appointment ends during unavailability period
 		# - Appointment spans the entire unavailability period
-		if (unavailable_start <= appt_start < unavailable_end) or \
-		   (unavailable_start < appt_end <= unavailable_end) or \
-		   (appt_start <= unavailable_start and appt_end >= unavailable_end):
-			
+		if (
+			(unavailable_start <= appt_start < unavailable_end)
+			or (unavailable_start < appt_end <= unavailable_end)
+			or (appt_start <= unavailable_start and appt_end >= unavailable_end)
+		):
 			# Format time for display
-			appointment['appointment_time'] = appt_time.strftime("%H:%M:%S")
+			appointment["appointment_time"] = appt_time.strftime("%H:%M:%S")
 			conflicts.append(appointment)
-	
+
 	return conflicts
+
 
 @frappe.whitelist()
 def get_unavailability_appointments(date=None):
 	"""
 	Get unavailability appointments for a given date
-	
+
 	Args:
 		date: Date to check (defaults to today)
-		
+
 	Returns:
 		List of unavailability appointments
 	"""
@@ -1837,44 +1916,47 @@ def get_unavailability_appointments(date=None):
 		date = getdate()
 	else:
 		date = getdate(date)
-	
+
 	return frappe.get_all(
 		"Patient Appointment",
-		filters={
-			"appointment_date": date,
-			"appointment_type": "Unavailable",
-			"status": ["!=", "Cancelled"]
-		},
+		filters={"appointment_date": date, "appointment_type": "Unavailable", "status": ["!=", "Cancelled"]},
 		fields=[
-			"name", "practitioner", "practitioner_name", "service_unit", 
-			"appointment_time", "duration", "status", "notes"
-		]
+			"name",
+			"practitioner",
+			"practitioner_name",
+			"service_unit",
+			"appointment_time",
+			"duration",
+			"status",
+			"notes",
+		],
 	)
+
 
 @frappe.whitelist()
 def cancel_unavailability_appointment(appointment_name):
 	"""
 	Cancel an unavailability appointment
-	
+
 	Args:
 		appointment_name: Name of the appointment to cancel
-		
+
 	Returns:
 		True if successful
 	"""
 	if not appointment_name:
 		frappe.throw(_("Appointment name is required"))
-	
+
 	appointment = frappe.get_doc("Patient Appointment", appointment_name)
-	
+
 	# Verify this is an unavailability appointment
 	if appointment.appointment_type != "Unavailable":
 		frappe.throw(_("This is not an unavailability appointment"))
-	
+
 	# Instead of saving the document which tries to modify set_only_once fields,
 	# directly update the status in the database
 	frappe.db.set_value("Patient Appointment", appointment_name, "status", "Cancelled")
-	
+
 	# Cancel the linked event if it exists
 	if appointment.event:
 		try:
@@ -1882,30 +1964,34 @@ def cancel_unavailability_appointment(appointment_name):
 			event_doc.status = "Cancelled"
 			event_doc.save(ignore_permissions=True)
 		except Exception as e:
-			frappe.log_error(f"Error cancelling event for unavailability appointment: {str(e)}")
-	
+			frappe.log_error(f"Error cancelling event for unavailability appointment: {e!s}")
+
 	frappe.msgprint(_("Unavailability record cancelled successfully"), alert=True)
 	return True
+
 
 def setup_appointment_type_for_unavailability():
 	"""Set up the Unavailable appointment type if it doesn't exist"""
 	if not frappe.db.exists("Appointment Type", "Unavailable"):
 		appointment_type = frappe.new_doc("Appointment Type")
-		appointment_type.update({
-			"appointment_type": "Unavailable",
-			"default_duration": 60,
-			"color": "#ff5858",
-			"price": 0,
-			"description": "System appointment type for marking unavailability"
-		})
+		appointment_type.update(
+			{
+				"appointment_type": "Unavailable",
+				"default_duration": 60,
+				"color": "#ff5858",
+				"price": 0,
+				"description": "System appointment type for marking unavailability",
+			}
+		)
 		appointment_type.insert(ignore_permissions=True)
 		frappe.db.commit()
+
 
 @frappe.whitelist()
 def create_unavailability_appointment(data):
 	"""
 	Create an appointment to mark time as unavailable
-	
+
 	Args:
 		data: A dict or JSON string containing:
 			- unavailability_for: "Practitioner" or "Service Unit"
@@ -1916,159 +2002,153 @@ def create_unavailability_appointment(data):
 			- to_time: End time
 			- reason: Reason for unavailability
 			- conflicts: List of conflicting appointments
-			
+
 	Returns:
 		Created appointment document
 	"""
 	if isinstance(data, str):
 		data = json.loads(data)
-	
+
 	# Setup Unavailable appointment type if it doesn't exist
 	setup_appointment_type_for_unavailability()
-	
+
 	# Parse date and times
-	date = getdate(data.get('date'))
-	from_time = get_time(data.get('from_time'))
-	to_time = get_time(data.get('to_time'))
-	
+	date = getdate(data.get("date"))
+	from_time = get_time(data.get("from_time"))
+	to_time = get_time(data.get("to_time"))
+
 	# Calculate duration in minutes - very important for proper calendar display
 	from_datetime = datetime.combine(date, from_time)
 	to_datetime = datetime.combine(date, to_time)
 	duration = (to_datetime - from_datetime).total_seconds() / 60
-	
+
 	print(f"Creating unavailability from {from_time} to {to_time} on {date}")
 	print(f"Calculated duration: {duration} minutes")
-	
-	# Detect if there are conflicts but don't modify them
-	has_conflicts = False
-	
-	if data.get('conflicts'):
-		conflicts = data.get('conflicts')
+
+	if data.get("conflicts"):
+		conflicts = data.get("conflicts")
 		if conflicts and isinstance(conflicts, list) and len(conflicts) > 0:
-			has_conflicts = True
 			print(f"Detected {len(conflicts)} conflicts, but not modifying them per user request")
-	
+
 	# Set the company - required field
 	# In some versions of Healthcare, practitioners might not have a company field
 	company = None
 	try:
-		if data.get('practitioner'):
+		if data.get("practitioner"):
 			# First check if the company field exists in the doctype
 			practitioner_meta = frappe.get_meta("Healthcare Practitioner")
 			if practitioner_meta.has_field("company"):
-				company = frappe.db.get_value("Healthcare Practitioner", data.get('practitioner'), "company")
+				company = frappe.db.get_value("Healthcare Practitioner", data.get("practitioner"), "company")
 	except Exception as e:
-		print(f"Error getting company from practitioner: {str(e)}")
+		print(f"Error getting company from practitioner: {e!s}")
 		company = None
-	
+
 	# If we couldn't get the company from the practitioner, use the default
 	if not company:
-		company = frappe.defaults.get_user_default('company')
-		
+		company = frappe.defaults.get_user_default("company")
+
 	# If we still don't have a company, try to get the first company in the system
 	if not company:
 		companies = frappe.get_all("Company", limit=1)
 		if companies:
 			company = companies[0].name
-			
+
 	# Create a new appointment document - now using standard Frappe approach
 	# instead of trying to directly manipulate the database
 	appointment = frappe.new_doc("Patient Appointment")
-	
+
 	# Set all the standard fields
 	appointment.naming_series = "HLC-APP-.YYYY.-"
 	appointment.appointment_type = "Unavailable"
 	appointment.status = "Unavailable"
 	appointment.company = company
-	appointment.appointment_for = data.get('unavailability_for', "Practitioner")
+	appointment.appointment_for = data.get("unavailability_for", "Practitioner")
 	appointment.appointment_date = date
 	appointment.appointment_time = str(from_time)
 	appointment.duration = duration
-	appointment.notes = data.get('reason', "Marked as unavailable")
-	
+	appointment.notes = data.get("reason", "Marked as unavailable")
+
 	# Set practitioner or service unit based on unavailability_for
-	if data.get('unavailability_for') == "Practitioner":
-		appointment.practitioner = data.get('practitioner')
-		if data.get('practitioner'):
+	if data.get("unavailability_for") == "Practitioner":
+		appointment.practitioner = data.get("practitioner")
+		if data.get("practitioner"):
 			try:
-				practitioner_name = frappe.db.get_value("Healthcare Practitioner", data.get('practitioner'), "practitioner_name")
+				practitioner_name = frappe.db.get_value(
+					"Healthcare Practitioner", data.get("practitioner"), "practitioner_name"
+				)
 				appointment.practitioner_name = practitioner_name
 			except Exception as e:
-				print(f"Error getting practitioner name: {str(e)}")
+				print(f"Error getting practitioner name: {e!s}")
 				try:
-					practitioner_doc = frappe.get_doc("Healthcare Practitioner", data.get('practitioner'))
+					practitioner_doc = frappe.get_doc("Healthcare Practitioner", data.get("practitioner"))
 					appointment.practitioner_name = practitioner_doc.practitioner_name
 				except Exception:
 					appointment.practitioner_name = "Unknown Practitioner"
-				
-	elif data.get('unavailability_for') == "Service Unit":
-		appointment.service_unit = data.get('service_unit')
-	
+
+	elif data.get("unavailability_for") == "Service Unit":
+		appointment.service_unit = data.get("service_unit")
+
 	# Set patient_name to indicate it's an unavailability record
 	# Format times for better display
 	from_time_str = from_time.strftime("%H:%M")
 	to_time_str = to_time.strftime("%H:%M")
 	time_range = f"{from_time_str} to {to_time_str}"
-	
+
 	if appointment.practitioner_name:
 		appointment.patient_name = f"UNAVAILABLE: {appointment.practitioner_name} ({time_range})"
 	elif appointment.service_unit:
 		appointment.patient_name = f"UNAVAILABLE: {appointment.service_unit} ({time_range})"
 	else:
 		appointment.patient_name = f"UNAVAILABLE ({time_range})"
-	
+
 	# Explicitly set the title to match patient_name
 	appointment.title = appointment.patient_name
-	
+
 	# Add end time data
 	appointment.appointment_end_time = str(to_time)
-	appointment.appointment_end_datetime = to_datetime.strftime('%Y-%m-%d %H:%M:%S')
+	appointment.appointment_end_datetime = to_datetime.strftime("%Y-%m-%d %H:%M:%S")
 	# Ensure end_time is properly formatted as HH:MM:SS
-	appointment.end_time = to_time.strftime('%H:%M:%S')
-	
+	appointment.end_time = to_time.strftime("%H:%M:%S")
+
 	# Mark this as an unavailability appointment to bypass validation
 	appointment.is_unavailability = True
-	
+
 	# Skip validation that would normally require a patient
 	appointment.flags.ignore_validate = True
 	appointment.flags.ignore_mandatory = True
-	
+
 	# Insert the document
 	appointment.insert(ignore_permissions=True)
-	
+
 	print(f"Created unavailability appointment: {appointment.name}")
 	print(f"Appointment duration: {duration} minutes, end time: {to_time}")
-	
+
 	# After insert, double-check that title matches patient_name and end_time is set
 	update_values = {}
 	if appointment.title != appointment.patient_name:
 		update_values["title"] = appointment.patient_name
-	
+
 	# Double-check that end_time is set correctly
-	if not appointment.end_time or appointment.end_time != to_time.strftime('%H:%M:%S'):
-		update_values["end_time"] = to_time.strftime('%H:%M:%S')
-	
+	if not appointment.end_time or appointment.end_time != to_time.strftime("%H:%M:%S"):
+		update_values["end_time"] = to_time.strftime("%H:%M:%S")
+
 	if update_values:
-		frappe.db.set_value(
-			"Patient Appointment",
-			appointment.name,
-			update_values,
-			update_modified=False
-		)
+		frappe.db.set_value("Patient Appointment", appointment.name, update_values, update_modified=False)
 		print(f"Fixed values after insert: {update_values}")
-	
+
 	# Notify of update to refresh any views
 	appointment.notify_update()
-	
+
 	# Include end_time in the response for the JavaScript
 	return {
 		"name": appointment.name,
-		"date": date.strftime('%Y-%m-%d'),
-		"from_time": from_time.strftime('%H:%M:%S'),
-		"to_time": to_time.strftime('%H:%M:%S'),
-		"end_time": to_time.strftime('%H:%M:%S'),
-		"duration": duration
+		"date": date.strftime("%Y-%m-%d"),
+		"from_time": from_time.strftime("%H:%M:%S"),
+		"to_time": to_time.strftime("%H:%M:%S"),
+		"end_time": to_time.strftime("%H:%M:%S"),
+		"duration": duration,
 	}
+
 
 @frappe.whitelist()
 def update_appointment_end_times():
@@ -2077,49 +2157,50 @@ def update_appointment_end_times():
 	Can be run as a patch or called manually to fix existing appointments.
 	"""
 	from datetime import datetime, timedelta
-	from frappe.utils import getdate, get_time, flt
-	
+
+	from frappe.utils import flt, get_time, getdate
+
 	count = 0
 	# Get all appointments that have a duration but no end time
 	appointments = frappe.get_all(
-		"Patient Appointment", 
+		"Patient Appointment",
 		filters={"duration": ["not in", ["", 0, None]]},
-		fields=["name", "appointment_date", "appointment_time", "duration", "appointment_end_time"]
+		fields=["name", "appointment_date", "appointment_time", "duration", "appointment_end_time"],
 	)
-	
+
 	for appointment in appointments:
 		if not appointment.appointment_end_time:
 			try:
 				start_dt = datetime.combine(
-					getdate(appointment.appointment_date), 
-					get_time(appointment.appointment_time)
+					getdate(appointment.appointment_date), get_time(appointment.appointment_time)
 				)
 				end_dt = start_dt + timedelta(minutes=flt(appointment.duration))
 				end_time = end_dt.time().strftime("%H:%M:%S")
 				end_datetime = f"{appointment.appointment_date} {end_time}"
-				
+
 				frappe.db.set_value(
-					"Patient Appointment", 
-					appointment.name, 
+					"Patient Appointment",
+					appointment.name,
 					{
 						"appointment_end_time": end_time,
 						"appointment_end_datetime": end_datetime,
-						"end_time": end_time
+						"end_time": end_time,
 					},
-					update_modified=False
+					update_modified=False,
 				)
 				count += 1
-				
+
 				# Update the calendar event too
 				event_name = frappe.db.get_value("Patient Appointment", appointment.name, "event")
 				if event_name:
 					frappe.db.set_value("Event", event_name, "ends_on", end_dt, update_modified=False)
-					
+
 			except Exception as e:
-				print(f"Error updating appointment {appointment.name}: {str(e)}")
-	
+				print(f"Error updating appointment {appointment.name}: {e!s}")
+
 	frappe.db.commit()
 	print(f"Updated end times for {count} appointments")
+
 
 @frappe.whitelist()
 def update_unavailability_appointment_names():
@@ -2129,23 +2210,28 @@ def update_unavailability_appointment_names():
 	"""
 	# Get all unavailability appointments
 	appointments = frappe.get_all(
-		"Patient Appointment", 
-		filters={
-			"appointment_type": "Unavailable",
-			"status": ["!=", "Cancelled"]
-		},
-		fields=["name", "practitioner", "practitioner_name", "service_unit", 
-				"appointment_time", "appointment_end_time", "duration", 
-				"appointment_date", "notes"]
+		"Patient Appointment",
+		filters={"appointment_type": "Unavailable", "status": ["!=", "Cancelled"]},
+		fields=[
+			"name",
+			"practitioner",
+			"practitioner_name",
+			"service_unit",
+			"appointment_time",
+			"appointment_end_time",
+			"duration",
+			"appointment_date",
+			"notes",
+		],
 	)
-	
+
 	count = 0
 	for appointment in appointments:
 		try:
 			# Get properly formatted times
 			from_time = get_time(appointment.appointment_time)
 			from_time_str = from_time.strftime("%H:%M")
-			
+
 			# Get or calculate end time
 			if appointment.appointment_end_time:
 				to_time = get_time(appointment.appointment_end_time)
@@ -2158,35 +2244,34 @@ def update_unavailability_appointment_names():
 					to_time_str = end_dt.time().strftime("%H:%M")
 				else:
 					to_time_str = "??:??"
-			
+
 			time_range = f"{from_time_str} to {to_time_str}"
-			
+
 			# Create new patient_name with time information
 			patient_name = None
 			if appointment.practitioner:
-				patient_name = f"UNAVAILABLE: {appointment.practitioner_name or appointment.practitioner} ({time_range})"
+				patient_name = (
+					f"UNAVAILABLE: {appointment.practitioner_name or appointment.practitioner} ({time_range})"
+				)
 			elif appointment.service_unit:
 				patient_name = f"UNAVAILABLE: {appointment.service_unit} ({time_range})"
 			else:
 				patient_name = f"UNAVAILABLE ({time_range})"
-			
+
 			# Update the appointment
 			if patient_name:
 				title = patient_name  # Use same format for title
 				frappe.db.set_value(
-					"Patient Appointment", 
-					appointment.name, 
-					{
-						"patient_name": patient_name,
-						"title": title
-					},
-					update_modified=False
+					"Patient Appointment",
+					appointment.name,
+					{"patient_name": patient_name, "title": title},
+					update_modified=False,
 				)
 				count += 1
-				
+
 		except Exception as e:
-			print(f"Error updating appointment {appointment.name}: {str(e)}")
-	
+			print(f"Error updating appointment {appointment.name}: {e!s}")
+
 	frappe.db.commit()
 	print(f"Updated names for {count} unavailability appointments")
 	return count
@@ -2197,7 +2282,7 @@ def update_unavailability_appointment_names():
 def apply_filter_on_therapy_type(doctype, txt, searchfield, start, page_len, filters):
 	if not filters.get("therapy_plan"):
 		frappe.throw("Please set therapy plan first")
-	conditions = ''
+	conditions = ""
 	if txt:
 		conditions += f" and therapy_type like '%{txt}%'"
 	return frappe.db.sql(f"""


### PR DESCRIPTION
## Summary

When creating an appointment with `Appointment Type = "Unavailable"`, the system enforced the Patient field as mandatory, preventing creation of unavailability blocks. This PR fixes that by:

1. **Conditional mandatory on `patient` field** (`patient_appointment.json`): Replaced `"reqd": 1` with `"mandatory_depends_on": "eval:doc.appointment_type !== 'Unavailable'"` so that the Patient field is only required for non-unavailability appointments.

2. **Auto-generate `patient_name` for unavailability appointments** (`patient_appointment.py`): Added `set_unavailability_patient_name()` method, called during `validate()`, which generates a descriptive name like `"UNAVAILABLE: Dr. Smith (09:00 to 10:00)"`.

3. **Hide "Unavailable" from bookable appointment types** (`patient_appointment.js`): Added a `set_query` filter on the `appointment_type` field to exclude `"Unavailable"` from the dropdown, preventing users from accidentally selecting it.

**Note:** The diff is inflated by prettier auto-formatting of the JS file and ruff auto-fixes in the Python file. The functional JS change is solely the `set_query('appointment_type', ...)` addition (~4 lines). The Python lint fixes include renaming `today` → `today_date` (to resolve F811 shadowing), converting `%s` formatting to f-strings (UP031), removing unused `has_conflicts` variable (F841), and initializing `end_time` before a loop (F821).

## Review & Testing Checklist for Human

- [ ] **Test `mandatory_depends_on` eval with empty `appointment_type`**: On a brand-new Patient Appointment form (before selecting any appointment type), verify the Patient field is still enforced as mandatory. The expression `eval:doc.appointment_type !== 'Unavailable'` evaluates truthy when `appointment_type` is `null`/`undefined`/`""`, but confirm this in the actual Frappe UI.
- [ ] **Test creating an Unavailable appointment**: Set Appointment Type to "Unavailable" (via URL param, API, or the existing unavailability dialog), confirm it saves without a Patient and that `patient_name` is auto-generated correctly.
- [ ] **Verify "Unavailable" is hidden from the dropdown**: Open a new Patient Appointment form and confirm "Unavailable" does not appear in the Appointment Type link field options, while all other appointment types still appear.
- [ ] **Verify existing unavailability workflows still work**: Test the "Mark Unavailability" flow (from practitioner schedule or calendar) end-to-end — the `create_unavailability_appointment` function uses `flags.ignore_mandatory = True`, so confirm it still works alongside the new conditional mandatory.
- [ ] **Run `bench migrate`** after deploying to sync the JSON schema change for the `patient` field.

### Notes
- The `patient_appointment.json` `modified` timestamp was updated, which will trigger a schema sync on next `bench migrate`.
- Upstream marley version-16 also has `patient` as `"reqd": 1`, so this is a biograph-specific enhancement rather than a backport.
- Pre-existing ruff lint errors were fixed as part of this PR since pre-commit hooks enforce them. These are formatting-only changes to existing code.

Link to Devin session: https://app.devin.ai/sessions/b6d1301c034942fead82274c35dbe0ed
Requested by: @pythonpen