### PR TITLE
fix: handle NULL appointment_date/appointment_time in calendar get_events

### DIFF
--- a/healthcare/healthcare/doctype/patient_appointment/patient_appointment.py
+++ b/healthcare/healthcare/doctype/patient_appointment/patient_appointment.py
@@ -1547,6 +1547,8 @@ def get_events(start, end, filters=None):
 		left join `tabAppointment Type` on `tabPatient Appointment`.appointment_type=`tabAppointment Type`.name
 		where
 		(`tabPatient Appointment`.appointment_date between %(start)s and %(end)s)
+		and `tabPatient Appointment`.appointment_date is not null
+		and `tabPatient Appointment`.appointment_time is not null
 		and `tabPatient Appointment`.status != 'Cancelled' and `tabPatient Appointment`.docstatus < 2 {conditions}""".format(
 			conditions=conditions
 		),
@@ -1556,6 +1558,8 @@ def get_events(start, end, filters=None):
 	)
 
 	for item in data:
+		if item.start is None or item.duration is None:
+			continue
 		item.end = item.start + timedelta(minutes=item.duration)
 		
 		# Special handling for unavailability appointments


### PR DESCRIPTION
## Summary

Fixes `TypeError: unsupported operand type(s) for +: 'NoneType' and 'datetime.timedelta'` when opening the Patient Appointment calendar view.

The root cause is that some `Patient Appointment` records have NULL `appointment_date` or `appointment_time` fields. When `get_events()` builds calendar data, it computes `end = start + timedelta(minutes=duration)`, which throws a `TypeError` when `start` is `None`.

**Two layers of fix applied:**
1. **SQL filter** — adds `appointment_date IS NOT NULL` and `appointment_time IS NOT NULL` to the WHERE clause so bad records are never fetched.
2. **Python guard** — skips any record where `start` or `duration` is `None` before the arithmetic, as defense-in-depth.

## Review & Testing Checklist for Human

- [ ] **Verify that appointments with NULL `appointment_time` should be hidden from the calendar.** The fix silently excludes them. If they should instead appear with a default time (e.g., midnight), the approach needs adjustment.
- [ ] **Identify and backfill the Patient Appointment records that have NULL `appointment_date`/`appointment_time`.** This fix prevents the crash but does not repair the underlying bad data — those appointments will simply not appear on the calendar.
- [ ] **Test the calendar view** by navigating to the Patient Appointment calendar for a date range that previously triggered the error and confirming it loads without errors and displays the expected appointments.

### Notes
- `appointment_date` is marked `reqd: 1` in the DocType JSON, but `appointment_time` is only conditionally mandatory (`mandatory_depends_on`), so NULL time values can legitimately exist.
- The `appointment_date IS NOT NULL` SQL clause is technically redundant with the existing `BETWEEN` filter, but is included for clarity and safety.
- No existing appointments are modified by this change — it only affects the calendar query endpoint.

Link to Devin session: https://app.devin.ai/sessions/9a3941f3cafa4100b20ba4811d0453e5
Requested by: @pythonpen