### PR TITLE
fix: add missing `country` field to Patient DocType

### DIFF
--- a/healthcare/healthcare/doctype/patient/patient.json
+++ b/healthcare/healthcare/doctype/patient/patient.json
@@ -36,6 +36,7 @@
   "customer",
   "customer_group",
   "territory",
+  "country",
   "column_break_24",
   "default_currency",
   "default_price_list",
@@ -411,6 +412,12 @@
    "fieldtype": "Link",
    "label": "Territory",
    "options": "Territory"
+  },
+  {
+   "fieldname": "country",
+   "fieldtype": "Link",
+   "label": "Country",
+   "options": "Country"
   },
   {
    "fieldname": "column_break_24",

--- a/healthcare/healthcare/doctype/patient_insurance_policy/patient_insurance_policy.json
+++ b/healthcare/healthcare/doctype/patient_insurance_policy/patient_insurance_policy.json
@@ -22,7 +22,6 @@
   "column_break_8",
   "email",
   "mobile_number",
-  "country",
   "insurance_details_section",
   "insurance_payor",
   "policy_expiry_date",
@@ -133,15 +132,6 @@
    "fieldname": "birth_date",
    "fieldtype": "Date",
    "label": "Birth Date",
-   "read_only": 1
-  },
-  {
-   "depends_on": "patient",
-   "fetch_from": "patient.country",
-   "fieldname": "country",
-   "fieldtype": "Link",
-   "label": "Country",
-   "options": "Country",
    "read_only": 1
   },
   {

--- a/healthcare/healthcare/doctype/patient_insurance_policy/patient_insurance_policy.json
+++ b/healthcare/healthcare/doctype/patient_insurance_policy/patient_insurance_policy.json
@@ -22,6 +22,7 @@
   "column_break_8",
   "email",
   "mobile_number",
+  "country",
   "insurance_details_section",
   "insurance_payor",
   "policy_expiry_date",
@@ -132,6 +133,15 @@
    "fieldname": "birth_date",
    "fieldtype": "Date",
    "label": "Birth Date",
+   "read_only": 1
+  },
+  {
+   "depends_on": "patient",
+   "fetch_from": "patient.country",
+   "fieldname": "country",
+   "fieldtype": "Link",
+   "label": "Country",
+   "options": "Country",
    "read_only": 1
   },
   {


### PR DESCRIPTION
## Summary

The Patient Insurance Policy DocType defines a `country` field with `fetch_from: "patient.country"`, but the Patient DocType was missing the source `country` field. This mismatch causes the database column on `tabPatient Insurance Policy` to fail to sync during `bench migrate`.

**Root cause:** The upstream marley `version-16` branch has a `country` field on both the Patient DocType and the Patient Insurance Policy DocType. Biograph's `biograph-fh` branch had the Insurance Policy side but was missing the Patient side.

**Fix:** Added a `country` Link field (options: `Country`) to the Patient DocType in the Customer Details section, after `territory` — matching the upstream marley `version-16` definition exactly.

## Review & Testing Checklist for Human

- [ ] Run `bench migrate` on a test site and confirm the `country` column is created on `tabPatient` without errors
- [ ] Open a Patient form and verify the Country field appears in the Customer Details section
- [ ] Create or edit a Patient Insurance Policy, select a Patient with a country set, and confirm the `country` field auto-populates via `fetch_from`
- [ ] Verify no regressions on Patient list views, filters, or reports (field is not indexed or in standard filters, so impact should be minimal)

### Notes
- Existing Patient records will have an empty `country` value after migration — this is expected and can be backfilled as needed.
- The upstream marley `version-16` Patient `country` field has no extra attributes (`reqd`, `in_standard_filter`, etc.), and this PR matches that definition exactly.
- Initially the fix removed the `country` field from Patient Insurance Policy (based on checking against marley `version-15`, which lacks Insurance DocTypes entirely). After re-checking against `version-16`, the approach was corrected to add the missing field to Patient instead.

Link to Devin session: https://app.devin.ai/sessions/ca3066a2b1a5462483a63948efd5dfc7
Requested by: @pythonpen