### PR TITLE
fix: add missing Patient Portal business logic to Healthcare Settings JS from upstream marley

### DIFF
--- a/healthcare/healthcare/doctype/healthcare_settings/healthcare_settings.js
+++ b/healthcare/healthcare/doctype/healthcare_settings/healthcare_settings.js
@@ -1,121 +1,181 @@
 // Copyright (c) 2017, Frappe Technologies Pvt. Ltd. and contributors
 // For license information, please see license.txt
 
-frappe.ui.form.on('Healthcare Settings', {
-	setup: function(frm) {
-		frm.set_query('default_google_calendar', function(doc) {
+frappe.ui.form.on("Healthcare Settings", {
+	setup: function (frm) {
+		frm.set_query("default_google_calendar", function (doc) {
 			return {
 				filters: {
-					'enable': true
-				}
+					enable: true,
+				},
 			};
 		});
-		frm.set_query('account', 'receivable_account', function(doc, cdt, cdn) {
-			var d  = locals[cdt][cdn];
+		set_naming_series(frm);
+		frm.set_query("account", "receivable_account", function (doc, cdt, cdn) {
+			var d = locals[cdt][cdn];
 			return {
 				filters: {
-					'account_type': 'Receivable',
-					'company': d.company,
-					'is_group': 0
-				}
+					account_type: "Receivable",
+					company: d.company,
+					is_group: 0,
+				},
 			};
 		});
-		frm.set_query('account', 'income_account', function(doc, cdt, cdn) {
-			var d  = locals[cdt][cdn];
+		frm.set_query("account", "income_account", function (doc, cdt, cdn) {
+			var d = locals[cdt][cdn];
 			return {
 				filters: {
-					'root_type': 'Income',
-					'company': d.company,
-					'is_group': 0
-				}
+					root_type: "Income",
+					company: d.company,
+					is_group: 0,
+				},
 			};
 		});
-		frm.set_query('default_code_system', function(doc) {
+		frm.set_query("default_code_system", function (doc) {
 			return {
 				filters: {
-					'is_fhir_defined': false
-				}
+					is_fhir_defined: false,
+				},
 			};
 		});
-		frm.set_query('default_priority', function () {
+		frm.set_query("default_priority", function () {
 			return {
 				filters: {
-					code_system: 'Priority'
-				}
-			};
-		});
-
-		frm.set_query('default_intent', function () {
-			return {
-				filters: {
-					code_system: 'Intent'
-				}
+					code_system: "Priority",
+				},
 			};
 		});
 
-		set_query_service_item(frm, 'inpatient_visit_charge_item');
-		set_query_service_item(frm, 'op_consulting_charge_item');
-		set_query_service_item(frm, 'clinical_procedure_consumable_item');
-		set_query_service_item(frm, 'registration_item');
-	}
+		frm.set_query("default_intent", function () {
+			return {
+				filters: {
+					code_system: "Intent",
+				},
+			};
+		});
+
+		set_query_service_item(frm, "inpatient_visit_charge_item");
+		set_query_service_item(frm, "op_consulting_charge_item");
+		set_query_service_item(frm, "clinical_procedure_consumable_item");
+		set_query_service_item(frm, "registration_item");
+
+		frappe.call({
+			method: "healthcare.healthcare.doctype.healthcare_settings.healthcare_settings.check_payments_app",
+			callback: data => {
+				if (!data.message) {
+					frm.set_df_property("payment_section", "hidden", 1);
+					if (frm.doc.collect_payment) {
+						frm.set_value("collect_payment", 0);
+						frm.save();
+					}
+					frm.set_df_property("collect_payment", "read_only", 1);
+					frm.trigger("set_no_payments_app_html");
+				} else {
+					frm.set_df_property("no_payments_app", "hidden", 1);
+					frm.set_df_property("collect_payment", "read_only", 0);
+				}
+			},
+		});
+	},
+
+	set_no_payments_app_html(frm) {
+		frm.get_field("payments_app_is_not_installed").html(`
+				<div class="alert alert-warning">
+					Please install the
+					<a target="_blank" style="text-decoration: underline; color: var(--alert-text-warning); background: var(--alert-bg-warning);" href="https://frappecloud.com/marketplace/apps/payments">Payments app</a>
+					 to enable payment gateway. Refer to the
+					 <a target="_blank" style="text-decoration: underline; color: var(--alert-text-warning); background: var(--alert-bg-warning);" href="https://docs.frappe.io/learning/setting-up-payment-gateway">Documentation</a>
+					 for more information.
+				</div>
+			`);
+	},
 });
 
-var set_query_service_item = function(frm, service_item_field) {
-	frm.set_query(service_item_field, function() {
+var set_query_service_item = function (frm, service_item_field) {
+	frm.set_query(service_item_field, function () {
 		return {
 			filters: {
-				'is_sales_item': 1,
-				'is_stock_item': 0
-			}
+				is_sales_item: 1,
+				is_stock_item: 0,
+			},
 		};
 	});
 };
 
-frappe.tour['Healthcare Settings'] = [
-	{
-		fieldname: 'link_customer_to_patient',
-		title: __('Link Customer to Patient'),
-		description: __('If checked, a customer will be created for every Patient. Patient Invoices will be created against this Customer. You can also select existing Customer while creating a Patient. This field is checked by default.')
-	},
-	{
-		fieldname: 'default_code_system',
-		title: __('Default Code System'),
-		description: __('Will be set as the default Code System selected in the Codification Table')
-	},
-	{
-		fieldname: 'default_google_calendar',
-		title: __('Default Google Calendar'),
-		description: __('While booking tele-consultation appointments via Google Meet, this Google Calendar will be used. You can also configure separate Google Calender for each Practitioner if required')
-	},
-	{
-		fieldname: 'collect_registration_fee',
-		title: __('Collect Registration Fee'),
-		description: __('If your Healthcare facility bills registrations of Patients, you can check this and set the Registration Fee in the field below. Checking this will create new Patients with a Disabled status by default and will only be enabled after invoicing the Registration Fee.')
-	},
-	{
-		fieldname: 'show_payment_popup',
-		title: __('Show Payment Popup'),
-		description: __('Checking this will popup to invoice appointment')
-	},
-	{
-		fieldname: 'validate_nursing_checklists',
-		title: __('validate_nursing_checklists'),
-		description: __('Validates all mandatory tasks in nursing checklist to be Completed before a Patient transactional event. For example, if any of the tasks as part of the Discharge Checklist is not in status Completed, system will alert the user while trying to Discharge the Patient from inpatient facility')
-	},
-	{
-		fieldname: 'inpatient_visit_charge_item',
-		title: __('Healthcare Service Items'),
-		description: __('You can create a service item for Inpatient Visit Charge and set it here. Similarly, you can set up other Healthcare Service Items for billing in this section. Click ') + "<a href='https://frappehealth.com/docs/v13/user/manual/en/healthcare/healthcare_settings#2-default-healthcare-service-items' target='_blank'>here</a>" + __(' to know more')
-	},
-	{
-		fieldname: 'income_account',
-		title: __('Set up default Accounts for the Healthcare Facility'),
-		description: __('If you wish to override default accounts settings and configure the Income and Receivable accounts for Healthcare, you can do so here.')
+var set_naming_series = function (frm) {
+	frm.set_df_property(
+		"naming_series_for_journal_entry",
+		"options",
+		frm.doc.__onload.naming_series_for_journal_entry,
+	);
+};
 
+frappe.tour["Healthcare Settings"] = [
+	{
+		fieldname: "link_customer_to_patient",
+		title: __("Link Customer to Patient"),
+		description: __(
+			"If checked, a customer will be created for every Patient. Patient Invoices will be created against this Customer. You can also select existing Customer while creating a Patient. This field is checked by default.",
+		),
 	},
 	{
-		fieldname: 'send_registration_msg',
-		title: __('Out Patient SMS alerts'),
-		description: __('If you want to send SMS alert on Patient Registration, you can enable this option. Similary, you can set up Out Patient SMS alerts for other functionalities in this section. Click ') + "<a href='https://frappehealth.com/docs/v13/user/manual/en/healthcare/healthcare_settings#4-out-patient-sms-alerts' target='_blank'>here</a>" + __(' to know more')
-	}
+		fieldname: "default_code_system",
+		title: __("Default Code System"),
+		description: __(
+			"Will be set as the default Code System selected in the Codification Table",
+		),
+	},
+	{
+		fieldname: "default_google_calendar",
+		title: __("Default Google Calendar"),
+		description: __(
+			"While booking tele-consultation appointments via Google Meet, this Google Calendar will be used. You can also configure separate Google Calender for each Practitioner if required",
+		),
+	},
+	{
+		fieldname: "collect_registration_fee",
+		title: __("Collect Registration Fee"),
+		description: __(
+			"If your Healthcare facility bills registrations of Patients, you can check this and set the Registration Fee in the field below. Checking this will create new Patients with a Disabled status by default and will only be enabled after invoicing the Registration Fee.",
+		),
+	},
+	{
+		fieldname: "show_payment_popup",
+		title: __("Show Payment Popup"),
+		description: __("Checking this will popup to invoice appointment"),
+	},
+	{
+		fieldname: "validate_nursing_checklists",
+		title: __("validate_nursing_checklists"),
+		description: __(
+			"Validates all mandatory tasks in nursing checklist to be Completed before a Patient transactional event. For example, if any of the tasks as part of the Discharge Checklist is not in status Completed, system will alert the user while trying to Discharge the Patient from inpatient facility",
+		),
+	},
+	{
+		fieldname: "inpatient_visit_charge_item",
+		title: __("Healthcare Service Items"),
+		description:
+			__(
+				"You can create a service item for Inpatient Visit Charge and set it here. Similarly, you can set up other Healthcare Service Items for billing in this section. Click ",
+			) +
+			"<a href='https://frappehealth.com/docs/v13/user/manual/en/healthcare/healthcare_settings#2-default-healthcare-service-items' target='_blank'>here</a>" +
+			__(" to know more"),
+	},
+	{
+		fieldname: "income_account",
+		title: __("Set up default Accounts for the Healthcare Facility"),
+		description: __(
+			"If you wish to override default accounts settings and configure the Income and Receivable accounts for Healthcare, you can do so here.",
+		),
+	},
+	{
+		fieldname: "send_registration_msg",
+		title: __("Out Patient SMS alerts"),
+		description:
+			__(
+				"If you want to send SMS alert on Patient Registration, you can enable this option. Similary, you can set up Out Patient SMS alerts for other functionalities in this section. Click ",
+			) +
+			"<a href='https://frappehealth.com/docs/v13/user/manual/en/healthcare/healthcare_settings#4-out-patient-sms-alerts' target='_blank'>here</a>" +
+			__(" to know more"),
+	},
 ];


### PR DESCRIPTION
## Summary

Companion to PR #245 (which added the missing field definitions to `healthcare_settings.json`). This PR adds the **client-side business logic** from upstream marley that was also missing from biograph's `healthcare_settings.js`. Without this logic, the new Patient Portal / Payment fields added in #245 do not behave correctly at runtime.

**Three pieces of logic added:**

1. **`set_naming_series(frm)`** — Populates the `naming_series_for_journal_entry` Select field's dropdown options from `__onload` data (set by the Python controller's `onload` method).

2. **`check_payments_app` call in `setup`** — On form load, calls the server-side `check_payments_app` whitelisted method. If the Payments app is *not* installed: hides `payment_section`, resets `collect_payment` to 0, and renders a warning banner. If installed: hides the warning section and enables `collect_payment`.

3. **`set_no_payments_app_html` handler** — Renders an alert banner in the `payments_app_is_not_installed` HTML field with links to install the Payments app and documentation.

The remaining line changes are **prettier auto-formatting** (single→double quotes, trailing commas, spacing) — no functional change.

## Review & Testing Checklist for Human

- [ ] **Verify `__onload` safety**: `set_naming_series` accesses `frm.doc.__onload.naming_series_for_journal_entry` — confirm this doesn't throw if `__onload` is undefined (e.g., before migration). The Python `get_journal_entry_naming_series` method sets it, but only if the `naming_series_for_journal_entry` field exists in the schema (added in #245).
- [ ] **Run `bench migrate` first**, then open Healthcare Settings → confirm no JS console errors on load
- [ ] **Test with Payments app NOT installed**: Open Healthcare Settings → Patient Portal tab → verify the payment section is hidden, `collect_payment` is read-only, and the "Please install the Payments app" alert banner renders correctly
- [ ] **Test with Payments app installed** (if applicable): Confirm `payment_section` is visible, `collect_payment` is editable, and the warning banner is hidden
- [ ] **Verify the `frm.save()` side effect**: If `collect_payment` was previously checked and Payments app is removed, the form auto-saves on load to reset it — confirm this doesn't cause issues

### Notes
- All logic was copied from [upstream marley `version-16`](https://github.com/earthians/marley/blob/version-16/healthcare/healthcare/doctype/healthcare_settings/healthcare_settings.js) and adapted only for quote style (prettier)
- `healthcare_settings.py` and `patient_portal.py` were verified identical to upstream — no missing server-side logic
- The `check_payments_app` Python method already exists in biograph's `healthcare_settings.py` (identical to upstream)

Link to Devin session: https://app.devin.ai/sessions/0f7b972549b6493192fcbf288eaae5a2
Requested by: @pythonpen