### PR TITLE
fix: add missing `practitioner` field to Therapy Plan doctype

### DIFF
--- a/healthcare/healthcare/doctype/therapy_plan/therapy_plan.json
+++ b/healthcare/healthcare/doctype/therapy_plan/therapy_plan.json
@@ -16,6 +16,7 @@
   "invoiced",
   "column_break_4",
   "company",
+  "practitioner",
   "status",
   "start_date",
   "section_break_3",
@@ -121,6 +122,12 @@
    "label": "Company",
    "options": "Company",
    "reqd": 1
+  },
+  {
+   "fieldname": "practitioner",
+   "fieldtype": "Link",
+   "label": "Healthcare Practitioner",
+   "options": "Healthcare Practitioner"
   },
   {
    "fieldname": "therapy_plan_template",


### PR DESCRIPTION
## Summary

The `make_sales_invoice` function in `therapy_plan.py` (line 252) queries `frappe.db.get_value("Therapy Plan", reference_name, "practitioner")`, but the `practitioner` column does not exist on the Therapy Plan doctype schema — causing:

```
MySQLdb.OperationalError: (1054, "Unknown column 'practitioner' in 'SELECT'")
```

This PR adds the missing `practitioner` Link field (→ Healthcare Practitioner) to `therapy_plan.json`, placed after the `company` field. The column will be created on the next `bench migrate`.

## Review & Testing Checklist for Human

- [ ] **Run `bench migrate`** on a site with existing Therapy Plan data and confirm the column is created without errors
- [ ] **Test the "Create > Sales Invoice" button** on an existing Therapy Plan (e.g. `HLC-THP-2026-01026`) — the original crash path. Verify the invoice is created successfully
- [ ] **Verify `get_income_account(None, company)` behavior**: Existing Therapy Plans will have `practitioner = NULL`. Confirm that `make_sales_invoice` still works when practitioner is not set (lines 272, 284 pass `si.ref_practitioner` to `get_income_account`)
- [ ] **Check the "Create > Clinical Note" button** — `therapy_plan.js:106` also reads `frm.doc.practitioner`; confirm it degrades gracefully when empty
- [ ] **Consider backfilling**: Decide if existing Therapy Plans need their `practitioner` field populated (e.g., via a patch or manual update) for correct income account assignment on future invoices

### Notes
- The field is optional (not `reqd`) so it won't block saving existing records
- The Therapy Session doctype already has an identical `practitioner` Link field, so this is consistent with the data model
- The JS code (`therapy_plan.js:106`) and the `make_patient_appointment` mapper (`field_no_map: ["practitioner"]`) both expect this field to exist, confirming it was likely removed from the schema by mistake

Link to Devin session: https://app.devin.ai/sessions/d3475c3be2524522a3fc31ee31b8554a
Requested by: @pythonpen