### PR TITLE
feat: sync upstream marley version-16 commits (PRs #930, #933, #934, #936)

### DIFF
--- a/healthcare/healthcare/doctype/clinical_procedure/clinical_procedure.js
+++ b/healthcare/healthcare/doctype/clinical_procedure/clinical_procedure.js
@@ -1,335 +1,361 @@
 // Copyright (c) 2017, ESS LLP and contributors
 // For license information, please see license.txt
 
-frappe.ui.form.on('Clinical Procedure', {
-	setup: function(frm) {
-		frm.set_query('batch_no', 'items', function(doc, cdt, cdn) {
+frappe.ui.form.on("Clinical Procedure", {
+	setup: function (frm) {
+		frm.set_query("batch_no", "items", function (doc, cdt, cdn) {
 			let item = locals[cdt][cdn];
 			if (!item.item_code) {
-				frappe.throw(__('Please enter Item Code to get Batch Number'));
+				frappe.throw(__("Please enter Item Code to get Batch Number"));
 			} else {
-				let filters = {'item_code': item.item_code};
+				let filters = { item_code: item.item_code };
 
-				if (frm.doc.status == 'In Progress') {
-					filters['posting_date'] = frm.doc.start_date || frappe.datetime.nowdate();
-					if (frm.doc.warehouse) filters['warehouse'] = frm.doc.warehouse;
+				if (frm.doc.status == "In Progress") {
+					filters["posting_date"] =
+						frm.doc.start_date || frappe.datetime.nowdate();
+					if (frm.doc.warehouse) filters["warehouse"] = frm.doc.warehouse;
 				}
 
 				return {
-					query : 'erpnext.controllers.queries.get_batch_no',
-					filters: filters
+					query: "erpnext.controllers.queries.get_batch_no",
+					filters: filters,
 				};
 			}
 		});
 
-		frm.set_query('service_request', function() {
+		frm.set_query("service_request", function () {
 			return {
 				filters: {
-					'patient': frm.doc.patient,
-					'status': 'Active',
-					'docstatus': 1,
-					'template_dt': 'Clinical Procedure template'
-				}
+					patient: frm.doc.patient,
+					status: "Active",
+					docstatus: 1,
+					template_dt: "Clinical Procedure template",
+				},
 			};
 		});
 	},
 
-	refresh: function(frm) {
-		frm.set_query('patient', function () {
+	refresh: function (frm) {
+		frm.set_query("patient", function () {
 			return {
-				filters: {'status': ['!=', 'Disabled']}
+				filters: { status: ["!=", "Disabled"] },
 			};
 		});
 
-		frm.set_query('appointment', function () {
-			return {
-				filters: {
-					'procedure_template': ['not in', null],
-					'status': ['in', 'Open, Scheduled']
-				}
-			};
-		});
-
-		frm.set_query('service_unit', function() {
+		frm.set_query("appointment", function () {
 			return {
 				filters: {
-					'is_group': false,
-					'allow_appointments': true,
-					'company': frm.doc.company
-				}
+					procedure_template: ["not in", null],
+					status: ["in", "Open, Scheduled"],
+				},
 			};
 		});
 
-		frm.set_query('practitioner', function() {
+		frm.set_query("service_unit", function () {
 			return {
 				filters: {
-					'department': frm.doc.medical_department
-				}
+					is_group: false,
+					allow_appointments: true,
+					company: frm.doc.company,
+				},
 			};
 		});
 
-		frm.set_query("code_value", "codification_table", function(doc, cdt, cdn) {
+		frm.set_query("practitioner", function () {
+			return {
+				filters: {
+					department: frm.doc.medical_department,
+				},
+			};
+		});
+
+		frm.set_query("code_value", "codification_table", function (doc, cdt, cdn) {
 			let row = frappe.get_doc(cdt, cdn);
 			if (row.code_system) {
 				return {
 					filters: {
-						code_system: row.code_system
-					}
+						code_system: row.code_system,
+					},
 				};
 			}
 		});
 
 		if (frm.doc.consume_stock) {
-			frm.set_indicator_formatter('item_code',
-				function(doc) { return (doc.qty<=doc.actual_qty) ? 'green' : 'orange' ; });
+			frm.set_indicator_formatter("item_code", function (doc) {
+				return doc.qty <= doc.actual_qty ? "green" : "orange";
+			});
 		}
 
 		if (frm.doc.docstatus == 1) {
-			if (frm.doc.status == 'In Progress') {
-				let btn_label = '';
-				let msg = '';
+			if (frm.doc.status == "In Progress") {
+				let btn_label = "";
+				let msg = "";
 				if (frm.doc.consume_stock) {
-					btn_label = __('Complete and Consume');
-					msg = __('Complete {0} and Consume Stock?', [frm.doc.name]);
+					btn_label = __("Complete and Consume");
+					msg = __("Complete {0} and Consume Stock?", [frm.doc.name]);
 				} else {
-					btn_label = 'Complete';
-					msg = __('Complete {0}?', [frm.doc.name]);
+					btn_label = "Complete";
+					msg = __("Complete {0}?", [frm.doc.name]);
 				}
 
 				frm.add_custom_button(__(btn_label), function () {
-					frappe.confirm(
-						msg,
-						function() {
-							frappe.call({
-								method: 'complete_procedure',
-								doc: frm.doc,
-								freeze: true,
-								callback: function(r) {
-									if (r.message) {
-										frappe.show_alert({
-											message: __('Stock Entry {0} created', ['<a class="bold" href="/app/stock-entry/'+ r.message + '">' + r.message + '</a>']),
-											indicator: 'green'
-										});
-									}
-									frm.reload_doc();
+					frappe.confirm(msg, function () {
+						frappe.call({
+							method: "complete_procedure",
+							doc: frm.doc,
+							freeze: true,
+							callback: function (r) {
+								if (r.message) {
+									frappe.show_alert({
+										message: __("Stock Entry {0} created", [
+											'<a class="bold" href="/app/stock-entry/' +
+												r.message +
+												'">' +
+												r.message +
+												"</a>",
+										]),
+										indicator: "green",
+									});
 								}
-							});
-						}
-					);
+								frm.reload_doc();
+							},
+						});
+					});
 				}).addClass("btn-primary");
-
-			} else if (frm.doc.status == 'Pending') {
-				frm.add_custom_button(__('Start'), function() {
+			} else if (frm.doc.status == "Pending") {
+				frm.add_custom_button(__("Start"), function () {
 					frappe.call({
 						doc: frm.doc,
-						method: 'start_procedure',
-						callback: function(r) {
+						method: "start_procedure",
+						callback: function (r) {
 							if (!r.exc) {
-								if (r.message == 'insufficient stock') {
-									let msg = __('Stock quantity to start the Procedure is not available in the Warehouse {0}. Do you want to record a Stock Entry?', [frm.doc.warehouse.bold()]);
-									frappe.confirm(
-										msg,
-										function() {
-											frappe.call({
-												doc: frm.doc,
-												method: 'make_material_receipt',
-												freeze: true,
-												callback: function(r) {
-													if (!r.exc) {
-														frm.reload_doc();
-														let doclist = frappe.model.sync(r.message);
-														frappe.set_route('Form', doclist[0].doctype, doclist[0].name);
-													}
-												}
-											});
-										}
+								if (r.message == "insufficient stock") {
+									let msg = __(
+										"Stock quantity to start the Procedure is not available in the Warehouse {0}. Do you want to record a Stock Entry?",
+										[frm.doc.warehouse.bold()],
 									);
+									frappe.confirm(msg, function () {
+										frappe.call({
+											doc: frm.doc,
+											method: "make_material_receipt",
+											freeze: true,
+											callback: function (r) {
+												if (!r.exc) {
+													frm.reload_doc();
+													let doclist = frappe.model.sync(
+														r.message,
+													);
+													frappe.set_route(
+														"Form",
+														doclist[0].doctype,
+														doclist[0].name,
+													);
+												}
+											},
+										});
+									});
 								} else {
 									frm.reload_doc();
 								}
 							}
-						}
+						},
 					});
 				}).addClass("btn-primary");
 			}
 		}
-		if(frm.doc.__islocal) {
-			frm.add_custom_button(__('Get from Patient Encounter'), function () {
+		if (frm.doc.__islocal) {
+			frm.add_custom_button(__("Get from Patient Encounter"), function () {
 				get_procedure_prescribed(frm);
 			});
 		}
 
-		frm.add_custom_button(__("Clinical Note"), function() {
-			frappe.route_options = {
-				"patient": frm.doc.patient,
-				"reference_doc": "Clinical Procedure",
-				"reference_name": frm.doc.name}
-					frappe.new_doc("Clinical Note");
-		},__('Create'));
-
+		frm.add_custom_button(
+			__("Clinical Note"),
+			function () {
+				frappe.route_options = {
+					patient: frm.doc.patient,
+					reference_doc: "Clinical Procedure",
+					reference_name: frm.doc.name,
+				};
+				frappe.new_doc("Clinical Note");
+			},
+			__("Create"),
+		);
 	},
 
-	onload: function(frm) {
+	onload: function (frm) {
 		if (frm.is_new()) {
-			frm.add_fetch('procedure_template', 'medical_department', 'medical_department');
-			frm.set_value('start_time', null);
+			frm.add_fetch(
+				"procedure_template",
+				"medical_department",
+				"medical_department",
+			);
+			frm.set_value("start_time", null);
 		}
 		set_defaults(frm);
 	},
 
-	patient: function(frm) {
+	patient: function (frm) {
 		if (frm.doc.patient) {
 			frappe.call({
-				'method': 'healthcare.healthcare.doctype.patient.patient.get_patient_detail',
+				method: "healthcare.healthcare.doctype.patient.patient.get_patient_detail",
 				args: {
-					patient: frm.doc.patient
+					patient: frm.doc.patient,
 				},
 				callback: function (data) {
-					let age = '';
+					let age = "";
 					if (data.message.dob) {
 						age = calculate_age(data.message.dob);
 					} else if (data.message.age) {
 						age = data.message.age;
 						if (data.message.age_as_on) {
-							age = __('{0} as on {1}', [age, data.message.age_as_on]);
+							age = __("{0} as on {1}", [age, data.message.age_as_on]);
 						}
 					}
-					frm.set_value('patient_name', data.message.patient_name);
-					frm.set_value('patient_age', age);
-					frm.set_value('patient_sex', data.message.sex);
-				}
+					frm.set_value("patient_name", data.message.patient_name);
+					frm.set_value("patient_age", age);
+					frm.set_value("patient_sex", data.message.sex);
+				},
 			});
 		} else {
-			frm.set_value('patient_name', '');
-			frm.set_value('patient_age', '');
-			frm.set_value('patient_sex', '');
+			frm.set_value("patient_name", "");
+			frm.set_value("patient_age", "");
+			frm.set_value("patient_sex", "");
 		}
 	},
 
-	appointment: function(frm) {
+	appointment: function (frm) {
 		if (frm.doc.appointment) {
 			frappe.call({
-				'method': 'frappe.client.get',
+				method: "frappe.client.get",
 				args: {
-					doctype: 'Patient Appointment',
-					name: frm.doc.appointment
+					doctype: "Patient Appointment",
+					name: frm.doc.appointment,
 				},
-				callback: function(data) {
+				callback: function (data) {
 					let values = {
-						'patient':data.message.patient,
-						'procedure_template': data.message.procedure_template,
-						'medical_department': data.message.department,
-						'practitioner': data.message.practitioner,
-						'start_date': data.message.appointment_date,
-						'start_time': data.message.appointment_time,
-						'notes': data.message.notes,
-						'service_unit': data.message.service_unit,
-						'company': data.message.company
+						patient: data.message.patient,
+						procedure_template: data.message.procedure_template,
+						medical_department: data.message.department,
+						practitioner: data.message.practitioner,
+						start_date: data.message.appointment_date,
+						start_time: data.message.appointment_time,
+						notes: data.message.notes,
+						service_unit: data.message.service_unit,
+						company: data.message.company,
 					};
 					frm.set_value(values);
-				}
+				},
 			});
 		} else {
 			let values = {
-				'patient': '',
-				'patient_name': '',
-				'patient_sex': '',
-				'patient_age': '',
-				'medical_department': '',
-				'procedure_template': '',
-				'start_date': '',
-				'start_time': '',
-				'notes': '',
-				'service_unit': '',
-				'inpatient_record': ''
+				patient: "",
+				patient_name: "",
+				patient_sex: "",
+				patient_age: "",
+				medical_department: "",
+				procedure_template: "",
+				start_date: "",
+				start_time: "",
+				notes: "",
+				service_unit: "",
+				inpatient_record: "",
 			};
 			frm.set_value(values);
 		}
 	},
 
-	procedure_template: function(frm) {
+	procedure_template: function (frm) {
 		if (frm.doc.procedure_template) {
 			frappe.call({
-				'method': 'frappe.client.get',
+				method: "frappe.client.get",
 				args: {
-					doctype: 'Clinical Procedure Template',
-					name: frm.doc.procedure_template
+					doctype: "Clinical Procedure Template",
+					name: frm.doc.procedure_template,
 				},
 				callback: function (data) {
-					frm.set_value('medical_department', data.message.medical_department);
-					frm.set_value('consume_stock', data.message.consume_stock);
+					frm.set_value(
+						"medical_department",
+						data.message.medical_department,
+					);
+					frm.set_value("consume_stock", data.message.consume_stock);
 					frm.events.set_warehouse(frm);
 					frm.events.set_procedure_consumables(frm);
 					frm.events.set_medical_codes(frm);
-				}
+				},
 			});
 		} else {
-			frm.clear_table("codification_table")
+			frm.clear_table("codification_table");
 			frm.refresh_field("codification_table");
 		}
 	},
 
-	service_unit: function(frm) {
+	service_unit: function (frm) {
 		if (frm.doc.service_unit) {
 			frappe.call({
-				method: 'frappe.client.get_value',
-				args:{
-					fieldname: 'warehouse',
-					doctype: 'Healthcare Service Unit',
-					filters:{name: frm.doc.service_unit},
+				method: "frappe.client.get_value",
+				args: {
+					fieldname: "warehouse",
+					doctype: "Healthcare Service Unit",
+					filters: { name: frm.doc.service_unit },
 				},
-				callback: function(data) {
+				callback: function (data) {
 					if (data.message) {
-						frm.set_value('warehouse', data.message.warehouse);
+						frm.set_value("warehouse", data.message.warehouse);
 					}
-				}
+				},
 			});
 		}
 	},
 
-	practitioner: function(frm) {
+	practitioner: function (frm) {
 		if (frm.doc.practitioner) {
 			frappe.call({
-				'method': 'frappe.client.get',
+				method: "frappe.client.get",
 				args: {
-					doctype: 'Healthcare Practitioner',
-					name: frm.doc.practitioner
+					doctype: "Healthcare Practitioner",
+					name: frm.doc.practitioner,
 				},
 				callback: function (data) {
-					frappe.model.set_value(frm.doctype,frm.docname, 'practitioner_name', data.message.practitioner_name);
-				}
+					frappe.model.set_value(
+						frm.doctype,
+						frm.docname,
+						"practitioner_name",
+						data.message.practitioner_name,
+					);
+				},
 			});
 		} else {
-			frappe.model.set_value(frm.doctype,frm.docname, 'practitioner_name', '');
+			frappe.model.set_value(frm.doctype, frm.docname, "practitioner_name", "");
 		}
 	},
 
-	set_warehouse: function(frm) {
+	set_warehouse: function (frm) {
 		if (!frm.doc.warehouse) {
 			frappe.call({
-				method: 'frappe.client.get_value',
+				method: "frappe.client.get_value",
 				args: {
-					doctype: 'Stock Settings',
-					fieldname: 'default_warehouse'
+					doctype: "Stock Settings",
+					fieldname: "default_warehouse",
 				},
 				callback: function (data) {
-					frm.set_value('warehouse', data.message.default_warehouse);
-				}
+					frm.set_value("warehouse", data.message.default_warehouse);
+				},
 			});
 		}
 	},
 
-	set_procedure_consumables: function(frm) {
+	set_procedure_consumables: function (frm) {
 		frappe.call({
-			method: 'healthcare.healthcare.doctype.clinical_procedure.clinical_procedure.get_procedure_consumables',
+			method: "healthcare.healthcare.doctype.clinical_procedure.clinical_procedure.get_procedure_consumables",
 			args: {
-				procedure_template: frm.doc.procedure_template
+				procedure_template: frm.doc.procedure_template,
 			},
-			callback: function(data) {
+			callback: function (data) {
 				if (data.message) {
 					frm.doc.items = [];
-					$.each(data.message, function(i, v) {
-						let item = frm.add_child('items');
+					$.each(data.message, function (i, v) {
+						let item = frm.add_child("items");
 						item.item_code = v.item_code;
 						item.item_name = v.item_name;
 						item.uom = v.uom;
@@ -337,113 +363,115 @@ frappe.ui.form.on('Clinical Procedure', {
 						item.qty = flt(v.qty);
 						item.transfer_qty = v.transfer_qty;
 						item.conversion_factor = v.conversion_factor;
-						item.invoice_separately_as_consumables = v.invoice_separately_as_consumables;
+						item.invoice_separately_as_consumables =
+							v.invoice_separately_as_consumables;
 						item.batch_no = v.batch_no;
 					});
-					refresh_field('items');
+					refresh_field("items");
 				}
-			}
+			},
 		});
 	},
 
-	set_medical_codes: function(frm) {
+	set_medical_codes: function (frm) {
 		frappe.call({
-			"method": "healthcare.healthcare.utils.get_medical_codes",
+			method: "healthcare.healthcare.utils.get_medical_codes",
 			args: {
 				template_dt: "Clinical Procedure Template",
 				template_dn: frm.doc.procedure_template,
 			},
-			callback: function(r) {
+			callback: function (r) {
 				if (!r.exc && r.message) {
-					frm.doc.codification_table = []
-					$.each(r.message, function(k, val) {
+					frm.doc.codification_table = [];
+					$.each(r.message, function (k, val) {
 						if (val.code_value) {
 							var child = cur_frm.add_child("codification_table");
-							child.code_value = val.code_value
-							child.code_system = val.code_system
-							child.code = val.code
-							child.description = val.description
-							child.system = val.system
+							child.code_value = val.code_value;
+							child.code_system = val.code_system;
+							child.code = val.code;
+							child.description = val.description;
+							child.system = val.system;
 						}
 					});
 					frm.refresh_field("codification_table");
 				}
-			}
-		})
+			},
+		});
 	},
-
 });
 
-frappe.ui.form.on('Clinical Procedure Item', {
-	qty: function(frm, cdt, cdn) {
+frappe.ui.form.on("Clinical Procedure Item", {
+	qty: function (frm, cdt, cdn) {
 		let d = locals[cdt][cdn];
-		frappe.model.set_value(cdt, cdn, 'transfer_qty', d.qty*d.conversion_factor);
+		frappe.model.set_value(cdt, cdn, "transfer_qty", d.qty * d.conversion_factor);
 	},
 
-	uom: function(doc, cdt, cdn) {
+	uom: function (doc, cdt, cdn) {
 		let d = locals[cdt][cdn];
 		if (d.uom && d.item_code) {
 			return frappe.call({
-				method: 'erpnext.stock.doctype.stock_entry.stock_entry.get_uom_details',
+				method: "erpnext.stock.doctype.stock_entry.stock_entry.get_uom_details",
 				args: {
 					item_code: d.item_code,
 					uom: d.uom,
-					qty: d.qty
+					qty: d.qty,
 				},
-				callback: function(r) {
+				callback: function (r) {
 					if (r.message) {
 						frappe.model.set_value(cdt, cdn, r.message);
 					}
-				}
+				},
 			});
 		}
 	},
 
-	item_code: function(frm, cdt, cdn) {
+	item_code: function (frm, cdt, cdn) {
 		let d = locals[cdt][cdn];
 		let args = null;
 		if (d.item_code) {
 			args = {
-				'doctype' : 'Clinical Procedure',
-				'item_code' : d.item_code,
-				'company' : frm.doc.company,
-				'warehouse': frm.doc.warehouse
+				doctype: "Clinical Procedure",
+				item_code: d.item_code,
+				company: frm.doc.company,
+				warehouse: frm.doc.warehouse,
 			};
 			return frappe.call({
-				method: 'healthcare.healthcare.doctype.clinical_procedure_template.clinical_procedure_template.get_item_details',
-				args: {args: args},
-				callback: function(r) {
+				method: "healthcare.healthcare.doctype.clinical_procedure_template.clinical_procedure_template.get_item_details",
+				args: { args: args },
+				callback: function (r) {
 					if (r.message) {
 						let d = locals[cdt][cdn];
-						$.each(r.message, function(k, v) {
+						$.each(r.message, function (k, v) {
 							d[k] = v;
 						});
-						refresh_field('items');
+						refresh_field("items");
 					}
-				}
+				},
 			});
 		}
-	}
+	},
 });
 
-let calculate_age = function(birth) {
+let calculate_age = function (birth) {
 	let ageMS = Date.parse(Date()) - Date.parse(birth);
 	let age = new Date();
 	age.setTime(ageMS);
-	let years =  age.getFullYear() - 1970;
-	return `${years} ${__('Years(s)')} ${age.getMonth()} ${__('Month(s)')} ${age.getDate()} ${__('Day(s)')}`;
+	let years = age.getFullYear() - 1970;
+	return `${years} ${__("Years(s)")} ${age.getMonth()} ${__(
+		"Month(s)",
+	)} ${age.getDate()} ${__("Day(s)")}`;
 };
 
 // List Stock items
-cur_frm.set_query('item_code', 'items', function() {
+cur_frm.set_query("item_code", "items", function () {
 	return {
 		filters: {
-			is_stock_item:1
-		}
+			is_stock_item: 1,
+		},
 	};
 });
 
-let get_procedure_prescribed = function(frm) {
+let get_procedure_prescribed = function (frm) {
 	if (frm.doc.patient) {
 		show_orders(frm);
 	} else {
@@ -612,7 +640,7 @@ let get_service_request_list_html = function (data) {
 	return html;
 };
 
-let set_defaults = function(frm) {
+let set_defaults = function (frm) {
 	if (frm.is_new()) {
 		frappe.db
 			.get_single_value("Stock Settings", "default_warehouse")

--- a/healthcare/healthcare/doctype/clinical_procedure/clinical_procedure.js
+++ b/healthcare/healthcare/doctype/clinical_procedure/clinical_procedure.js
@@ -443,68 +443,173 @@ cur_frm.set_query('item_code', 'items', function() {
 	};
 });
 
-let get_procedure_prescribed = function(frm){
-	if(frm.doc.patient){
-		frappe.call({
-			method:"healthcare.healthcare.doctype.clinical_procedure.clinical_procedure.get_procedure_prescribed",
-			args: {patient: frm.doc.patient},
-			callback: function(r){
-				show_procedure_templates(frm, r.message);
-			}
-		});
-	}
-	else{
+let get_procedure_prescribed = function(frm) {
+	if (frm.doc.patient) {
+		show_orders(frm);
+	} else {
 		frappe.msgprint(__("Please select Patient to get prescribed procedure"));
 	}
 };
 
-
-let show_procedure_templates = function(frm, result){
-	var d = new frappe.ui.Dialog({
-		title: __("Prescribed Procedures"),
-		fields: [{
-				fieldtype: "HTML", fieldname: "procedure_template"
-		}]
-	});
-	var html_field = d.fields_dict.procedure_template.$wrapper;
-	html_field.empty();
-	$.each(result, function(x, y){
-		var row = $(repl(
-			'<div class="col-xs-12 row" style="padding-top:12px;">\
-				<div class="col-xs-3"> %(procedure_template)s </div>\
-				<div class="col-xs-4">%(encounter)s</div>\
-				<div class="col-xs-3"> %(date)s </div>\
-				<div class="col-xs-1">\
-				<a data-name="%(name)s" data-procedure-template="%(procedure_template)s"\
-					data-encounter="%(encounter)s" data-practitioner="%(practitioner)s"\
-					data-invoiced="%(invoiced)s" data-source="%(source)s"\
-					href="#"><button class="btn btn-default btn-xs">Get</button></a>\
-				</div>\
-			</div><hr>',
-			{ procedure_template: y[0], encounter: y[1], invoiced: y[2], practitioner: y[3], date: y[4],
-				name: y[5]})
-			).appendTo(html_field);
-			row.find("a").click(function() {
-			frm.doc.procedure_template = $(this).attr("data-procedure-template");
-			frm.doc.service_request = $(this).attr('data-name');
-			frm.doc.practitioner = $(this).attr("data-practitioner");
-			frm.doc.invoiced = 0;
-			if ($(this).attr('data-invoiced') === "Invoiced") {
-				frm.doc.invoiced = 1;
+let show_orders = function (frm) {
+	const d = new frappe.ui.Dialog({
+		title: __("Select a Service Request"),
+		fields: [
+			{
+				fieldname: "service_html",
+				fieldtype: "HTML",
+				options: `
+					<div id="service-request-list"
+						style="max-height: 420px; overflow-y: auto; padding-right: 5px;">
+						No active procedure orders found for the selected Patient
+					</div>
+				`,
+			},
+		],
+		primary_action_label: __("Select"),
+		primary_action() {
+			const selected = d.$wrapper.find('.service-row[data-selected="true"]')[0];
+			if (!selected) {
+				frappe.msgprint(__("Please select a service request."));
+				return;
 			}
-			frm.refresh_field("procedure_template");
-			frm.refresh_field("service_request");
-			frm.refresh_field("practitioner");
-			frm.refresh_field('invoiced');
+
+			const selected_id = selected.dataset.name;
+			if (selected_id) {
+				frappe.db.get_doc("Service Request", selected_id).then(doc => {
+					frm.set_value({
+						service_request: selected_id,
+						procedure_template: doc.template_dn,
+						practitioner: doc.practitioner,
+						invoiced: doc.billing_status === "Invoiced" ? 1 : 0,
+					});
+					if (doc.insurance_policy) {
+						frm.set_value("insurance_policy", doc.insurance_policy);
+						frm.set_value("insurance_payor", doc.insurance_payor);
+						frm.set_df_property("insurance_policy", "read_only", 1);
+					}
+					frm.refresh_fields();
+				});
+			}
+
 			d.hide();
-			return false;
-		});
+		},
 	});
-	if(!result || result.length < 1){
-		var msg = "There are no procedure prescribed for patient "+frm.doc.patient;
-		$(repl('<div class="text-left">%(msg)s</div>', {msg: msg})).appendTo(html_field);
-	}
 	d.show();
+
+	frappe.db
+		.get_list("Service Request", {
+			fields: [
+				"name",
+				"order_group",
+				"order_date",
+				"practitioner",
+				"practitioner_name",
+				"template_dt",
+				"template_dn",
+				"status",
+				"coverage_status",
+				"billing_status",
+			],
+			filters: {
+				patient: frm.doc.patient,
+				template_dt: "Clinical Procedure Template",
+				status: "active-Request Status",
+			},
+		})
+		.then(r => {
+			const data = r || [];
+
+			if (data.length) {
+				const html = get_service_request_list_html(data);
+				const wrapper = d.fields_dict.service_html.$wrapper;
+				wrapper.html(html);
+
+				wrapper.find(".service-row").each(function () {
+					const row = this;
+
+					row.addEventListener("mouseenter", function () {
+						if (row.dataset.selected !== "true") {
+							row.style.backgroundColor = "#fafafa";
+						}
+					});
+
+					row.addEventListener("mouseleave", function () {
+						if (row.dataset.selected !== "true") {
+							row.style.backgroundColor = "";
+						}
+					});
+
+					row.addEventListener("click", function () {
+						wrapper.find(".service-row").each(function () {
+							this.dataset.selected = "false";
+							this.style.border = "1px solid #dddaaa";
+							this.style.backgroundColor = "";
+						});
+
+						row.dataset.selected = "true";
+						row.style.border = "2px solid #afafaf";
+						row.style.backgroundColor = "#f3f3f3";
+					});
+				});
+			} else {
+				d.$wrapper.find(".modal-footer .btn-primary").hide();
+			}
+		});
+};
+
+let get_service_request_list_html = function (data) {
+	let html = `
+		<div style="max-height: 420px; overflow-y: auto; display: flex; flex-direction: column; gap: 0.5rem; padding-right: 5px;">
+	`;
+
+	data.forEach(row => {
+		// trimming the last part of template_dt (Template, Type etc)
+		const service_type = (row.template_dt || "").trim().split(" ").pop();
+
+		const coverage_status = (row.coverage_status || "").toLowerCase();
+		const status_clr = coverage_status.includes("approved")
+			? "green"
+			: coverage_status.includes("pending") ||
+			    coverage_status.includes("requested")
+			  ? "orange"
+			  : "gray";
+		const status_txt = row.coverage_status || "NA";
+
+		html += `
+			<div class="service-row"
+				data-name="${row.name}"
+				data-selected="false"
+				style="
+				border: 1px solid #dddaaa;
+				border-radius: 6px;
+				padding: 12px;
+				cursor: pointer;
+				transition: all 0.2s ease-in-out;
+			">
+				<div style="display: flex; justify-content: space-between; align-items: center;">
+					<div style="font-size: 1rem;">
+						${service_type}: <b>${row.template_dn || ""}</b>
+					</div>
+					<span class="indicator ${status_clr}">${status_txt}</span>
+				</div>
+
+				<div style="display: flex; justify-content: space-between; margin-top: 5px; font-size: 0.875rem; color: #4b4b4b;">
+					<div style="display: flex; flex-direction: column; align-items: flex-start; text-align: left;">
+						<div>${row.order_group || ""}</div>
+						<div style="color: gray;">${frappe.datetime.str_to_user(row.order_date) || ""}</div>
+					</div>
+					<div style="display: flex; flex-direction: column; align-items: flex-end; text-align: right;">
+						<div>${row.practitioner || ""}</div>
+						<div style="color: gray;">${row.practitioner_name || ""}</div>
+					</div>
+				</div>
+			</div>
+		`;
+	});
+
+	html += "</div>";
+	return html;
 };
 
 let set_defaults = function(frm) {

--- a/healthcare/healthcare/doctype/item_insurance_eligibility/item_insurance_eligibility.js
+++ b/healthcare/healthcare/doctype/item_insurance_eligibility/item_insurance_eligibility.js
@@ -25,6 +25,7 @@ frappe.ui.form.on("Item Insurance Eligibility", {
 				"Clinical Procedure Template",
 				"Therapy Type",
 				"Medication",
+				"Observation Template",
 				"Lab Test Template",
 				"Healthcare Service Unit Type",
 			];

--- a/healthcare/healthcare/doctype/item_insurance_eligibility/item_insurance_eligibility.py
+++ b/healthcare/healthcare/doctype/item_insurance_eligibility/item_insurance_eligibility.py
@@ -20,13 +20,13 @@ class ItemInsuranceEligibility(Document):
 			self.set_service_item()
 
 		if self.is_active:
-			self.validate_coverage_percentageages()
+			self.validate_percentages()
 			self.validate_dates()
 			self.validate_overlaps()
 
 		self.set_title()
 
-	def validate_coverage_percentageages(self):
+	def validate_percentages(self):
 		if self.coverage == 100:
 			self.discount = 0
 

--- a/healthcare/healthcare/doctype/medication/medication.js
+++ b/healthcare/healthcare/doctype/medication/medication.js
@@ -1,124 +1,123 @@
 // Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and contributors
 // For license information, please see license.txt
 
-frappe.ui.form.on('Medication', {
-	generic_name: function(frm) {
-		frm.set_value("abbr", frappe.get_abbr(frm.doc.generic_name))
+frappe.ui.form.on("Medication", {
+	generic_name: function (frm) {
+		frm.set_value("abbr", frappe.get_abbr(frm.doc.generic_name));
 	},
-	refresh: function(frm) {
-		frm.set_query("medication", "combinations", function() {
+	refresh: function (frm) {
+		frm.set_query("medication", "combinations", function () {
 			return {
 				filters: {
-					is_combination: false
-				}
+					is_combination: false,
+				},
 			};
 		});
-		frm.set_query("price_list", function() {
+		frm.set_query("price_list", function () {
 			return {
 				filters: {
-					selling: true
-				}
+					selling: true,
+				},
 			};
 		});
 
 		if (!frm.is_new()) {
-			frm.add_custom_button(
-				__("Browse Medication"),
-				function () {
-					frappe.route_options = {
-						medication: frm.doc.name,
-					};
-					frappe.set_route("Tree", "Medication");
-				},
-			);
+			frm.add_custom_button(__("Browse Medication"), function () {
+				frappe.route_options = {
+					medication: frm.doc.name,
+				};
+				frappe.set_route("Tree", "Medication");
+			});
 		}
 	},
 	onload: function (frm) {
 		if (frm.is_new() && !frm.doc.price_list) {
-			frappe.db.get_single_value("Selling Settings", "selling_price_list").then((price_list) => {
-				if (price_list) {
-					frm.set_value("price_list", price_list);
-				}
-			});
+			frappe.db
+				.get_single_value("Selling Settings", "selling_price_list")
+				.then(price_list => {
+					if (price_list) {
+						frm.set_value("price_list", price_list);
+					}
+				});
 		}
 	},
 	price_list: function (frm) {
 		if (!frm.is_new() && frm.doc.price_list && frm.doc.linked_items) {
-			frm.doc.linked_items.forEach((row) => {
+			frm.doc.linked_items.forEach(row => {
 				mark_change_in_item(frm, row.doctype, row.name);
 			});
 		}
-	}
+	},
 });
 
-frappe.ui.form.on('Medication Linked Item', {
+frappe.ui.form.on("Medication Linked Item", {
 	item: function (frm, cdt, cdn) {
 		let child = frappe.get_doc(cdt, cdn);
 		frappe.model.set_value(cdt, cdn, "item_code", child.item);
 
 		mark_change_in_item(frm, cdt, cdn);
 	},
-	rate: function(frm, cdt, cdn) {
+	rate: function (frm, cdt, cdn) {
 		mark_change_in_item(frm, cdt, cdn);
 	},
 
-	is_billable: function(frm, cdt, cdn) {
+	is_billable: function (frm, cdt, cdn) {
 		mark_change_in_item(frm, cdt, cdn);
 	},
 
-	item_group: function(frm, cdt, cdn) {
+	item_group: function (frm, cdt, cdn) {
 		mark_change_in_item(frm, cdt, cdn);
 	},
 
-	description: function(frm, cdt, cdn) {
+	description: function (frm, cdt, cdn) {
 		mark_change_in_item(frm, cdt, cdn);
 	},
 
-	gst_hsn_code: function(frm, cdt, cdn) {
+	gst_hsn_code: function (frm, cdt, cdn) {
 		mark_change_in_item(frm, cdt, cdn);
 	},
-})
+});
 
-let mark_change_in_item = function(frm, cdt, cdn) {
+let mark_change_in_item = function (frm, cdt, cdn) {
 	if (!frm.doc.__islocal) {
-		frappe.model.set_value(cdt, cdn, 'change_in_item', 1);
+		frappe.model.set_value(cdt, cdn, "change_in_item", 1);
 	}
 };
 
-let change_medication_code = function(doc) {
+let change_medication_code = function (doc) {
 	let d = new frappe.ui.Dialog({
-		title: __('Change Item Code'),
+		title: __("Change Item Code"),
 		fields: [
 			{
-				'fieldtype': 'Data',
-				'label': 'Item Code',
-				'fieldname': 'item_code',
-				reqd: 1
-			}
+				fieldtype: "Data",
+				label: "Item Code",
+				fieldname: "item_code",
+				reqd: 1,
+			},
 		],
-		primary_action: function() {
+		primary_action: function () {
 			let values = d.get_values();
 
 			if (values) {
 				frappe.call({
-					'method': 'healthcare.healthcare.doctype.medication.medication.change_item_code_from_medication',
-					'args': {item_code: values.item_code, doc: doc},
+					method: "healthcare.healthcare.doctype.medication.medication.change_item_code_from_medication",
+					args: { item_code: values.item_code, doc: doc },
 					callback: function () {
 						frm.reload_doc();
 						frappe.show_alert({
-							message: 'Item Code renamed successfully',
-							indicator: 'green'
+							message: "Item Code renamed successfully",
+							indicator: "green",
 						});
-					}
+					},
 				});
 			}
 			d.hide();
 		},
-		primary_action_label: __('Change Item Code')
+		primary_action_label: __("Change Item Code"),
 	});
 	d.show();
 
 	d.set_values({
-		'item_code': doc.item_code
+		item_code: doc.item_code,
 	});
 };

--- a/healthcare/healthcare/doctype/medication/medication.js
+++ b/healthcare/healthcare/doctype/medication/medication.js
@@ -52,6 +52,12 @@ frappe.ui.form.on('Medication', {
 });
 
 frappe.ui.form.on('Medication Linked Item', {
+	item: function (frm, cdt, cdn) {
+		let child = frappe.get_doc(cdt, cdn);
+		frappe.model.set_value(cdt, cdn, "item_code", child.item);
+
+		mark_change_in_item(frm, cdt, cdn);
+	},
 	rate: function(frm, cdt, cdn) {
 		mark_change_in_item(frm, cdt, cdn);
 	},

--- a/healthcare/healthcare/doctype/medication/medication.json
+++ b/healthcare/healthcare/doctype/medication/medication.json
@@ -154,8 +154,6 @@
    "fieldtype": "Column Break"
   },
   {
-   "collapsible": 1,
-   "collapsible_depends_on": "!doc.__islocal",
    "description": "Properties of the linked Item, you may further configure Batch Number and Expiry, Serial Number, Shelf Life etc. in the Item master",
    "fieldname": "item_details",
    "fieldtype": "Section Break",
@@ -168,7 +166,6 @@
    "options": "Role"
   },
   {
-   "collapsible": 1,
    "depends_on": "is_combination",
    "fieldname": "combinations_section",
    "fieldtype": "Section Break",

--- a/healthcare/healthcare/doctype/medication_linked_item/medication_linked_item.json
+++ b/healthcare/healthcare/doctype/medication_linked_item/medication_linked_item.json
@@ -7,8 +7,8 @@
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
-  "item_code",
   "item",
+  "item_code",
   "item_group",
   "stock_uom",
   "brand",
@@ -42,6 +42,7 @@
    "label": "Rate"
   },
   {
+   "description": "Set if you want to create a new Item",
    "fieldname": "item_code",
    "fieldtype": "Data",
    "in_list_view": 1,
@@ -71,13 +72,13 @@
    "options": "UOM"
   },
   {
+   "description": "Select if you want to chose an existing Item",
    "fieldname": "item",
    "fieldtype": "Link",
    "in_list_view": 1,
    "label": "Item",
    "no_copy": 1,
-   "options": "Item",
-   "read_only": 1
+   "options": "Item"
   },
   {
    "fieldname": "column_break_p72x",


### PR DESCRIPTION
## Summary

Syncs 4 substantive upstream [earthians/marley](https://github.com/earthians/marley) PRs into `biograph-fh`, cherry-picked/manually merged to preserve biograph-specific customizations.

**Included upstream PRs:**
| PR | Change |
|---|---|
| [#930](https://github.com/earthians/marley/pull/930) | Medication linked Item — reorder fields, add descriptions, allow selecting existing Item (syncs `item_code` automatically) |
| [#933](https://github.com/earthians/marley/pull/933) | Allow creating insurance eligibility for Observation Templates |
| [#934](https://github.com/earthians/marley/pull/934) | Fix `validate_coverage_percentageages` → `validate_percentages` typo |
| [#936](https://github.com/earthians/marley/pull/936) | Replace old prescribed-procedures dialog with Service Request-based UI in Clinical Procedure |

**Intentionally skipped:**
- **PR #934 partial (commit f1500dae)** — removal of `get_procedure_from_encounter`, `show_procedure_templates`, and `show_therapy_types` from `patient_appointment.js`. Biograph still uses these functions (including a heavily customized `show_therapy_types` with checkboxes/table UI). Removing them would break the appointment form.
- **PR #949** — workspace title fix. Biograph already has the correct `"Healthcare"` title.

**Note:** `clinical_procedure.js` and `medication.js` were auto-reformatted by prettier (pre-commit hook), making the diff noisy. The actual logic changes are small.

## Review & Testing Checklist for Human

- [ ] **Verify `show_orders` Service Request filter syntax**: The new Clinical Procedure dialog filters with `status: "active-Request Status"` — confirm this is a valid Frappe filter value that returns the expected active service requests for a patient
- [ ] **Verify `insurance_policy`/`insurance_payor` fields exist on Service Request**: The new dialog reads these fields from the fetched Service Request doc to propagate insurance info. If Service Request doesn't have these fields in biograph, the code silently no-ops but won't set insurance data
- [ ] **Verify no other code calls `validate_coverage_percentageages`**: The method was renamed to `validate_percentages` — confirm nothing else references the old name
- [ ] **Test Medication Linked Item flow**: Open a Medication, add a linked item by selecting an existing Item — confirm `item_code` auto-populates from the selected Item
- [ ] **Test "Get from Patient Encounter" on Clinical Procedure**: Create a new Clinical Procedure, select a patient with active Service Requests, click "Get from Patient Encounter" — verify the new card-based dialog loads and selecting a request populates the form correctly

### Notes
- The old `get_procedure_prescribed` Python server method (`clinical_procedure.py`) is still present — the JS now just doesn't call it directly (uses `frappe.db.get_list` client-side instead). You may want to deprecate/remove the Python method separately if it's no longer needed.
- The old `show_procedure_templates` / `show_therapy_types` functions in `patient_appointment.js` are intentionally preserved to avoid breaking biograph's custom therapy selection workflow.

Link to Devin session: https://app.devin.ai/sessions/db8e0d1b2da54f058c210d03251677e6
Requested by: @pythonpen
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tacten/biograph/pull/247" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
