### PR TITLE
fix: add missing Patient Portal fields to Healthcare Settings from upstream marley

### DIFF
--- a/healthcare/healthcare/doctype/healthcare_settings/healthcare_settings.json
+++ b/healthcare/healthcare/doctype/healthcare_settings/healthcare_settings.json
@@ -48,6 +48,7 @@
   "sb_in_ac",
   "income_account",
   "receivable_account",
+  "naming_series_for_journal_entry",
   "order_details_section",
   "process_service_request_only_if_paid",
   "validate_medication_quantity_in_invoice",
@@ -70,7 +71,18 @@
   "laboratory_sms_alerts",
   "sms_printed",
   "column_break_28",
-  "sms_emailed"
+  "sms_emailed",
+  "patient_portal_tab",
+  "default_appointment_type",
+  "column_break_nxka",
+  "show_diagnostics_tab",
+  "payment_section",
+  "payment_gateway",
+  "mode_of_payment",
+  "column_break_xvtl",
+  "collect_payment",
+  "no_payments_app",
+  "payments_app_is_not_installed"
  ],
  "fields": [
   {
@@ -472,6 +484,72 @@
    "fieldname": "validate_medication_quantity_in_invoice",
    "fieldtype": "Check",
    "label": "Validate Medication Quantity In invoice"
+  },
+  {
+   "fieldname": "naming_series_for_journal_entry",
+   "fieldtype": "Select",
+   "label": "Naming Series for Insurance Coverage Journal Entry"
+  },
+  {
+   "default": "0",
+   "fieldname": "patient_portal_tab",
+   "fieldtype": "Tab Break",
+   "label": "Patient Portal"
+  },
+  {
+   "fieldname": "default_appointment_type",
+   "fieldtype": "Link",
+   "label": "Default Appointment Type",
+   "options": "Appointment Type"
+  },
+  {
+   "fieldname": "column_break_nxka",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "description": "If enabled, diagnostic details tab will show on patient portal",
+   "fieldname": "show_diagnostics_tab",
+   "fieldtype": "Check",
+   "label": "Show Diagnostics Tab on Portal"
+  },
+  {
+   "fieldname": "payment_section",
+   "fieldtype": "Section Break",
+   "label": "Payment Settings"
+  },
+  {
+   "depends_on": "eval: doc.collect_payment==1;",
+   "fieldname": "payment_gateway",
+   "fieldtype": "Data",
+   "label": "Payment Gateway"
+  },
+  {
+   "depends_on": "eval: doc.collect_payment==1;",
+   "fieldname": "mode_of_payment",
+   "fieldtype": "Link",
+   "label": "Mode of Payment",
+   "options": "Mode of Payment"
+  },
+  {
+   "fieldname": "column_break_xvtl",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "description": "To enable this feature need Payments App",
+   "fieldname": "collect_payment",
+   "fieldtype": "Check",
+   "label": "Collect Payment on Portal"
+  },
+  {
+   "fieldname": "no_payments_app",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "payments_app_is_not_installed",
+   "fieldtype": "HTML",
+   "label": "Payments app is not installed"
   }
  ],
  "issingle": 1,


### PR DESCRIPTION
## Summary

Patient Portal appointment booking fails with `"Field default_appointment_type does not exist on Healthcare Settings"` because 13 fields present in [upstream marley (version-16)](https://github.com/earthians/marley/blob/version-16/healthcare/healthcare/doctype/healthcare_settings/healthcare_settings.json) were missing from biograph's Healthcare Settings DocType schema.

Existing code in `patient_portal.py`, `healthcare_payment_record.py`, `PatientPortal.vue`, and `BookAppointmentModel.vue` already references these fields — only the JSON field definitions were missing.

**Fields added:**
| Field | Type | Purpose |
|---|---|---|
| `patient_portal_tab` | Tab Break | New "Patient Portal" tab |
| `default_appointment_type` | Link → Appointment Type | **Root cause of the reported bug** |
| `show_diagnostics_tab` | Check | Toggle diagnostics on portal |
| `payment_section` | Section Break | Payment Settings section |
| `payment_gateway` | Data | Payment gateway config |
| `mode_of_payment` | Link → Mode of Payment | Payment mode for portal |
| `collect_payment` | Check | Enable payment collection on portal |
| `no_payments_app` / `payments_app_is_not_installed` | Section Break / HTML | Notice when Payments app missing |
| `naming_series_for_journal_entry` | Select | Journal entry naming series (Billing tab) |
| Column breaks | Column Break | Layout (×2) |

## Review & Testing Checklist for Human

- [ ] **Run `bench migrate` on a test site** and confirm the new fields appear under a "Patient Portal" tab in Healthcare Settings — this was not tested against a live Frappe instance
- [ ] **Test the original bug**: Login to Patient Portal → select "General" → book with "Dr Nitin" → verify appointment books successfully without the `default_appointment_type` error
- [ ] **Set a value for Default Appointment Type** in Healthcare Settings → Patient Portal tab, and confirm it is correctly used when booking from the portal
- [ ] Verify Healthcare Settings DocType is now visible/searchable in the system (it was reported as not visible)
- [ ] Spot-check that payment-related fields (`collect_payment`, `payment_gateway`, `mode_of_payment`) render correctly and their `depends_on` visibility toggles work

### Notes
- All field definitions were copied verbatim from upstream marley `version-16` to maintain compatibility
- The `depends_on` expressions for `payment_gateway` and `mode_of_payment` contain trailing semicolons (`eval: doc.collect_payment==1;`) — this matches upstream exactly
- No Python or JS code changes were needed; only the DocType JSON schema was out of sync

Link to Devin session: https://app.devin.ai/sessions/0f7b972549b6493192fcbf288eaae5a2
Requested by: @pythonpen
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tacten/biograph/pull/245" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
