### PR TITLE
feat: add Code Value Set support to Codification Table (port of earthians/marley#953)

### DIFF
--- a/healthcare/healthcare/doctype/appointment_type/appointment_type.js
+++ b/healthcare/healthcare/doctype/appointment_type/appointment_type.js
@@ -58,6 +58,16 @@ frappe.ui.form.on("Appointment Type", {
 				},
 			};
 		});
+		frappe.require("assets/healthcare/js/utils.js", function () {
+			healthcare.utils.set_codification_table_query(frm);
+		});
+	},
+
+	before_save: async function (frm) {
+		await new Promise(function (resolve) {
+			frappe.require("assets/healthcare/js/utils.js", resolve);
+		});
+		await healthcare.utils.before_save_check(frm);
 	},
 });
 
@@ -114,5 +124,29 @@ frappe.ui.form.on("Appointment Type Service Item", {
 				},
 			});
 		}
+	},
+});
+
+frappe.ui.form.on("Codification Table", {
+	code_value_set: function (frm, cdt, cdn) {
+		frappe.require("assets/healthcare/js/utils.js", function () {
+			healthcare.utils.set_codification_table_query(frm);
+		});
+	},
+	code_system: function (frm, cdt, cdn) {
+		frappe.require("assets/healthcare/js/utils.js", function () {
+			healthcare.utils.set_codification_table_query(frm);
+		});
+	},
+	code_value: function (frm, cdt, cdn) {
+		var row = locals[cdt][cdn];
+		if (!row.code_value_set) {
+			frappe.require("assets/healthcare/js/utils.js", function () {
+				healthcare.utils.auto_table_code_val_set(frm, cdt, cdn);
+			});
+		}
+		frappe.require("assets/healthcare/js/utils.js", function () {
+			healthcare.utils.set_codification_table_query(frm);
+		});
 	},
 });

--- a/healthcare/healthcare/doctype/clinical_procedure/clinical_procedure.js
+++ b/healthcare/healthcare/doctype/clinical_procedure/clinical_procedure.js
@@ -181,6 +181,18 @@ frappe.ui.form.on("Clinical Procedure", {
 			},
 			__("Create"),
 		);
+
+		frm.trigger("procedure_template");
+		frappe.require("assets/healthcare/js/utils.js", function () {
+			healthcare.utils.set_codification_table_query(frm);
+		});
+	},
+
+	before_save: async function (frm) {
+		await new Promise(function (resolve) {
+			frappe.require("assets/healthcare/js/utils.js", resolve);
+		});
+		await healthcare.utils.before_save_check(frm);
 	},
 
 	onload: function (frm) {
@@ -391,6 +403,7 @@ frappe.ui.form.on("Clinical Procedure", {
 							child.code = val.code;
 							child.description = val.description;
 							child.system = val.system;
+							child.code_value_set = val.code_value_set;
 						}
 					});
 					frm.refresh_field("codification_table");
@@ -639,6 +652,30 @@ let get_service_request_list_html = function (data) {
 	html += "</div>";
 	return html;
 };
+
+frappe.ui.form.on("Codification Table", {
+	code_value_set: function (frm, cdt, cdn) {
+		frappe.require("assets/healthcare/js/utils.js", function () {
+			healthcare.utils.set_codification_table_query(frm);
+		});
+	},
+	code_system: function (frm, cdt, cdn) {
+		frappe.require("assets/healthcare/js/utils.js", function () {
+			healthcare.utils.set_codification_table_query(frm);
+		});
+	},
+	code_value: function (frm, cdt, cdn) {
+		var row = locals[cdt][cdn];
+		if (!row.code_value_set) {
+			frappe.require("assets/healthcare/js/utils.js", function () {
+				healthcare.utils.auto_table_code_val_set(frm, cdt, cdn);
+			});
+		}
+		frappe.require("assets/healthcare/js/utils.js", function () {
+			healthcare.utils.set_codification_table_query(frm);
+		});
+	},
+});
 
 let set_defaults = function (frm) {
 	if (frm.is_new()) {

--- a/healthcare/healthcare/doctype/clinical_procedure_template/clinical_procedure_template.js
+++ b/healthcare/healthcare/doctype/clinical_procedure_template/clinical_procedure_template.js
@@ -1,7 +1,7 @@
 // Copyright (c) 2017, earthians and contributors
 // For license information, please see license.txt
 
-frappe.ui.form.on('Clinical Procedure Template', {
+frappe.ui.form.on("Clinical Procedure Template", {
 	setup: function (frm) {
 		if (frappe.meta.has_field(frm.doc.doctype, "gst_hsn_code")) {
 			frm.add_fetch("item", "gst_hsn_code", "gst_hsn_code");
@@ -9,133 +9,166 @@ frappe.ui.form.on('Clinical Procedure Template', {
 	},
 
 	template: function (frm) {
-		if (!frm.doc.item_code)
-			frm.set_value('item_code', frm.doc.template);
-		if (!frm.doc.description)
-			frm.set_value('description', frm.doc.template);
+		if (!frm.doc.item_code) frm.set_value("item_code", frm.doc.template);
+		if (!frm.doc.description) frm.set_value("description", frm.doc.template);
 	},
 
-
 	refresh: function (frm) {
-		frm.fields_dict['items'].grid.set_column_disp('barcode', false);
-		frm.fields_dict['items'].grid.set_column_disp('batch_no', false);
+		frm.fields_dict["items"].grid.set_column_disp("barcode", false);
+		frm.fields_dict["items"].grid.set_column_disp("batch_no", false);
 
 		if (!frm.doc.__islocal) {
-			cur_frm.add_custom_button(__('Change Item Code'), function () {
+			cur_frm.add_custom_button(__("Change Item Code"), function () {
 				change_template_code(frm.doc);
 			});
 		}
 
-		frm.set_query('item', function() {
+		frm.set_query("item", function () {
 			return {
 				filters: {
-					'disabled': false,
-					'is_stock_item': false
-				}
+					disabled: false,
+					is_stock_item: false,
+				},
 			};
 		});
 
-		frm.set_query("code_value", "codification_table", function(doc, cdt, cdn) {
+		frm.set_query("code_value", "codification_table", function (doc, cdt, cdn) {
 			let row = frappe.get_doc(cdt, cdn);
 			if (row.code_system) {
 				return {
 					filters: {
-						code_system: row.code_system
-					}
+						code_system: row.code_system,
+					},
 				};
 			}
-		})
+		});
 
-		frm.set_query('staff_role', function () {
+		frm.set_query("staff_role", function () {
 			return {
 				filters: {
-					'restrict_to_domain': 'Healthcare'
-				}
+					restrict_to_domain: "Healthcare",
+				},
 			};
 		});
+
+		frappe.require("assets/healthcare/js/utils.js", function () {
+			healthcare.utils.set_codification_table_query(frm);
+		});
+	},
+
+	before_save: async function (frm) {
+		await new Promise(function (resolve) {
+			frappe.require("assets/healthcare/js/utils.js", resolve);
+		});
+		await healthcare.utils.before_save_check(frm);
 	},
 
 	link_existing_item: function (frm) {
 		if (frm.doc.link_existing_item) {
-			frm.set_value('item_code', '');
+			frm.set_value("item_code", "");
 		} else {
-			frm.set_value('item', '');
+			frm.set_value("item", "");
 		}
 	},
 
 	item: function (frm) {
 		if (frm.doc.item) {
-			frappe.db.get_value('Item', frm.doc.item, ['item_group', 'description'])
-			.then(r => {
-				frm.set_value({
-					'item_group': r.message.item_group,
-					'description': r.message.description,
-					'item_code': frm.doc.item
+			frappe.db
+				.get_value("Item", frm.doc.item, ["item_group", "description"])
+				.then(r => {
+					frm.set_value({
+						item_group: r.message.item_group,
+						description: r.message.description,
+						item_code: frm.doc.item,
+					});
 				});
-			})
 		}
-	}
+	},
 });
 
 let change_template_code = function (doc) {
 	let d = new frappe.ui.Dialog({
-		title: __('Change Item Code'),
+		title: __("Change Item Code"),
 		fields: [
 			{
-				'fieldtype': 'Data',
-				'label': 'Item Code',
-				'fieldname': 'item_code',
-				reqd: 1
-			}
+				fieldtype: "Data",
+				label: "Item Code",
+				fieldname: "item_code",
+				reqd: 1,
+			},
 		],
 		primary_action: function () {
 			let values = d.get_values();
 
 			if (values) {
 				frappe.call({
-					'method': 'healthcare.healthcare.doctype.clinical_procedure_template.clinical_procedure_template.change_item_code_from_template',
-					'args': { item_code: values.item_code, doc: doc },
+					method: "healthcare.healthcare.doctype.clinical_procedure_template.clinical_procedure_template.change_item_code_from_template",
+					args: { item_code: values.item_code, doc: doc },
 					callback: function () {
 						cur_frm.reload_doc();
 						frappe.show_alert({
-							message: 'Item Code renamed successfully',
-							indicator: 'green'
+							message: "Item Code renamed successfully",
+							indicator: "green",
 						});
-					}
+					},
 				});
 			}
 			d.hide();
 		},
-		primary_action_label: __('Change Item Code')
+		primary_action_label: __("Change Item Code"),
 	});
 	d.show();
 
 	d.set_values({
-		'item_code': doc.item_code
+		item_code: doc.item_code,
 	});
 };
 
-frappe.ui.form.on('Clinical Procedure Item', {
+frappe.ui.form.on("Codification Table", {
+	code_value_set: function (frm, cdt, cdn) {
+		frappe.require("assets/healthcare/js/utils.js", function () {
+			healthcare.utils.set_codification_table_query(frm);
+		});
+	},
+	code_system: function (frm, cdt, cdn) {
+		frappe.require("assets/healthcare/js/utils.js", function () {
+			healthcare.utils.set_codification_table_query(frm);
+		});
+	},
+	code_value: function (frm, cdt, cdn) {
+		var row = locals[cdt][cdn];
+		if (!row.code_value_set) {
+			frappe.require("assets/healthcare/js/utils.js", function () {
+				healthcare.utils.auto_table_code_val_set(frm, cdt, cdn);
+			});
+		}
+		frappe.require("assets/healthcare/js/utils.js", function () {
+			healthcare.utils.set_codification_table_query(frm);
+		});
+	},
+});
+
+frappe.ui.form.on("Clinical Procedure Item", {
 	qty: function (frm, cdt, cdn) {
 		let d = locals[cdt][cdn];
-		frappe.model.set_value(cdt, cdn, 'transfer_qty', d.qty * d.conversion_factor);
+		frappe.model.set_value(cdt, cdn, "transfer_qty", d.qty * d.conversion_factor);
 	},
 
 	uom: function (doc, cdt, cdn) {
 		let d = locals[cdt][cdn];
 		if (d.uom && d.item_code) {
 			return frappe.call({
-				method: 'erpnext.stock.doctype.stock_entry.stock_entry.get_uom_details',
+				method: "erpnext.stock.doctype.stock_entry.stock_entry.get_uom_details",
 				args: {
 					item_code: d.item_code,
 					uom: d.uom,
-					qty: d.qty
+					qty: d.qty,
 				},
 				callback: function (r) {
 					if (r.message) {
 						frappe.model.set_value(cdt, cdn, r.message);
 					}
-				}
+				},
 			});
 		}
 	},
@@ -144,12 +177,12 @@ frappe.ui.form.on('Clinical Procedure Item', {
 		let d = locals[cdt][cdn];
 		if (d.item_code) {
 			let args = {
-				'item_code': d.item_code,
-				'transfer_qty': d.transfer_qty,
-				'quantity': d.qty
+				item_code: d.item_code,
+				transfer_qty: d.transfer_qty,
+				quantity: d.qty,
 			};
 			return frappe.call({
-				method: 'healthcare.healthcare.doctype.clinical_procedure_template.clinical_procedure_template.get_item_details',
+				method: "healthcare.healthcare.doctype.clinical_procedure_template.clinical_procedure_template.get_item_details",
 				args: { args: args },
 				callback: function (r) {
 					if (r.message) {
@@ -157,52 +190,61 @@ frappe.ui.form.on('Clinical Procedure Item', {
 						$.each(r.message, function (k, v) {
 							d[k] = v;
 						});
-						refresh_field('items');
+						refresh_field("items");
 					}
-				}
+				},
 			});
 		}
-	}
+	},
 });
 
 // List Stock items
-cur_frm.set_query('item_code', 'items', function () {
+cur_frm.set_query("item_code", "items", function () {
 	return {
 		filters: {
-			is_stock_item: 1
-		}
+			is_stock_item: 1,
+		},
 	};
 });
 
-frappe.tour['Clinical Procedure Template'] = [
+frappe.tour["Clinical Procedure Template"] = [
 	{
-		fieldname: 'template',
-		title: __('Template Name'),
-		description: __('Enter a name for the Clinical Procedure Template')
+		fieldname: "template",
+		title: __("Template Name"),
+		description: __("Enter a name for the Clinical Procedure Template"),
 	},
 	{
-		fieldname: 'item_code',
-		title: __('Item Code'),
-		description: __('Set the Item Code which will be used for billing the Clinical Procedure.')
+		fieldname: "item_code",
+		title: __("Item Code"),
+		description: __(
+			"Set the Item Code which will be used for billing the Clinical Procedure.",
+		),
 	},
 	{
-		fieldname: 'item_group',
-		title: __('Item Group'),
-		description: __('Select an Item Group for the Clinical Procedure Item.')
+		fieldname: "item_group",
+		title: __("Item Group"),
+		description: __("Select an Item Group for the Clinical Procedure Item."),
 	},
 	{
-		fieldname: 'is_billable',
-		title: __('Clinical Procedure Rate'),
-		description: __('Check this if the Clinical Procedure is billable and also set the rate.')
+		fieldname: "is_billable",
+		title: __("Clinical Procedure Rate"),
+		description: __(
+			"Check this if the Clinical Procedure is billable and also set the rate.",
+		),
 	},
 	{
-		fieldname: 'consume_stock',
-		title: __('Allow Stock Consumption'),
-		description: __('Check this if the Clinical Procedure utilises consumables. Click ') + "<a href='https://frappehealth.com/docs/v13/user/manual/en/healthcare/clinical_procedure_template#22-manage-procedure-consumables' target='_blank'>here</a>" + __(' to know more')
+		fieldname: "consume_stock",
+		title: __("Allow Stock Consumption"),
+		description:
+			__("Check this if the Clinical Procedure utilises consumables. Click ") +
+			"<a href='https://frappehealth.com/docs/v13/user/manual/en/healthcare/clinical_procedure_template#22-manage-procedure-consumables' target='_blank'>here</a>" +
+			__(" to know more"),
 	},
 	{
-		fieldname: 'medical_department',
-		title: __('Medical Department'),
-		description: __('You can also set the Medical Department for the template. After saving the document, an Item will automatically be created for billing this Clinical Procedure. You can then use this template while creating Clinical Procedures for Patients. Templates save you from filling up redundant data every single time. You can also create templates for other operations like Lab Tests, Therapy Sessions, etc.')
-	}
+		fieldname: "medical_department",
+		title: __("Medical Department"),
+		description: __(
+			"You can also set the Medical Department for the template. After saving the document, an Item will automatically be created for billing this Clinical Procedure. You can then use this template while creating Clinical Procedures for Patients. Templates save you from filling up redundant data every single time. You can also create templates for other operations like Lab Tests, Therapy Sessions, etc.",
+		),
+	},
 ];

--- a/healthcare/healthcare/doctype/codification_table/codification_table.json
+++ b/healthcare/healthcare/doctype/codification_table/codification_table.json
@@ -15,6 +15,7 @@
   "code_value",
   "code",
   "display",
+  "code_value_set",
   "section_break_5",
   "definition"
  ],
@@ -84,6 +85,13 @@
    "in_list_view": 1,
    "label": "Display",
    "read_only": 1
+  },
+  {
+   "fieldname": "code_value_set",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Code Value Set",
+   "options": "Code Value Set"
   },
   {
    "fieldname": "section_break_5",

--- a/healthcare/healthcare/doctype/diagnosis/diagnosis.js
+++ b/healthcare/healthcare/doctype/diagnosis/diagnosis.js
@@ -13,5 +13,40 @@ frappe.ui.form.on("Diagnosis", {
 				};
 			}
 		});
+
+		frappe.require("assets/healthcare/js/utils.js", function () {
+			healthcare.utils.set_codification_table_query(frm);
+		});
+	},
+
+	before_save: async function (frm) {
+		await new Promise(function (resolve) {
+			frappe.require("assets/healthcare/js/utils.js", resolve);
+		});
+		await healthcare.utils.before_save_check(frm);
+	},
+});
+
+frappe.ui.form.on("Codification Table", {
+	code_value_set: function (frm, cdt, cdn) {
+		frappe.require("assets/healthcare/js/utils.js", function () {
+			healthcare.utils.set_codification_table_query(frm);
+		});
+	},
+	code_system: function (frm, cdt, cdn) {
+		frappe.require("assets/healthcare/js/utils.js", function () {
+			healthcare.utils.set_codification_table_query(frm);
+		});
+	},
+	code_value: function (frm, cdt, cdn) {
+		var row = locals[cdt][cdn];
+		if (!row.code_value_set) {
+			frappe.require("assets/healthcare/js/utils.js", function () {
+				healthcare.utils.auto_table_code_val_set(frm, cdt, cdn);
+			});
+		}
+		frappe.require("assets/healthcare/js/utils.js", function () {
+			healthcare.utils.set_codification_table_query(frm);
+		});
 	},
 });

--- a/healthcare/healthcare/doctype/lab_test/lab_test.js
+++ b/healthcare/healthcare/doctype/lab_test/lab_test.js
@@ -2,74 +2,97 @@
 // For license information, please see license.txt
 
 cur_frm.cscript.custom_refresh = function (doc) {
-	cur_frm.toggle_display('sb_sensitivity', doc.sensitivity_toggle);
-	cur_frm.toggle_display('organisms_section', doc.descriptive_toggle);
-	cur_frm.toggle_display('sb_descriptive', doc.descriptive_toggle);
-	cur_frm.toggle_display('sb_normal', doc.normal_toggle);
-	cur_frm.toggle_display('sb_descriptive_result', doc.imaging_toggle);
+	cur_frm.toggle_display("sb_sensitivity", doc.sensitivity_toggle);
+	cur_frm.toggle_display("organisms_section", doc.descriptive_toggle);
+	cur_frm.toggle_display("sb_descriptive", doc.descriptive_toggle);
+	cur_frm.toggle_display("sb_normal", doc.normal_toggle);
+	cur_frm.toggle_display("sb_descriptive_result", doc.imaging_toggle);
 };
 
-frappe.ui.form.on('Lab Test', {
+frappe.ui.form.on("Lab Test", {
 	setup: function (frm) {
-		frm.get_field('normal_test_items').grid.editable_fields = [
-			{ fieldname: 'lab_test_name', columns: 3 },
-			{ fieldname: 'lab_test_event', columns: 2 },
-			{ fieldname: 'result_value', columns: 2 },
-			{ fieldname: 'lab_test_uom', columns: 1 },
-			{ fieldname: 'normal_range', columns: 2 }
+		frm.get_field("normal_test_items").grid.editable_fields = [
+			{ fieldname: "lab_test_name", columns: 3 },
+			{ fieldname: "lab_test_event", columns: 2 },
+			{ fieldname: "result_value", columns: 2 },
+			{ fieldname: "lab_test_uom", columns: 1 },
+			{ fieldname: "normal_range", columns: 2 },
 		];
-		frm.get_field('descriptive_test_items').grid.editable_fields = [
-			{ fieldname: 'lab_test_particulars', columns: 3 },
-			{ fieldname: 'result_value', columns: 7 }
+		frm.get_field("descriptive_test_items").grid.editable_fields = [
+			{ fieldname: "lab_test_particulars", columns: 3 },
+			{ fieldname: "result_value", columns: 7 },
 		];
 
-		frm.set_query('service_request', function() {
+		frm.set_query("service_request", function () {
 			return {
 				filters: {
-					'patient': frm.doc.patient,
-					'status': 'Active',
-					'docstatus': 1,
-					'template_dt': 'Lab Test template'
-				}
+					patient: frm.doc.patient,
+					status: "Active",
+					docstatus: 1,
+					template_dt: "Lab Test template",
+				},
 			};
 		});
 	},
 
 	refresh: function (frm) {
-		refresh_field('normal_test_items');
-		refresh_field('descriptive_test_items');
+		refresh_field("normal_test_items");
+		refresh_field("descriptive_test_items");
 		if (frm.doc.__islocal) {
-			frm.add_custom_button(__('Get from Patient Encounter'), function () {
+			frm.add_custom_button(__("Get from Patient Encounter"), function () {
 				get_lab_test_prescribed(frm);
 			});
 		}
 
-		frm.set_query("code_value", "codification_table", function(doc, cdt, cdn) {
+		frm.set_query("code_value", "codification_table", function (doc, cdt, cdn) {
 			let row = frappe.get_doc(cdt, cdn);
 			if (row.code_system) {
 				return {
 					filters: {
-						code_system: row.code_system
-					}
+						code_system: row.code_system,
+					},
 				};
 			}
 		});
 
-		if (frappe.defaults.get_default('lab_test_approval_required') && frappe.user.has_role('LabTest Approver')) {
-			if (frm.doc.docstatus === 1 && frm.doc.status !== 'Approved' && frm.doc.status !== 'Rejected') {
-				frm.add_custom_button(__('Approve'), function () {
-					status_update(1, frm);
-				}, __('Actions'));
-				frm.add_custom_button(__('Reject'), function () {
-					status_update(0, frm);
-				}, __('Actions'));
+		frappe.require("assets/healthcare/js/utils.js", function () {
+			healthcare.utils.set_codification_table_query(frm);
+		});
+
+		if (
+			frappe.defaults.get_default("lab_test_approval_required") &&
+			frappe.user.has_role("LabTest Approver")
+		) {
+			if (
+				frm.doc.docstatus === 1 &&
+				frm.doc.status !== "Approved" &&
+				frm.doc.status !== "Rejected"
+			) {
+				frm.add_custom_button(
+					__("Approve"),
+					function () {
+						status_update(1, frm);
+					},
+					__("Actions"),
+				);
+				frm.add_custom_button(
+					__("Reject"),
+					function () {
+						status_update(0, frm);
+					},
+					__("Actions"),
+				);
 			}
 		}
 
-		if (frm.doc.docstatus === 1 && frm.doc.sms_sent === 0 && frm.doc.status !== 'Rejected' ) {
-			frm.add_custom_button(__('Send SMS'), function () {
+		if (
+			frm.doc.docstatus === 1 &&
+			frm.doc.sms_sent === 0 &&
+			frm.doc.status !== "Rejected"
+		) {
+			frm.add_custom_button(__("Send SMS"), function () {
 				frappe.call({
-					method: 'healthcare.healthcare.doctype.healthcare_settings.healthcare_settings.get_sms_text',
+					method: "healthcare.healthcare.doctype.healthcare_settings.healthcare_settings.get_sms_text",
 					args: { doc: frm.doc.name },
 					callback: function (r) {
 						if (!r.exc) {
@@ -77,52 +100,83 @@ frappe.ui.form.on('Lab Test', {
 							var printed = r.message.printed;
 							make_dialog(frm, emailed, printed);
 						}
-					}
+					},
 				});
 			});
 		}
 	},
 
-	template: function(frm) {
+	template: function (frm) {
 		if (frm.doc.template) {
 			frappe.call({
-				"method": "healthcare.healthcare.utils.get_medical_codes",
+				method: "healthcare.healthcare.utils.get_medical_codes",
 				args: {
 					template_dt: "Lab Test Template",
 					template_dn: frm.doc.template,
 				},
-				callback: function(r) {
+				callback: function (r) {
 					if (!r.exc && r.message) {
-						frm.doc.codification_table = []
-						$.each(r.message, function(k, val) {
+						frm.doc.codification_table = [];
+						$.each(r.message, function (k, val) {
 							if (val.code_value) {
 								var child = cur_frm.add_child("codification_table");
-								child.code_value = val.code_value
-								child.code_system = val.code_system
-								child.code = val.code
-								child.description = val.description
-								child.system = val.system
+								child.code_value = val.code_value;
+								child.code_system = val.code_system;
+								child.code = val.code;
+								child.description = val.description;
+								child.system = val.system;
+								child.code_value_set = val.code_value_set;
 							}
 						});
 						frm.refresh_field("codification_table");
 					} else {
-						frm.clear_table("codification_table")
+						frm.clear_table("codification_table");
 						frm.refresh_field("codification_table");
 					}
-				}
-			})
+				},
+			});
 		} else {
-			frm.clear_table("codification_table")
+			frm.clear_table("codification_table");
 			frm.refresh_field("codification_table");
 		}
-	}
+	},
+
+	before_save: async function (frm) {
+		await new Promise(function (resolve) {
+			frappe.require("assets/healthcare/js/utils.js", resolve);
+		});
+		await healthcare.utils.before_save_check(frm);
+	},
 });
 
+frappe.ui.form.on("Codification Table", {
+	code_value_set: function (frm, cdt, cdn) {
+		frappe.require("assets/healthcare/js/utils.js", function () {
+			healthcare.utils.set_codification_table_query(frm);
+		});
+	},
+	code_system: function (frm, cdt, cdn) {
+		frappe.require("assets/healthcare/js/utils.js", function () {
+			healthcare.utils.set_codification_table_query(frm);
+		});
+	},
+	code_value: function (frm, cdt, cdn) {
+		var row = locals[cdt][cdn];
+		if (!row.code_value_set) {
+			frappe.require("assets/healthcare/js/utils.js", function () {
+				healthcare.utils.auto_table_code_val_set(frm, cdt, cdn);
+			});
+		}
+		frappe.require("assets/healthcare/js/utils.js", function () {
+			healthcare.utils.set_codification_table_query(frm);
+		});
+	},
+});
 
-frappe.ui.form.on('Lab Test', 'patient', function (frm) {
+frappe.ui.form.on("Lab Test", "patient", function (frm) {
 	if (frm.doc.patient) {
 		frappe.call({
-			'method': 'healthcare.healthcare.doctype.patient.patient.get_patient_detail',
+			method: "healthcare.healthcare.doctype.patient.patient.get_patient_detail",
 			args: { patient: frm.doc.patient },
 			callback: function (data) {
 				var age = null;
@@ -130,77 +184,79 @@ frappe.ui.form.on('Lab Test', 'patient', function (frm) {
 					age = calculate_age(data.message.dob);
 				}
 				let values = {
-					'patient_age': age,
-					'patient_sex': data.message.sex,
-					'email': data.message.email,
-					'mobile': data.message.mobile,
-					'report_preference': data.message.report_preference
+					patient_age: age,
+					patient_sex: data.message.sex,
+					email: data.message.email,
+					mobile: data.message.mobile,
+					report_preference: data.message.report_preference,
 				};
 				frm.set_value(values);
-			}
+			},
 		});
 	}
 });
 
-frappe.ui.form.on('Normal Test Result', {
+frappe.ui.form.on("Normal Test Result", {
 	normal_test_items_remove: function () {
-		frappe.msgprint(__('Not permitted, configure Lab Test Template as required'));
+		frappe.msgprint(__("Not permitted, configure Lab Test Template as required"));
 		cur_frm.reload_doc();
-	}
+	},
 });
 
-frappe.ui.form.on('Descriptive Test Result', {
+frappe.ui.form.on("Descriptive Test Result", {
 	descriptive_test_items_remove: function () {
-		frappe.msgprint(__('Not permitted, configure Lab Test Template as required'));
+		frappe.msgprint(__("Not permitted, configure Lab Test Template as required"));
 		cur_frm.reload_doc();
-	}
+	},
 });
 
 var status_update = function (approve, frm) {
 	var doc = frm.doc;
 	var status = null;
 	if (approve == 1) {
-		status = 'Approved';
-	}
-	else {
-		status = 'Rejected';
+		status = "Approved";
+	} else {
+		status = "Rejected";
 	}
 	frappe.call({
-		method: 'healthcare.healthcare.doctype.lab_test.lab_test.update_status',
+		method: "healthcare.healthcare.doctype.lab_test.lab_test.update_status",
 		args: { status: status, name: doc.name },
 		callback: function () {
 			cur_frm.reload_doc();
-		}
+		},
 	});
 };
 
 var get_lab_test_prescribed = function (frm) {
 	if (frm.doc.patient) {
 		frappe.call({
-			method: 'healthcare.healthcare.doctype.lab_test.lab_test.get_lab_test_prescribed',
+			method: "healthcare.healthcare.doctype.lab_test.lab_test.get_lab_test_prescribed",
 			args: { patient: frm.doc.patient },
 			callback: function (r) {
 				show_lab_tests(frm, r.message);
-			}
+			},
 		});
-	}
-	else {
-		frappe.msgprint(__('Please select Patient to get Lab Tests'));
+	} else {
+		frappe.msgprint(__("Please select Patient to get Lab Tests"));
 	}
 };
 
 var show_lab_tests = function (frm, lab_test_list) {
 	var d = new frappe.ui.Dialog({
-		title: __('Lab Tests'),
-		fields: [{
-			fieldtype: 'HTML', fieldname: 'lab_test'
-		}]
+		title: __("Lab Tests"),
+		fields: [
+			{
+				fieldtype: "HTML",
+				fieldname: "lab_test",
+			},
+		],
 	});
 	var html_field = d.fields_dict.lab_test.$wrapper;
 	html_field.empty();
 	$.each(lab_test_list, function (x, y) {
-		var row = $(repl(
-			'<div class="col-xs-12 row" style="padding-top:12px;">\
+		var row = $(
+			repl(
+				'<div class="col-xs-12 row" style="padding-top:12px;">\
 			<div class="col-xs-3"> %(lab_test)s </div>\
 			<div class="col-xs-4">%(encounter)s</div>\
 			<div class="col-xs-3"> %(date)s </div>\
@@ -211,31 +267,44 @@ var show_lab_tests = function (frm, lab_test_list) {
 				data-referring-practitioner="%(referring_practitioner)s" href="#"><button class="btn btn-default btn-xs">Get</button></a>\
 			</div>\
 		</div><hr>',
-		{ lab_test: y[0], encounter: y[1], invoiced: y[2], practitioner: y[3], date: y[4],
-			name: y[5]})
+				{
+					lab_test: y[0],
+					encounter: y[1],
+					invoiced: y[2],
+					practitioner: y[3],
+					date: y[4],
+					name: y[5],
+				},
+			),
 		).appendTo(html_field);
 		row.find("a").click(function () {
-			frm.doc.template = $(this).attr('data-lab-test');
-			frm.doc.service_request = $(this).attr('data-name');
-			frm.doc.practitioner = $(this).attr('data-practitioner');
-			frm.set_df_property('template', 'read_only', 1);
-			frm.set_df_property('patient', 'read_only', 1);
-			frm.set_df_property('practitioner', 'read_only', 1);
+			frm.doc.template = $(this).attr("data-lab-test");
+			frm.doc.service_request = $(this).attr("data-name");
+			frm.doc.practitioner = $(this).attr("data-practitioner");
+			frm.set_df_property("template", "read_only", 1);
+			frm.set_df_property("patient", "read_only", 1);
+			frm.set_df_property("practitioner", "read_only", 1);
 			frm.doc.invoiced = 0;
-			if ($(this).attr('data-invoiced') === "Invoiced") {
+			if ($(this).attr("data-invoiced") === "Invoiced") {
 				frm.doc.invoiced = 1;
 			}
-			refresh_field('invoiced');
-			refresh_field('template');
-			frm.refresh_field('service_request');
+			refresh_field("invoiced");
+			refresh_field("template");
+			frm.refresh_field("service_request");
 			d.hide();
 			return false;
 		});
 	});
 	if (!lab_test_list.length) {
-		var msg = __('No Lab Tests found for the Patient {0}', [frm.doc.patient_name.bold()]);
+		var msg = __("No Lab Tests found for the Patient {0}", [
+			frm.doc.patient_name.bold(),
+		]);
 		html_field.empty();
-		$(repl('<div class="col-xs-12" style="padding-top:0px;" >%(msg)s</div>', { msg: msg })).appendTo(html_field);
+		$(
+			repl('<div class="col-xs-12" style="padding-top:0px;" >%(msg)s</div>', {
+				msg: msg,
+			}),
+		).appendTo(html_field);
 	}
 	d.show();
 };
@@ -244,14 +313,24 @@ var make_dialog = function (frm, emailed, printed) {
 	var number = frm.doc.mobile;
 
 	var dialog = new frappe.ui.Dialog({
-		title: 'Send SMS',
+		title: "Send SMS",
 		width: 400,
 		fields: [
-			{ fieldname: 'result_format', fieldtype: 'Select', label: 'Result Format', options: ['Emailed', 'Printed'] },
-			{ fieldname: 'number', fieldtype: 'Data', label: 'Mobile Number', reqd: 1 },
-			{ fieldname: 'message', fieldtype: 'Small Text', label: 'Message', reqd: 1 }
+			{
+				fieldname: "result_format",
+				fieldtype: "Select",
+				label: "Result Format",
+				options: ["Emailed", "Printed"],
+			},
+			{ fieldname: "number", fieldtype: "Data", label: "Mobile Number", reqd: 1 },
+			{
+				fieldname: "message",
+				fieldtype: "Small Text",
+				label: "Message",
+				reqd: 1,
+			},
 		],
-		primary_action_label: __('Send'),
+		primary_action_label: __("Send"),
 		primary_action: function () {
 			var values = dialog.fields_dict;
 			if (!values) {
@@ -259,32 +338,32 @@ var make_dialog = function (frm, emailed, printed) {
 			}
 			send_sms(values, frm);
 			dialog.hide();
-		}
+		},
 	});
-	if (frm.doc.report_preference === 'Print') {
+	if (frm.doc.report_preference === "Print") {
 		dialog.set_values({
-			'result_format': 'Printed',
-			'number': number,
-			'message': printed
+			result_format: "Printed",
+			number: number,
+			message: printed,
 		});
 	} else {
 		dialog.set_values({
-			'result_format': 'Emailed',
-			'number': number,
-			'message': emailed
+			result_format: "Emailed",
+			number: number,
+			message: emailed,
 		});
 	}
 	var fd = dialog.fields_dict;
 	$(fd.result_format.input).change(function () {
-		if (dialog.get_value('result_format') === 'Emailed') {
+		if (dialog.get_value("result_format") === "Emailed") {
 			dialog.set_values({
-				'number': number,
-				'message': emailed
+				number: number,
+				message: emailed,
 			});
 		} else {
 			dialog.set_values({
-				'number': number,
-				'message': printed
+				number: number,
+				message: printed,
 			});
 		}
 	});
@@ -296,13 +375,15 @@ var send_sms = function (vals, frm) {
 	var message = vals.message.last_value;
 
 	if (!number || !message) {
-		frappe.throw(__('Did not send SMS, missing patient mobile number or message content.'));
+		frappe.throw(
+			__("Did not send SMS, missing patient mobile number or message content."),
+		);
 	}
 	frappe.call({
-		method: 'frappe.core.doctype.sms_settings.sms_settings.send_sms',
+		method: "frappe.core.doctype.sms_settings.sms_settings.send_sms",
 		args: {
 			receiver_list: [number],
-			msg: message
+			msg: message,
 		},
 		callback: function (r) {
 			if (r.exc) {
@@ -310,7 +391,7 @@ var send_sms = function (vals, frm) {
 			} else {
 				frm.reload_doc();
 			}
-		}
+		},
 	});
 };
 
@@ -319,5 +400,7 @@ var calculate_age = function (dob) {
 	var age = new Date();
 	age.setTime(ageMS);
 	var years = age.getFullYear() - 1970;
-	return `${years} ${__('Years(s)')} ${age.getMonth()} ${__('Month(s)')} ${age.getDate()} ${__('Day(s)')}`;
+	return `${years} ${__("Years(s)")} ${age.getMonth()} ${__(
+		"Month(s)",
+	)} ${age.getDate()} ${__("Day(s)")}`;
 };

--- a/healthcare/healthcare/doctype/lab_test_template/lab_test_template.js
+++ b/healthcare/healthcare/doctype/lab_test_template/lab_test_template.js
@@ -43,6 +43,17 @@ frappe.ui.form.on("Lab Test Template", {
 				change_template_code(frm);
 			});
 		}
+
+		frappe.require("assets/healthcare/js/utils.js", function () {
+			healthcare.utils.set_codification_table_query(frm);
+		});
+	},
+
+	before_save: async function (frm) {
+		await new Promise(function (resolve) {
+			frappe.require("assets/healthcare/js/utils.js", resolve);
+		});
+		await healthcare.utils.before_save_check(frm);
 	},
 
 	link_existing_item: function (frm) {
@@ -114,6 +125,30 @@ frappe.ui.form.on("Lab Test Template", "lab_test_group", function (frm) {
 
 frappe.ui.form.on("Lab Test Template", "lab_test_description", function (frm) {
 	frm.doc.change_in_item = 1;
+});
+
+frappe.ui.form.on("Codification Table", {
+	code_value_set: function (frm, cdt, cdn) {
+		frappe.require("assets/healthcare/js/utils.js", function () {
+			healthcare.utils.set_codification_table_query(frm);
+		});
+	},
+	code_system: function (frm, cdt, cdn) {
+		frappe.require("assets/healthcare/js/utils.js", function () {
+			healthcare.utils.set_codification_table_query(frm);
+		});
+	},
+	code_value: function (frm, cdt, cdn) {
+		var row = locals[cdt][cdn];
+		if (!row.code_value_set) {
+			frappe.require("assets/healthcare/js/utils.js", function () {
+				healthcare.utils.auto_table_code_val_set(frm, cdt, cdn);
+			});
+		}
+		frappe.require("assets/healthcare/js/utils.js", function () {
+			healthcare.utils.set_codification_table_query(frm);
+		});
+	},
 });
 
 frappe.ui.form.on("Lab Test Groups", "template_or_new_line", function (frm, cdt, cdn) {

--- a/healthcare/healthcare/doctype/medication/medication.js
+++ b/healthcare/healthcare/doctype/medication/medication.js
@@ -29,6 +29,17 @@ frappe.ui.form.on("Medication", {
 				frappe.set_route("Tree", "Medication");
 			});
 		}
+
+		frappe.require("assets/healthcare/js/utils.js", function () {
+			healthcare.utils.set_codification_table_query(frm);
+		});
+	},
+
+	before_save: async function (frm) {
+		await new Promise(function (resolve) {
+			frappe.require("assets/healthcare/js/utils.js", resolve);
+		});
+		await healthcare.utils.before_save_check(frm);
 	},
 	onload: function (frm) {
 		if (frm.is_new() && !frm.doc.price_list) {
@@ -75,6 +86,30 @@ frappe.ui.form.on("Medication Linked Item", {
 
 	gst_hsn_code: function (frm, cdt, cdn) {
 		mark_change_in_item(frm, cdt, cdn);
+	},
+});
+
+frappe.ui.form.on("Codification Table", {
+	code_value_set: function (frm, cdt, cdn) {
+		frappe.require("assets/healthcare/js/utils.js", function () {
+			healthcare.utils.set_codification_table_query(frm);
+		});
+	},
+	code_system: function (frm, cdt, cdn) {
+		frappe.require("assets/healthcare/js/utils.js", function () {
+			healthcare.utils.set_codification_table_query(frm);
+		});
+	},
+	code_value: function (frm, cdt, cdn) {
+		var row = locals[cdt][cdn];
+		if (!row.code_value_set) {
+			frappe.require("assets/healthcare/js/utils.js", function () {
+				healthcare.utils.auto_table_code_val_set(frm, cdt, cdn);
+			});
+		}
+		frappe.require("assets/healthcare/js/utils.js", function () {
+			healthcare.utils.set_codification_table_query(frm);
+		});
 	},
 });
 

--- a/healthcare/healthcare/doctype/medication_request/medication_request.js
+++ b/healthcare/healthcare/doctype/medication_request/medication_request.js
@@ -11,6 +11,40 @@ frappe.ui.form.on('Medication Request', {
 				}
 			};
 		});
+
+		frappe.require("assets/healthcare/js/utils.js", function () {
+			healthcare.utils.set_codification_table_query(frm);
+		});
 	},
 
+	before_save: async function (frm) {
+		await new Promise(function (resolve) {
+			frappe.require("assets/healthcare/js/utils.js", resolve);
+		});
+		await healthcare.utils.before_save_check(frm);
+	},
+});
+
+frappe.ui.form.on("Codification Table", {
+	code_value_set: function (frm, cdt, cdn) {
+		frappe.require("assets/healthcare/js/utils.js", function () {
+			healthcare.utils.set_codification_table_query(frm);
+		});
+	},
+	code_system: function (frm, cdt, cdn) {
+		frappe.require("assets/healthcare/js/utils.js", function () {
+			healthcare.utils.set_codification_table_query(frm);
+		});
+	},
+	code_value: function (frm, cdt, cdn) {
+		var row = locals[cdt][cdn];
+		if (!row.code_value_set) {
+			frappe.require("assets/healthcare/js/utils.js", function () {
+				healthcare.utils.auto_table_code_val_set(frm, cdt, cdn);
+			});
+		}
+		frappe.require("assets/healthcare/js/utils.js", function () {
+			healthcare.utils.set_codification_table_query(frm);
+		});
+	},
 })

--- a/healthcare/healthcare/doctype/observation/observation.js
+++ b/healthcare/healthcare/doctype/observation/observation.js
@@ -41,6 +41,16 @@ frappe.ui.form.on("Observation", {
 
 	observation_template: function (frm) {
 		get_medical_codes(frm);
+		frappe.require("assets/healthcare/js/utils.js", function () {
+			healthcare.utils.set_codification_table_query(frm);
+		});
+	},
+
+	before_save: async function (frm) {
+		await new Promise(function (resolve) {
+			frappe.require("assets/healthcare/js/utils.js", resolve);
+		});
+		await healthcare.utils.before_save_check(frm);
 	},
 });
 
@@ -63,6 +73,7 @@ var get_medical_codes = function (frm) {
 							child.code = val.code;
 							child.description = val.description;
 							child.system = val.system;
+							child.code_value_set = val.code_value_set;
 						}
 					});
 					frm.refresh_field("codification_table");
@@ -77,3 +88,27 @@ var get_medical_codes = function (frm) {
 		frm.refresh_field("codification_table");
 	}
 };
+
+frappe.ui.form.on("Codification Table", {
+	code_value_set: function (frm, cdt, cdn) {
+		frappe.require("assets/healthcare/js/utils.js", function () {
+			healthcare.utils.set_codification_table_query(frm);
+		});
+	},
+	code_system: function (frm, cdt, cdn) {
+		frappe.require("assets/healthcare/js/utils.js", function () {
+			healthcare.utils.set_codification_table_query(frm);
+		});
+	},
+	code_value: function (frm, cdt, cdn) {
+		var row = locals[cdt][cdn];
+		if (!row.code_value_set) {
+			frappe.require("assets/healthcare/js/utils.js", function () {
+				healthcare.utils.auto_table_code_val_set(frm, cdt, cdn);
+			});
+		}
+		frappe.require("assets/healthcare/js/utils.js", function () {
+			healthcare.utils.set_codification_table_query(frm);
+		});
+	},
+});

--- a/healthcare/healthcare/doctype/observation_template/observation_template.js
+++ b/healthcare/healthcare/doctype/observation_template/observation_template.js
@@ -8,62 +8,109 @@ frappe.ui.form.on("Observation Template", {
 		}
 	},
 
-	onload: function(frm) {
+	onload: function (frm) {
 		set_select_field_options(frm);
 	},
 
-	observation: function(frm) {
+	observation: function (frm) {
 		if (!frm.doc.observation_code) {
-			frm.set_value('item_code', frm.doc.observation);
+			frm.set_value("item_code", frm.doc.observation);
 		}
 		if (!frm.doc.has_component && !frm.doc.abbr) {
 			frm.set_value("abbr", frappe.get_abbr(frm.doc.observation).toUpperCase());
 		}
 	},
 
-	preferred_display_name: function(frm) {
+	preferred_display_name: function (frm) {
 		if (!frm.doc.has_component && !frm.doc.abbr) {
-			frm.set_value("abbr", frappe.get_abbr(frm.doc.preferred_display_name).toUpperCase())
+			frm.set_value(
+				"abbr",
+				frappe.get_abbr(frm.doc.preferred_display_name).toUpperCase(),
+			);
 		}
 	},
 
-	refresh: function(frm) {
+	refresh: function (frm) {
 		frm.set_query("method", function () {
 			return {
-				"filters": {
-					"code_system": "Observation Method",
-				}
+				filters: {
+					code_system: "Observation Method",
+				},
 			};
 		});
-		frm.set_query("reference_type", "observation_reference_range", function() {
+		frm.set_query("reference_type", "observation_reference_range", function () {
 			return {
 				filters: {
-					"code_system": "Reference Type",
-				}
+					code_system: "Reference Type",
+				},
 			};
-		})
+		});
+
+		frappe.require("assets/healthcare/js/utils.js", function () {
+			healthcare.utils.set_codification_table_query(frm);
+		});
 	},
 
-	permitted_data_type: function(frm) {
+	before_save: async function (frm) {
+		await new Promise(function (resolve) {
+			frappe.require("assets/healthcare/js/utils.js", resolve);
+		});
+		await healthcare.utils.before_save_check(frm);
+	},
+
+	permitted_data_type: function (frm) {
 		set_observation_reference_range(frm);
 	},
 });
 
 frappe.ui.form.on("Observation Reference Range", {
-	observation_reference_range_add: function(frm) {
+	observation_reference_range_add: function (frm) {
 		set_observation_reference_range(frm);
-	}
-})
+	},
+});
 
-var set_observation_reference_range = function(frm) {
-	$.each(frm.doc.observation_reference_range, function(i, value) {
-		frappe.model.set_value(value.doctype, value.name, "permitted_data_type", frm.doc.permitted_data_type)
-	})
-}
+var set_observation_reference_range = function (frm) {
+	$.each(frm.doc.observation_reference_range, function (i, value) {
+		frappe.model.set_value(
+			value.doctype,
+			value.name,
+			"permitted_data_type",
+			frm.doc.permitted_data_type,
+		);
+	});
+};
 
-var set_select_field_options = function(frm) {
+var set_select_field_options = function (frm) {
 	if (frm.doc.permitted_data_type == "Select") {
-		var normal_df = frappe.meta.get_docfield("Observation Reference Range", "options", frm.doc.name);
+		var normal_df = frappe.meta.get_docfield(
+			"Observation Reference Range",
+			"options",
+			frm.doc.name,
+		);
 		normal_df.options = frm.doc.options;
 	}
-}
+};
+
+frappe.ui.form.on("Codification Table", {
+	code_value_set: function (frm, cdt, cdn) {
+		frappe.require("assets/healthcare/js/utils.js", function () {
+			healthcare.utils.set_codification_table_query(frm);
+		});
+	},
+	code_system: function (frm, cdt, cdn) {
+		frappe.require("assets/healthcare/js/utils.js", function () {
+			healthcare.utils.set_codification_table_query(frm);
+		});
+	},
+	code_value: function (frm, cdt, cdn) {
+		var row = locals[cdt][cdn];
+		if (!row.code_value_set) {
+			frappe.require("assets/healthcare/js/utils.js", function () {
+				healthcare.utils.auto_table_code_val_set(frm, cdt, cdn);
+			});
+		}
+		frappe.require("assets/healthcare/js/utils.js", function () {
+			healthcare.utils.set_codification_table_query(frm);
+		});
+	},
+});

--- a/healthcare/healthcare/doctype/patient_encounter/patient_encounter.js
+++ b/healthcare/healthcare/doctype/patient_encounter/patient_encounter.js
@@ -353,6 +353,17 @@ frappe.ui.form.on("Patient Encounter", {
 				},
 			};
 		};
+
+		frappe.require("assets/healthcare/js/utils.js", function () {
+			healthcare.utils.set_codification_table_query(frm);
+		});
+	},
+
+	before_save: async function (frm) {
+		await new Promise(function (resolve) {
+			frappe.require("assets/healthcare/js/utils.js", resolve);
+		});
+		await healthcare.utils.before_save_check(frm);
 	},
 
 	appointment: function (frm) {
@@ -1045,6 +1056,30 @@ let create_patient_referral = function (frm) {
 
 	dialog.show();
 };
+
+frappe.ui.form.on("Codification Table", {
+	code_value_set: function (frm, cdt, cdn) {
+		frappe.require("assets/healthcare/js/utils.js", function () {
+			healthcare.utils.set_codification_table_query(frm);
+		});
+	},
+	code_system: function (frm, cdt, cdn) {
+		frappe.require("assets/healthcare/js/utils.js", function () {
+			healthcare.utils.set_codification_table_query(frm);
+		});
+	},
+	code_value: function (frm, cdt, cdn) {
+		var row = locals[cdt][cdn];
+		if (!row.code_value_set) {
+			frappe.require("assets/healthcare/js/utils.js", function () {
+				healthcare.utils.auto_table_code_val_set(frm, cdt, cdn);
+			});
+		}
+		frappe.require("assets/healthcare/js/utils.js", function () {
+			healthcare.utils.set_codification_table_query(frm);
+		});
+	},
+});
 
 frappe.ui.form.on("Therapy Plan Detail", {
 	no_of_days: (frm, cdt, cdn) => {

--- a/healthcare/healthcare/doctype/service_request/service_request.js
+++ b/healthcare/healthcare/doctype/service_request/service_request.js
@@ -2,9 +2,9 @@
 // For license information, please see license.txt
 // {% include "healthcare/public/js/service_request.js" %}
 
-frappe.ui.form.on('Service Request', {
-	refresh: function(frm) {
-		frm.set_query('template_dt', function() {
+frappe.ui.form.on("Service Request", {
+	refresh: function (frm) {
+		frm.set_query("template_dt", function () {
 			let order_template_doctypes = [
 				"Therapy Type",
 				"Lab Test Template",
@@ -12,174 +12,267 @@ frappe.ui.form.on('Service Request', {
 				"Appointment Type",
 				"Observation Template",
 				"Healthcare Activity",
-				"Healthcare Practitioner"];
+				"Healthcare Practitioner",
+			];
 			return {
 				filters: {
-					name: ['in', order_template_doctypes]
-				}
+					name: ["in", order_template_doctypes],
+				},
 			};
 		});
 
 		frm.set_query("status", function () {
 			return {
-				"filters": {
-					"code_system": "Request Status",
-				}
+				filters: {
+					code_system: "Request Status",
+				},
 			};
 		});
 
-		frm.trigger('setup_create_buttons');
+		frm.trigger("setup_create_buttons");
+
+		frappe.require("assets/healthcare/js/utils.js", function () {
+			healthcare.utils.set_codification_table_query(frm);
+		});
 	},
 
+	before_save: async function (frm) {
+		await new Promise(function (resolve) {
+			frappe.require("assets/healthcare/js/utils.js", resolve);
+		});
+		await healthcare.utils.before_save_check(frm);
+	},
 
-	setup_create_buttons: function(frm) {
-		if (frm.doc.docstatus !== 1 || frm.doc.status === 'Completed') return;
+	setup_create_buttons: function (frm) {
+		if (frm.doc.docstatus !== 1 || frm.doc.status === "Completed") return;
 
-		if (frm.doc.template_dt === 'Clinical Procedure Template') {
-
-			frm.add_custom_button(__('Clinical Procedure'), function() {
-				frappe.db.get_value("Clinical Procedure", {"service_request": frm.doc.name, "docstatus":["!=", 2]}, "name")
-				.then(r => {
-					if (Object.keys(r.message).length == 0) {
-						frm.trigger('make_clinical_procedure');
-					} else {
-						if (r.message && r.message.name) {
-							frappe.set_route("Form", "Clinical Procedure", r.message.name);
-							frappe.show_alert({
-								message: __(`Clinical Procedure is already created`),
-								indicator: "info",
-							});
-						}
-					}
-				})
-			}, __('Create'));
-
-
-		} else if (frm.doc.template_dt === 'Lab Test Template') {
-			frm.add_custom_button(__('Lab Test'), function() {
-				frappe.db.get_value("Lab Test", {"service_request": frm.doc.name, "docstatus":["!=", 2]}, "name")
-				.then(r => {
-					if (Object.keys(r.message).length == 0) {
-						frm.trigger('make_lab_test');
-					} else {
-						if (r.message && r.message.name) {
-							frappe.set_route("Form", "Lab Test", r.message.name);
-							frappe.show_alert({
-								message: __(`Lab Test is already created`),
-								indicator: "info",
-							});
-						}
-					}
-				})
-			}, __('Create'));
-
-
-		} else if (frm.doc.template_dt === 'Therapy Type') {
-			frm.add_custom_button(__("Therapy Session"), function() {
-				frappe.db.get_value("Therapy Session", {"service_request": frm.doc.name, "docstatus":["!=", 2]}, "name")
-				.then(r => {
-					if (Object.keys(r.message).length == 0) {
-						frm.trigger('make_therapy_session');
-					} else {
-						if (r.message && r.message.name) {
-							frappe.set_route("Form", "Therapy Session", r.message.name);
-							frappe.show_alert({
-								message: __(`Therapy Session is already created`),
-								indicator: "info",
-							});
-						}
-					}
-				})
-			}, __('Create'));
-
-		} else if (frm.doc.template_dt === "Observation Template") {
-			frm.add_custom_button(__('Observation'), function() {
-				frm.trigger('make_observation');
-			}, __('Create'));
-
-		} else if (frm.doc.template_dt === "Appointment Type") {
-			frm.add_custom_button(__("Appointment"), function () {
-				frappe.db.get_value("Patient Appointment", { service_request: frm.doc.name, status: ["!=", "Cancelled"] }, "name")
-					.then(r => {
-						if (Object.keys(r.message).length == 0) {
-							frappe.model.open_mapped_doc({
-								method: "healthcare.healthcare.doctype.service_request.service_request.make_appointment",
-								frm: frm,
-							});
-						} else {
-							if (r.message && r.message.name) {
-								frappe.set_route("Form", "Patient Appointment", r.message.name);
-								frappe.show_alert({
-									message: __("Patient Appointment is already created"),
-									indicator: "info",
-								});
+		if (frm.doc.template_dt === "Clinical Procedure Template") {
+			frm.add_custom_button(
+				__("Clinical Procedure"),
+				function () {
+					frappe.db
+						.get_value(
+							"Clinical Procedure",
+							{ service_request: frm.doc.name, docstatus: ["!=", 2] },
+							"name",
+						)
+						.then(r => {
+							if (Object.keys(r.message).length == 0) {
+								frm.trigger("make_clinical_procedure");
+							} else {
+								if (r.message && r.message.name) {
+									frappe.set_route(
+										"Form",
+										"Clinical Procedure",
+										r.message.name,
+									);
+									frappe.show_alert({
+										message: __(
+											`Clinical Procedure is already created`,
+										),
+										indicator: "info",
+									});
+								}
 							}
-						}
-					})
-			}, __("Create"));
+						});
+				},
+				__("Create"),
+			);
+		} else if (frm.doc.template_dt === "Lab Test Template") {
+			frm.add_custom_button(
+				__("Lab Test"),
+				function () {
+					frappe.db
+						.get_value(
+							"Lab Test",
+							{ service_request: frm.doc.name, docstatus: ["!=", 2] },
+							"name",
+						)
+						.then(r => {
+							if (Object.keys(r.message).length == 0) {
+								frm.trigger("make_lab_test");
+							} else {
+								if (r.message && r.message.name) {
+									frappe.set_route(
+										"Form",
+										"Lab Test",
+										r.message.name,
+									);
+									frappe.show_alert({
+										message: __(`Lab Test is already created`),
+										indicator: "info",
+									});
+								}
+							}
+						});
+				},
+				__("Create"),
+			);
+		} else if (frm.doc.template_dt === "Therapy Type") {
+			frm.add_custom_button(
+				__("Therapy Session"),
+				function () {
+					frappe.db
+						.get_value(
+							"Therapy Session",
+							{ service_request: frm.doc.name, docstatus: ["!=", 2] },
+							"name",
+						)
+						.then(r => {
+							if (Object.keys(r.message).length == 0) {
+								frm.trigger("make_therapy_session");
+							} else {
+								if (r.message && r.message.name) {
+									frappe.set_route(
+										"Form",
+										"Therapy Session",
+										r.message.name,
+									);
+									frappe.show_alert({
+										message: __(
+											`Therapy Session is already created`,
+										),
+										indicator: "info",
+									});
+								}
+							}
+						});
+				},
+				__("Create"),
+			);
+		} else if (frm.doc.template_dt === "Observation Template") {
+			frm.add_custom_button(
+				__("Observation"),
+				function () {
+					frm.trigger("make_observation");
+				},
+				__("Create"),
+			);
+		} else if (frm.doc.template_dt === "Appointment Type") {
+			frm.add_custom_button(
+				__("Appointment"),
+				function () {
+					frappe.db
+						.get_value(
+							"Patient Appointment",
+							{
+								service_request: frm.doc.name,
+								status: ["!=", "Cancelled"],
+							},
+							"name",
+						)
+						.then(r => {
+							if (Object.keys(r.message).length == 0) {
+								frappe.model.open_mapped_doc({
+									method: "healthcare.healthcare.doctype.service_request.service_request.make_appointment",
+									frm: frm,
+								});
+							} else {
+								if (r.message && r.message.name) {
+									frappe.set_route(
+										"Form",
+										"Patient Appointment",
+										r.message.name,
+									);
+									frappe.show_alert({
+										message: __(
+											"Patient Appointment is already created",
+										),
+										indicator: "info",
+									});
+								}
+							}
+						});
+				},
+				__("Create"),
+			);
 		}
 
-		frm.page.set_inner_btn_group_as_primary(__('Create'));
+		frm.page.set_inner_btn_group_as_primary(__("Create"));
 	},
 
-	make_clinical_procedure: function(frm) {
+	make_clinical_procedure: function (frm) {
 		frappe.call({
-			method: 'healthcare.healthcare.doctype.service_request.service_request.make_clinical_procedure',
+			method: "healthcare.healthcare.doctype.service_request.service_request.make_clinical_procedure",
 			args: { service_request: frm.doc },
 			freeze: true,
-			callback: function(r) {
+			callback: function (r) {
 				var doclist = frappe.model.sync(r.message);
-				frappe.set_route('Form', doclist[0].doctype, doclist[0].name);
-			}
+				frappe.set_route("Form", doclist[0].doctype, doclist[0].name);
+			},
 		});
 	},
 
-	make_lab_test: function(frm) {
+	make_lab_test: function (frm) {
 		frappe.call({
-			method: 'healthcare.healthcare.doctype.service_request.service_request.make_lab_test',
+			method: "healthcare.healthcare.doctype.service_request.service_request.make_lab_test",
 			args: { service_request: frm.doc },
 			freeze: true,
-			callback: function(r) {
+			callback: function (r) {
 				var doclist = frappe.model.sync(r.message);
-				frappe.set_route('Form', doclist[0].doctype, doclist[0].name);
-			}
+				frappe.set_route("Form", doclist[0].doctype, doclist[0].name);
+			},
 		});
 	},
 
-	make_therapy_session: function(frm) {
+	make_therapy_session: function (frm) {
 		frappe.call({
-			method: 'healthcare.healthcare.doctype.service_request.service_request.make_therapy_session',
+			method: "healthcare.healthcare.doctype.service_request.service_request.make_therapy_session",
 			args: { service_request: frm.doc },
 			freeze: true,
-			callback: function(r) {
+			callback: function (r) {
 				var doclist = frappe.model.sync(r.message);
-				frappe.set_route('Form', doclist[0].doctype, doclist[0].name);
-			}
+				frappe.set_route("Form", doclist[0].doctype, doclist[0].name);
+			},
 		});
 	},
 
-	make_observation: function(frm) {
+	make_observation: function (frm) {
 		frappe.call({
-			method: 'healthcare.healthcare.doctype.service_request.service_request.make_observation',
+			method: "healthcare.healthcare.doctype.service_request.service_request.make_observation",
 			args: { service_request: frm.doc },
 			freeze: true,
-			callback: function(r) {
+			callback: function (r) {
 				if (r.message) {
 					var title = "";
-					var indicator =  "info";
+					var indicator = "info";
 					if (r.message[2]) {
-						title = `${r.message[0]} is already created`
+						title = `${r.message[0]} is already created`;
 					} else {
-						title = `${r.message[0]} is created`
-						indicator = "green"
+						title = `${r.message[0]} is created`;
+						indicator = "green";
 					}
 					frappe.show_alert({
 						message: __("{0}", [title]),
 						indicator: indicator,
 					});
-					frappe.set_route('Form', r.message[1], r.message[0]);
+					frappe.set_route("Form", r.message[1], r.message[0]);
 				}
-			}
+			},
+		});
+	},
+});
+
+frappe.ui.form.on("Codification Table", {
+	code_value_set: function (frm, cdt, cdn) {
+		frappe.require("assets/healthcare/js/utils.js", function () {
+			healthcare.utils.set_codification_table_query(frm);
+		});
+	},
+	code_system: function (frm, cdt, cdn) {
+		frappe.require("assets/healthcare/js/utils.js", function () {
+			healthcare.utils.set_codification_table_query(frm);
+		});
+	},
+	code_value: function (frm, cdt, cdn) {
+		var row = locals[cdt][cdn];
+		if (!row.code_value_set) {
+			frappe.require("assets/healthcare/js/utils.js", function () {
+				healthcare.utils.auto_table_code_val_set(frm, cdt, cdn);
+			});
+		}
+		frappe.require("assets/healthcare/js/utils.js", function () {
+			healthcare.utils.set_codification_table_query(frm);
 		});
 	},
 });

--- a/healthcare/healthcare/doctype/therapy_session/therapy_session.js
+++ b/healthcare/healthcare/doctype/therapy_session/therapy_session.js
@@ -1,159 +1,188 @@
 // Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and contributors
 // For license information, please see license.txt
 
-frappe.ui.form.on('Therapy Session', {
-	setup: function(frm) {
-		frm.get_field('exercises').grid.editable_fields = [
-			{fieldname: 'exercise_type', columns: 7},
-			{fieldname: 'counts_target', columns: 1},
-			{fieldname: 'counts_completed', columns: 1},
-			{fieldname: 'assistance_level', columns: 1}
+frappe.ui.form.on("Therapy Session", {
+	setup: function (frm) {
+		frm.get_field("exercises").grid.editable_fields = [
+			{ fieldname: "exercise_type", columns: 7 },
+			{ fieldname: "counts_target", columns: 1 },
+			{ fieldname: "counts_completed", columns: 1 },
+			{ fieldname: "assistance_level", columns: 1 },
 		];
 
-		frm.set_query('service_unit', function() {
+		frm.set_query("service_unit", function () {
 			return {
 				filters: {
-					'is_group': false,
-					'allow_appointments': true,
-					'company': frm.doc.company
-				}
+					is_group: false,
+					allow_appointments: true,
+					company: frm.doc.company,
+				},
 			};
 		});
 
-		frm.set_query('appointment', function() {
+		frm.set_query("appointment", function () {
 			return {
 				query: "healthcare.healthcare.doctype.therapy_session.therapy_session.get_appointment_query",
 				filters: {
 					therapy_type: frm.doc.therapy_type,
 					therapy_plan: frm.doc.therapy_plan,
-					is_new : frm.is_new(),
-					name : frm.doc.name
+					is_new: frm.is_new(),
+					name: frm.doc.name,
 				},
 			};
 		});
 
-		frm.set_query('service_request', function() {
+		frm.set_query("service_request", function () {
 			return {
 				filters: {
-					'patient': frm.doc.patient,
-					'status': 'Active',
-					'docstatus': 1,
-					'template_dt': 'Therapy Type'
-				}
+					patient: frm.doc.patient,
+					status: "Active",
+					docstatus: 1,
+					template_dt: "Therapy Type",
+				},
 			};
 		});
 
-		frm.set_query('batch_no', 'items', function(doc, cdt, cdn) {
+		frm.set_query("batch_no", "items", function (doc, cdt, cdn) {
 			let item = locals[cdt][cdn];
 			if (!item.item_code) {
-				frappe.throw(__('Please enter Item Code to get Batch Number'));
+				frappe.throw(__("Please enter Item Code to get Batch Number"));
 			} else {
-				let filters = {'item_code': item.item_code};
+				let filters = { item_code: item.item_code };
 
 				return {
-					query : 'erpnext.controllers.queries.get_batch_no',
-					filters: filters
+					query: "erpnext.controllers.queries.get_batch_no",
+					filters: filters,
 				};
 			}
 		});
 	},
 
-	refresh: function(frm) {
+	refresh: function (frm) {
 		if (frm.doc.therapy_plan) {
-			frm.trigger('filter_therapy_types');
+			frm.trigger("filter_therapy_types");
 		}
 		if (frm.is_new() && frm.doc.therapy_plan) {
 			frm.call({
-				method : "validate_no_of_session",
-				args : {
-					therapy_plan : frm.doc.therapy_plan	
+				method: "validate_no_of_session",
+				args: {
+					therapy_plan: frm.doc.therapy_plan,
 				},
-				callback:(r)=>{
-					if(r.message){
-						frappe.throw(`Maximum number of sessions ${r.message[1]} already created for this Therapy Plan.`)
+				callback: r => {
+					if (r.message) {
+						frappe.throw(
+							`Maximum number of sessions ${r.message[1]} already created for this Therapy Plan.`,
+						);
 					}
-				}
-			})
+				},
+			});
 		}
-		frm.set_query("code_value", "codification_table", function(doc, cdt, cdn) {
+		frm.set_query("code_value", "codification_table", function (doc, cdt, cdn) {
 			let row = frappe.get_doc(cdt, cdn);
 			if (row.code_system) {
 				return {
 					filters: {
-						code_system: row.code_system
-					}
+						code_system: row.code_system,
+					},
 				};
 			}
 		});
 
 		if (!frm.doc.__islocal) {
-			frm.dashboard.add_indicator(__('Counts Targeted: {0}', [frm.doc.total_counts_targeted]), 'blue');
-			frm.dashboard.add_indicator(__('Counts Completed: {0}', [frm.doc.total_counts_completed]),
-				(frm.doc.total_counts_completed < frm.doc.total_counts_targeted) ? 'orange' : 'green');
+			frm.dashboard.add_indicator(
+				__("Counts Targeted: {0}", [frm.doc.total_counts_targeted]),
+				"blue",
+			);
+			frm.dashboard.add_indicator(
+				__("Counts Completed: {0}", [frm.doc.total_counts_completed]),
+				frm.doc.total_counts_completed < frm.doc.total_counts_targeted
+					? "orange"
+					: "green",
+			);
 
-			frm.add_custom_button(__("Clinical Note"), function() {
-				frappe.route_options = {
-					"patient": frm.doc.patient,
-					"reference_doc": "Therapy Session",
-					"reference_name": frm.doc.name,
-					"practitioner": frm.doc.practitioner
-				}
-				frappe.new_doc("Clinical Note");
-			},__('Create'));
+			frm.add_custom_button(
+				__("Clinical Note"),
+				function () {
+					frappe.route_options = {
+						patient: frm.doc.patient,
+						reference_doc: "Therapy Session",
+						reference_name: frm.doc.name,
+						practitioner: frm.doc.practitioner,
+					};
+					frappe.new_doc("Clinical Note");
+				},
+				__("Create"),
+			);
 		}
 
 		if (frm.doc.docstatus === 1) {
-			frm.add_custom_button(__('Patient Assessment'), function() {
-				frappe.model.open_mapped_doc({
-					method: 'healthcare.healthcare.doctype.patient_assessment.patient_assessment.create_patient_assessment',
-					frm: frm,
-				})
-			}, 'Create');
+			frm.add_custom_button(
+				__("Patient Assessment"),
+				function () {
+					frappe.model.open_mapped_doc({
+						method: "healthcare.healthcare.doctype.patient_assessment.patient_assessment.create_patient_assessment",
+						frm: frm,
+					});
+				},
+				"Create",
+			);
 
-			frappe.db.get_value('Therapy Plan', {'name': frm.doc.therapy_plan}, 'therapy_plan_template', (r) => {
-				if (r && !r.therapy_plan_template) {
-					frm.add_custom_button(__('Sales Invoice'), function() {
-						frappe.model.open_mapped_doc({
-							method: 'healthcare.healthcare.doctype.therapy_session.therapy_session.invoice_therapy_session',
-							frm: frm,
-						});
-					}, 'Create');
-				}
-			});
+			frappe.db.get_value(
+				"Therapy Plan",
+				{ name: frm.doc.therapy_plan },
+				"therapy_plan_template",
+				r => {
+					if (r && !r.therapy_plan_template) {
+						frm.add_custom_button(
+							__("Sales Invoice"),
+							function () {
+								frappe.model.open_mapped_doc({
+									method: "healthcare.healthcare.doctype.therapy_session.therapy_session.invoice_therapy_session",
+									frm: frm,
+								});
+							},
+							"Create",
+						);
+					}
+				},
+			);
 		}
 		if (frm.doc.consume_stock) {
-			frm.set_indicator_formatter('item_code', function(doc) {
-				return (doc.qty <= doc.actual_qty) ? 'green' : 'orange';
+			frm.set_indicator_formatter("item_code", function (doc) {
+				return doc.qty <= doc.actual_qty ? "green" : "orange";
 			});
 		}
 
 		if (frm.doc.docstatus === 1 && frm.doc.items?.length > 0) {
 			if (frm.doc.consumption_status === "Consumption Pending") {
-				frm.add_custom_button(__('Start Consumption'), async function () {
-					await handleStockCheck(frm,
-						() => frm.trigger('consume_stocks'),
-						() => frappe.call({
-							doc: frm.doc,
-							method: "update_consumption_status",
-							args: { status: "Insufficient Stock" },
-							callback: () => frm.reload_doc()
-						})
+				frm.add_custom_button(__("Start Consumption"), async function () {
+					await handleStockCheck(
+						frm,
+						() => frm.trigger("consume_stocks"),
+						() =>
+							frappe.call({
+								doc: frm.doc,
+								method: "update_consumption_status",
+								args: { status: "Insufficient Stock" },
+								callback: () => frm.reload_doc(),
+							}),
 					);
 				}).addClass("btn-primary");
 			}
 
 			if (frm.doc.consumption_status === "Insufficient Stock") {
-				frm.add_custom_button(__('Verify & Add Stock'), async function () {
-					await handleStockCheck(frm,
+				frm.add_custom_button(__("Verify & Add Stock"), async function () {
+					await handleStockCheck(
+						frm,
 						() => {
 							frappe.call({
 								doc: frm.doc,
 								method: "update_consumption_status",
 								args: { status: "Consumption Pending" },
-								callback: () => frm.reload_doc()
+								callback: () => frm.reload_doc(),
 							});
 						},
-						() => frm.trigger('make_material_receipt')
+						() => frm.trigger("make_material_receipt"),
 					);
 				}).addClass("btn-primary");
 			}
@@ -161,45 +190,59 @@ frappe.ui.form.on('Therapy Session', {
 
 		if (frm.doc.therapy_type && frm.is_new()) {
 			frappe.call({
-				'method': 'frappe.client.get',
+				method: "frappe.client.get",
 				args: {
-					doctype: 'Therapy Type',
-					name: frm.doc.therapy_type
+					doctype: "Therapy Type",
+					name: frm.doc.therapy_type,
 				},
-				callback: function(data) {
-					frm.set_value('consume_stock', data.message.consume_stock);
+				callback: function (data) {
+					frm.set_value("consume_stock", data.message.consume_stock);
 					frm.events.set_warehouse(frm);
 					frm.events.set_therapy_consumables(frm);
-				}
+				},
 			});
 		}
 
 		add_consumption_status_headline(frm);
+
+		frappe.require("assets/healthcare/js/utils.js", function () {
+			healthcare.utils.set_codification_table_query(frm);
+		});
+	},
+
+	before_save: async function (frm) {
+		await new Promise(function (resolve) {
+			frappe.require("assets/healthcare/js/utils.js", resolve);
+		});
+		await healthcare.utils.before_save_check(frm);
 	},
 
 	verify_stock: function (frm) {
 		return new Promise((resolve, reject) => {
 			frappe.call({
 				doc: frm.doc,
-				method: 'verify_stock',
+				method: "verify_stock",
 				freeze: true,
 				callback: function (r) {
 					if (r.message !== undefined) {
 						resolve(r.message);
 					} else {
-						reject(__('Error verifying stock'));
+						reject(__("Error verifying stock"));
 					}
-				}
+				},
 			});
 		});
 	},
 
-	make_material_receipt: function(frm) {
-		let msg = __('Stock quantity to start the Session is not available in the Warehouse {0}. Do you want to record a Stock Entry?', [frm.doc.warehouse.bold()]);
+	make_material_receipt: function (frm) {
+		let msg = __(
+			"Stock quantity to start the Session is not available in the Warehouse {0}. Do you want to record a Stock Entry?",
+			[frm.doc.warehouse.bold()],
+		);
 		frappe.confirm(msg, function () {
 			frappe.call({
 				doc: frm.doc,
-				method: 'make_material_receipt',
+				method: "make_material_receipt",
 				freeze: true,
 				callback: function (r) {
 					if (!r.exc) {
@@ -207,185 +250,195 @@ frappe.ui.form.on('Therapy Session', {
 							doc: frm.doc,
 							method: "update_consumption_status",
 							args: { status: "Consumption Pending" },
-							callback: () => frm.reload_doc()
+							callback: () => frm.reload_doc(),
 						});
 						let doclist = frappe.model.sync(r.message);
-						frappe.set_route('Form', doclist[0].doctype, doclist[0].name);
+						frappe.set_route("Form", doclist[0].doctype, doclist[0].name);
 					}
-				}
+				},
 			});
 		});
 	},
 
-	consume_stocks: function(frm) {
-		let msg = __('Complete {0} and Consume Stock?', [frm.doc.name]);
+	consume_stocks: function (frm) {
+		let msg = __("Complete {0} and Consume Stock?", [frm.doc.name]);
 		frappe.confirm(msg, function () {
 			frappe.call({
-				method: 'consume_stocks',
+				method: "consume_stocks",
 				doc: frm.doc,
 				freeze: true,
 				callback: function (r) {
 					if (r.message) {
 						frappe.show_alert({
-							message: __('Stock Entry {0} created', ['<a class="bold" href="/app/stock-entry/' + r.message + '">' + r.message + '</a>']),
-							indicator: 'green'
+							message: __("Stock Entry {0} created", [
+								'<a class="bold" href="/app/stock-entry/' +
+									r.message +
+									'">' +
+									r.message +
+									"</a>",
+							]),
+							indicator: "green",
 						});
 					}
 					frm.reload_doc();
-				}
+				},
 			});
 		});
 	},
 
-	therapy_plan: function(frm) {
+	therapy_plan: function (frm) {
 		if (frm.doc.therapy_plan) {
-			frm.trigger('filter_therapy_types');
+			frm.trigger("filter_therapy_types");
 		}
 	},
 
-	filter_therapy_types: function(frm) {
+	filter_therapy_types: function (frm) {
 		frappe.call({
-			'method': 'frappe.client.get',
+			method: "frappe.client.get",
 			args: {
-				doctype: 'Therapy Plan',
-				name: frm.doc.therapy_plan
+				doctype: "Therapy Plan",
+				name: frm.doc.therapy_plan,
 			},
-			callback: function(data) {
-				let therapy_types = (data.message.therapy_plan_details || []).map(function(d){ return d.therapy_type; });
-				frm.set_query('therapy_type', function() {
+			callback: function (data) {
+				let therapy_types = (data.message.therapy_plan_details || []).map(
+					function (d) {
+						return d.therapy_type;
+					},
+				);
+				frm.set_query("therapy_type", function () {
 					return {
-						filters: { 'therapy_type': ['in', therapy_types]}
+						filters: { therapy_type: ["in", therapy_types] },
 					};
 				});
-			}
+			},
 		});
 	},
 
-	patient: function(frm) {
+	patient: function (frm) {
 		if (frm.doc.patient) {
 			frappe.call({
-				'method': 'healthcare.healthcare.doctype.patient.patient.get_patient_detail',
+				method: "healthcare.healthcare.doctype.patient.patient.get_patient_detail",
 				args: {
-					patient: frm.doc.patient
+					patient: frm.doc.patient,
 				},
 				callback: function (data) {
-					let age = '';
+					let age = "";
 					if (data.message.dob) {
 						age = calculate_age(data.message.dob);
 					} else if (data.message.age) {
 						age = data.message.age;
 						if (data.message.age_as_on) {
-							age = __('{0} as on {1}', [age, data.message.age_as_on]);
+							age = __("{0} as on {1}", [age, data.message.age_as_on]);
 						}
 					}
-					frm.set_value('patient_age', age);
-					frm.set_value('gender', data.message.sex);
-					frm.set_value('patient_name', data.message.patient_name);
-				}
+					frm.set_value("patient_age", age);
+					frm.set_value("gender", data.message.sex);
+					frm.set_value("patient_name", data.message.patient_name);
+				},
 			});
 		} else {
-			frm.set_value('patient_age', '');
-			frm.set_value('gender', '');
-			frm.set_value('patient_name', '');
+			frm.set_value("patient_age", "");
+			frm.set_value("gender", "");
+			frm.set_value("patient_name", "");
 		}
 	},
 
-	appointment: function(frm) {
+	appointment: function (frm) {
 		if (frm.doc.appointment) {
 			frappe.call({
-				'method': 'frappe.client.get',
+				method: "frappe.client.get",
 				args: {
-					doctype: 'Patient Appointment',
-					name: frm.doc.appointment
+					doctype: "Patient Appointment",
+					name: frm.doc.appointment,
 				},
-				callback: function(data) {
+				callback: function (data) {
 					let values = {
-						'patient':data.message.patient,
-						'practitioner': data.message.practitioner,
-						'department': data.message.department,
-						'start_date': data.message.appointment_date,
-						'start_time': data.message.appointment_time,
-						'service_unit': data.message.service_unit,
-						'company': data.message.company,
-						'duration': data.message.duration
+						patient: data.message.patient,
+						practitioner: data.message.practitioner,
+						department: data.message.department,
+						start_date: data.message.appointment_date,
+						start_time: data.message.appointment_time,
+						service_unit: data.message.service_unit,
+						company: data.message.company,
+						duration: data.message.duration,
 					};
 					frm.set_value(values);
-				}
+				},
 			});
 		}
 	},
 
-	therapy_type: function(frm) {
+	therapy_type: function (frm) {
 		if (frm.doc.therapy_type) {
 			frappe.call({
-				'method': 'frappe.client.get',
+				method: "frappe.client.get",
 				args: {
-					doctype: 'Therapy Type',
-					name: frm.doc.therapy_type
+					doctype: "Therapy Type",
+					name: frm.doc.therapy_type,
 				},
-				callback: function(data) {
-					frm.set_value('duration', data.message.default_duration);
-					frm.set_value('rate', data.message.rate);
-					frm.set_value('service_unit', data.message.healthcare_service_unit);
-					frm.set_value('department', data.message.medical_department);
-					frm.set_value('consume_stock', data.message.consume_stock);
+				callback: function (data) {
+					frm.set_value("duration", data.message.default_duration);
+					frm.set_value("rate", data.message.rate);
+					frm.set_value("service_unit", data.message.healthcare_service_unit);
+					frm.set_value("department", data.message.medical_department);
+					frm.set_value("consume_stock", data.message.consume_stock);
 					frm.doc.exercises = [];
 					frm.events.set_warehouse(frm);
 					frm.events.set_therapy_consumables(frm);
-					$.each(data.message.exercises, function(_i, e) {
-						let exercise = frm.add_child('exercises');
+					$.each(data.message.exercises, function (_i, e) {
+						let exercise = frm.add_child("exercises");
 						exercise.exercise_type = e.exercise_type;
 						exercise.difficulty_level = e.difficulty_level;
 						exercise.counts_target = e.counts_target;
 						exercise.assistance_level = e.assistance_level;
 					});
-					frm.clear_table("codification_table")
-					$.each(data.message.codification_table, function(k, val) {
+					frm.clear_table("codification_table");
+					$.each(data.message.codification_table, function (k, val) {
 						if (val.code_value) {
 							let mcode = frm.add_child("codification_table");
-							mcode.code_value = val.code_value
-							mcode.code_system = val.code_system
-							mcode.code = val.code
-							mcode.description = val.description
-							mcode.system = val.system
+							mcode.code_value = val.code_value;
+							mcode.code_system = val.code_system;
+							mcode.code = val.code;
+							mcode.description = val.description;
+							mcode.system = val.system;
 						}
 					});
 					refresh_field("codification_table");
-					refresh_field('exercises');
-				}
+					refresh_field("exercises");
+				},
 			});
 		} else {
-			frm.clear_table("codification_table")
+			frm.clear_table("codification_table");
 			frm.refresh_field("codification_table");
 		}
 	},
 
-	set_warehouse: function(frm) {
+	set_warehouse: function (frm) {
 		if (!frm.doc.warehouse) {
 			frappe.call({
-				method: 'frappe.client.get_value',
+				method: "frappe.client.get_value",
 				args: {
-					doctype: 'Stock Settings',
-					fieldname: 'default_warehouse'
+					doctype: "Stock Settings",
+					fieldname: "default_warehouse",
 				},
 				callback: function (data) {
-					frm.set_value('warehouse', data.message.default_warehouse);
-				}
+					frm.set_value("warehouse", data.message.default_warehouse);
+				},
 			});
 		}
 	},
 
-	set_therapy_consumables: function(frm) {
+	set_therapy_consumables: function (frm) {
 		frappe.call({
-			method: 'healthcare.healthcare.doctype.therapy_session.therapy_session.get_therapy_consumables',
+			method: "healthcare.healthcare.doctype.therapy_session.therapy_session.get_therapy_consumables",
 			args: {
-				therapy_type: frm.doc.therapy_type
+				therapy_type: frm.doc.therapy_type,
 			},
-			callback: function(data) {
+			callback: function (data) {
 				if (data.message) {
 					frm.doc.items = [];
-					$.each(data.message, function(i, v) {
-						let item = frm.add_child('items');
+					$.each(data.message, function (i, v) {
+						let item = frm.add_child("items");
 						item.item_code = v.item_code;
 						item.item_name = v.item_name;
 						item.uom = v.uom;
@@ -393,95 +446,132 @@ frappe.ui.form.on('Therapy Session', {
 						item.qty = flt(v.qty);
 						item.transfer_qty = v.transfer_qty;
 						item.conversion_factor = v.conversion_factor;
-						item.invoice_separately_as_consumables = v.invoice_separately_as_consumables;
+						item.invoice_separately_as_consumables =
+							v.invoice_separately_as_consumables;
 						item.batch_no = v.batch_no;
 					});
-					refresh_field('items');
+					refresh_field("items");
 				}
-			}
+			},
 		});
-	}
+	},
 });
 
-frappe.ui.form.on('Clinical Procedure Item', {
-	qty: function(frm, cdt, cdn) {
+frappe.ui.form.on("Clinical Procedure Item", {
+	qty: function (frm, cdt, cdn) {
 		let d = locals[cdt][cdn];
-		frappe.model.set_value(cdt, cdn, 'transfer_qty', d.qty*d.conversion_factor);
+		frappe.model.set_value(cdt, cdn, "transfer_qty", d.qty * d.conversion_factor);
 	},
 
-	uom: function(doc, cdt, cdn) {
+	uom: function (doc, cdt, cdn) {
 		let d = locals[cdt][cdn];
 		if (d.uom && d.item_code) {
 			return frappe.call({
-				method: 'erpnext.stock.doctype.stock_entry.stock_entry.get_uom_details',
+				method: "erpnext.stock.doctype.stock_entry.stock_entry.get_uom_details",
 				args: {
 					item_code: d.item_code,
 					uom: d.uom,
-					qty: d.qty
+					qty: d.qty,
 				},
-				callback: function(r) {
+				callback: function (r) {
 					if (r.message) {
 						frappe.model.set_value(cdt, cdn, r.message);
 					}
-				}
+				},
 			});
 		}
 	},
 
-	item_code: function(frm, cdt, cdn) {
+	item_code: function (frm, cdt, cdn) {
 		let d = locals[cdt][cdn];
 		let args = null;
 		if (d.item_code) {
 			args = {
-				'doctype' : 'Clinical Procedure',
-				'item_code' : d.item_code,
-				'company' : frm.doc.company,
-				'warehouse': frm.doc.warehouse
+				doctype: "Clinical Procedure",
+				item_code: d.item_code,
+				company: frm.doc.company,
+				warehouse: frm.doc.warehouse,
 			};
 			return frappe.call({
-				method: 'healthcare.healthcare.doctype.clinical_procedure_template.clinical_procedure_template.get_item_details',
-				args: {args: args},
-				callback: function(r) {
+				method: "healthcare.healthcare.doctype.clinical_procedure_template.clinical_procedure_template.get_item_details",
+				args: { args: args },
+				callback: function (r) {
 					if (r.message) {
 						let d = locals[cdt][cdn];
-						$.each(r.message, function(k, v) {
+						$.each(r.message, function (k, v) {
 							d[k] = v;
 						});
-						refresh_field('items');
+						refresh_field("items");
 					}
-				}
+				},
 			});
 		}
-	}
+	},
 });
 
-let calculate_age = function(birth) {
+let calculate_age = function (birth) {
 	let ageMS = Date.parse(Date()) - Date.parse(birth);
 	let age = new Date();
 	age.setTime(ageMS);
-	let years =  age.getFullYear() - 1970;
-	return `${years} ${__('Years(s)')} ${age.getMonth()} ${__('Month(s)')} ${age.getDate()} ${__('Day(s)')}`;
+	let years = age.getFullYear() - 1970;
+	return `${years} ${__("Years(s)")} ${age.getMonth()} ${__(
+		"Month(s)",
+	)} ${age.getDate()} ${__("Day(s)")}`;
 };
 
 async function handleStockCheck(frm, onAvailable, onUnavailable) {
-	let has_stock = await frm.trigger('verify_stock');
+	let has_stock = await frm.trigger("verify_stock");
 	if (has_stock) {
-		frappe.show_alert({ message: __('Required stock is available'), indicator: 'green' });
+		frappe.show_alert({
+			message: __("Required stock is available"),
+			indicator: "green",
+		});
 		onAvailable();
 	} else {
-		frappe.show_alert({ message: __('Required stock is not available'), indicator: 'blue' });
+		frappe.show_alert({
+			message: __("Required stock is not available"),
+			indicator: "blue",
+		});
 		onUnavailable();
 	}
 }
 
+frappe.ui.form.on("Codification Table", {
+	code_value_set: function (frm, cdt, cdn) {
+		frappe.require("assets/healthcare/js/utils.js", function () {
+			healthcare.utils.set_codification_table_query(frm);
+		});
+	},
+	code_system: function (frm, cdt, cdn) {
+		frappe.require("assets/healthcare/js/utils.js", function () {
+			healthcare.utils.set_codification_table_query(frm);
+		});
+	},
+	code_value: function (frm, cdt, cdn) {
+		var row = locals[cdt][cdn];
+		if (!row.code_value_set) {
+			frappe.require("assets/healthcare/js/utils.js", function () {
+				healthcare.utils.auto_table_code_val_set(frm, cdt, cdn);
+			});
+		}
+		frappe.require("assets/healthcare/js/utils.js", function () {
+			healthcare.utils.set_codification_table_query(frm);
+		});
+	},
+});
+
 function add_consumption_status_headline(frm) {
-	if (frm.doc.docstatus === 1 && frm.doc.consumption_status && frm.doc.items?.length) {
-		if (frm.doc.consumption_status === 'Consumption Pending') {
-			frm.dashboard.set_headline(__('Consumption Pending'), 'blue', true);
-		} else if (frm.doc.consumption_status === 'Consumption Completed') {
-			frm.dashboard.set_headline(__('Consumption Completed'), 'green', true);
-		} else if (frm.doc.consumption_status === 'Insufficient Stock') {
-			frm.dashboard.set_headline(__('Insufficient Stock'), 'orange', true);
+	if (
+		frm.doc.docstatus === 1 &&
+		frm.doc.consumption_status &&
+		frm.doc.items?.length
+	) {
+		if (frm.doc.consumption_status === "Consumption Pending") {
+			frm.dashboard.set_headline(__("Consumption Pending"), "blue", true);
+		} else if (frm.doc.consumption_status === "Consumption Completed") {
+			frm.dashboard.set_headline(__("Consumption Completed"), "green", true);
+		} else if (frm.doc.consumption_status === "Insufficient Stock") {
+			frm.dashboard.set_headline(__("Insufficient Stock"), "orange", true);
 		}
 	}
 }

--- a/healthcare/healthcare/doctype/therapy_type/therapy_type.js
+++ b/healthcare/healthcare/doctype/therapy_type/therapy_type.js
@@ -1,94 +1,126 @@
 // Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and contributors
 // For license information, please see license.txt
 
-frappe.ui.form.on('Therapy Type', {
-	setup: function(frm) {
-		frm.get_field('exercises').grid.editable_fields = [
-			{fieldname: 'exercise_type', columns: 7},
-			{fieldname: 'difficulty_level', columns: 1},
-			{fieldname: 'counts_target', columns: 1},
-			{fieldname: 'assistance_level', columns: 1}
+frappe.ui.form.on("Therapy Type", {
+	setup: function (frm) {
+		frm.get_field("exercises").grid.editable_fields = [
+			{ fieldname: "exercise_type", columns: 7 },
+			{ fieldname: "difficulty_level", columns: 1 },
+			{ fieldname: "counts_target", columns: 1 },
+			{ fieldname: "assistance_level", columns: 1 },
 		];
 	},
 
-	refresh: function(frm) {
+	refresh: function (frm) {
 		if (!frm.doc.__islocal) {
-			cur_frm.add_custom_button(__('Change Item Code'), function() {
+			cur_frm.add_custom_button(__("Change Item Code"), function () {
 				change_template_code(frm.doc);
 			});
 		}
 
-		frm.set_query("code_value", "codification_table", function(doc, cdt, cdn) {
+		frm.set_query("code_value", "codification_table", function (doc, cdt, cdn) {
 			let row = frappe.get_doc(cdt, cdn);
 			if (row.code_system) {
 				return {
 					filters: {
-						code_system: row.code_system
-					}
+						code_system: row.code_system,
+					},
 				};
 			}
-		})
+		});
 
-		frm.set_query('staff_role', function () {
+		frm.set_query("staff_role", function () {
 			return {
 				filters: {
-					'restrict_to_domain': 'Healthcare'
-				}
+					restrict_to_domain: "Healthcare",
+				},
 			};
+		});
+
+		frappe.require("assets/healthcare/js/utils.js", function () {
+			healthcare.utils.set_codification_table_query(frm);
 		});
 	},
 
-	therapy_type: function(frm) {
-		if (!frm.doc.item_code)
-			frm.set_value('item_code', frm.doc.therapy_type);
-		if (!frm.doc.description)
-			frm.set_value('description', frm.doc.therapy_type);
+	before_save: async function (frm) {
+		await new Promise(function (resolve) {
+			frappe.require("assets/healthcare/js/utils.js", resolve);
+		});
+		await healthcare.utils.before_save_check(frm);
+	},
+
+	therapy_type: function (frm) {
+		if (!frm.doc.item_code) frm.set_value("item_code", frm.doc.therapy_type);
+		if (!frm.doc.description) frm.set_value("description", frm.doc.therapy_type);
 	},
 });
 
-let change_template_code = function(doc) {
+let change_template_code = function (doc) {
 	let d = new frappe.ui.Dialog({
-		title:__('Change Item Code'),
-		fields:[
+		title: __("Change Item Code"),
+		fields: [
 			{
-				'fieldtype': 'Data',
-				'label': 'Item Code',
-				'fieldname': 'item_code',
-				reqd: 1
-			}
+				fieldtype: "Data",
+				label: "Item Code",
+				fieldname: "item_code",
+				reqd: 1,
+			},
 		],
-		primary_action: function() {
+		primary_action: function () {
 			let values = d.get_values();
 
 			if (values) {
 				frappe.call({
-					'method': 'healthcare.healthcare.doctype.therapy_type.therapy_type.change_item_code_from_therapy',
-					'args': {item_code: values.item_code, doc: doc},
+					method: "healthcare.healthcare.doctype.therapy_type.therapy_type.change_item_code_from_therapy",
+					args: { item_code: values.item_code, doc: doc },
 					callback: function () {
 						cur_frm.reload_doc();
 						frappe.show_alert({
-							message: 'Item Code renamed successfully',
-							indicator: 'green'
+							message: "Item Code renamed successfully",
+							indicator: "green",
 						});
-					}
+					},
 				});
 			}
 			d.hide();
 		},
-		primary_action_label: __('Change Item Code')
+		primary_action_label: __("Change Item Code"),
 	});
 	d.show();
 
 	d.set_values({
-		'item_code': doc.item_code
+		item_code: doc.item_code,
 	});
 };
 
+frappe.ui.form.on("Codification Table", {
+	code_value_set: function (frm, cdt, cdn) {
+		frappe.require("assets/healthcare/js/utils.js", function () {
+			healthcare.utils.set_codification_table_query(frm);
+		});
+	},
+	code_system: function (frm, cdt, cdn) {
+		frappe.require("assets/healthcare/js/utils.js", function () {
+			healthcare.utils.set_codification_table_query(frm);
+		});
+	},
+	code_value: function (frm, cdt, cdn) {
+		var row = locals[cdt][cdn];
+		if (!row.code_value_set) {
+			frappe.require("assets/healthcare/js/utils.js", function () {
+				healthcare.utils.auto_table_code_val_set(frm, cdt, cdn);
+			});
+		}
+		frappe.require("assets/healthcare/js/utils.js", function () {
+			healthcare.utils.set_codification_table_query(frm);
+		});
+	},
+});
 
-frappe.ui.form.on('Clinical Procedure Item', {
+frappe.ui.form.on("Clinical Procedure Item", {
 	qty: function (frm, cdt, cdn) {
 		let d = locals[cdt][cdn];
-		frappe.model.set_value(cdt, cdn, 'transfer_qty', d.qty * d.conversion_factor);
+		frappe.model.set_value(cdt, cdn, "transfer_qty", d.qty * d.conversion_factor);
 		console.log(d.qty, d.conversion_factor, d.transfer_qty);
 	},
 
@@ -96,17 +128,17 @@ frappe.ui.form.on('Clinical Procedure Item', {
 		let d = locals[cdt][cdn];
 		if (d.uom && d.item_code) {
 			return frappe.call({
-				method: 'erpnext.stock.doctype.stock_entry.stock_entry.get_uom_details',
+				method: "erpnext.stock.doctype.stock_entry.stock_entry.get_uom_details",
 				args: {
 					item_code: d.item_code,
 					uom: d.uom,
-					qty: d.qty
+					qty: d.qty,
 				},
 				callback: function (r) {
 					if (r.message) {
 						frappe.model.set_value(cdt, cdn, r.message);
 					}
-				}
+				},
 			});
 		}
 	},
@@ -115,12 +147,12 @@ frappe.ui.form.on('Clinical Procedure Item', {
 		let d = locals[cdt][cdn];
 		if (d.item_code) {
 			let args = {
-				'item_code': d.item_code,
-				'transfer_qty': d.transfer_qty,
-				'quantity': d.qty
+				item_code: d.item_code,
+				transfer_qty: d.transfer_qty,
+				quantity: d.qty,
 			};
 			return frappe.call({
-				method: 'healthcare.healthcare.doctype.therapy_type.therapy_type.get_item_details',
+				method: "healthcare.healthcare.doctype.therapy_type.therapy_type.get_item_details",
 				args: { args: args },
 				callback: function (r) {
 					if (r.message) {
@@ -128,10 +160,10 @@ frappe.ui.form.on('Clinical Procedure Item', {
 						$.each(r.message, function (k, v) {
 							d[k] = v;
 						});
-						refresh_field('items');
+						refresh_field("items");
 					}
-				}
+				},
 			});
 		}
-	}
+	},
 });

--- a/healthcare/healthcare/utils.py
+++ b/healthcare/healthcare/utils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-utils
 # Copyright (c) 2018, earthians and contributors
 # For license information, please see license.txt
 
@@ -87,8 +86,8 @@ def get_appointments_to_invoice(patient, company):
 						"reference_type": "Patient Appointment",
 						"reference_name": appointment.name,
 						"service": appointment.procedure_template,
-						"practitioner" : appointment.practitioner,
-						"date" : appointment.appointment_date
+						"practitioner": appointment.practitioner,
+						"date": appointment.appointment_date,
 					}
 				)
 		# Consultation Appointments, should check fee validity
@@ -100,11 +99,11 @@ def get_appointments_to_invoice(patient, company):
 			practitioner_charge = 0
 			income_account = None
 			service_item = None
-			service_name=None
+			service_name = None
 			if appointment.practitioner:
 				details = get_appointment_billing_item_and_rate(appointment)
 				service_item = details.get("service_item")
-				service_name=frappe.db.get_value("Item",service_item,"item_name")
+				service_name = frappe.db.get_value("Item", service_item, "item_name")
 				practitioner_charge = details.get("practitioner_charge")
 				income_account = get_income_account(appointment.practitioner, appointment.company)
 			appointments_to_invoice.append(
@@ -112,15 +111,16 @@ def get_appointments_to_invoice(patient, company):
 					"reference_type": "Patient Appointment",
 					"reference_name": appointment.name,
 					"service": service_item,
-					"service_name":service_name,
+					"service_name": service_name,
 					"rate": practitioner_charge,
 					"income_account": income_account,
 					"practitioner": appointment.practitioner,
-					"date": appointment.appointment_date
+					"date": appointment.appointment_date,
 				}
 			)
 
 	return appointments_to_invoice
+
 
 def get_package_subscriptions_to_invoice(patient, company):
 	subscriptions_to_invoice = []
@@ -142,16 +142,27 @@ def get_package_subscriptions_to_invoice(patient, company):
 		)
 		if not item_wise_invoicing:
 			subscriptions_to_invoice.append(
-				{"reference_type": "Package Subscription", "reference_name": sub.name, "service": item, "date" : sub.valid_to}
+				{
+					"reference_type": "Package Subscription",
+					"reference_name": sub.name,
+					"service": item,
+					"date": sub.valid_to,
+				}
 			)
 		else:
 			for item in subscription_doc.package_details:
 				if not item.invoiced:
 					subscriptions_to_invoice.append(
-						{"reference_type": item.doctype, "reference_name": item.name, "service": item.item_code , "date": sub.valid_to}
+						{
+							"reference_type": item.doctype,
+							"reference_name": item.name,
+							"service": item.item_code,
+							"date": sub.valid_to,
+						}
 					)
 
 	return subscriptions_to_invoice
+
 
 def get_encounters_to_invoice(patient, company):
 	if not isinstance(patient, str):
@@ -188,7 +199,7 @@ def get_encounters_to_invoice(patient, company):
 						"service": service_item,
 						"rate": practitioner_charge,
 						"income_account": income_account,
-						"date" : encounter.encounter_date
+						"date": encounter.encounter_date,
 					}
 				)
 
@@ -215,7 +226,12 @@ def get_lab_tests_to_invoice(patient, company):
 		)
 		if is_billable:
 			lab_tests_to_invoice.append(
-				{"reference_type": "Lab Test", "reference_name": lab_test.name, "service": item, "date":lab_test.date}
+				{
+					"reference_type": "Lab Test",
+					"reference_name": lab_test.name,
+					"service": item,
+					"date": lab_test.date,
+				}
 			)
 
 	return lab_tests_to_invoice
@@ -243,7 +259,12 @@ def get_observations_to_invoice(patient, company):
 		)
 		if is_billable:
 			observations_to_invoice.append(
-				{"reference_type": "Observation", "reference_name": observation.name, "service": item, "date" : observation.posting_date}
+				{
+					"reference_type": "Observation",
+					"reference_name": observation.name,
+					"service": item,
+					"date": observation.posting_date,
+				}
 			)
 
 	return observations_to_invoice
@@ -261,7 +282,7 @@ def get_clinical_procedures_to_invoice(patient, company):
 			"docstatus": 1,
 			"service_request": "",
 		},
-		order_by="start_date desc"
+		order_by="start_date desc",
 	)
 	for procedure in procedures:
 		if not procedure.appointment:
@@ -270,7 +291,12 @@ def get_clinical_procedures_to_invoice(patient, company):
 			)
 			if procedure.procedure_template and is_billable:
 				clinical_procedures_to_invoice.append(
-					{"reference_type": "Clinical Procedure", "reference_name": procedure.name, "service": item, "date" : procedure.start_date}
+					{
+						"reference_type": "Clinical Procedure",
+						"reference_name": procedure.name,
+						"service": item,
+						"date": procedure.start_date,
+					}
 				)
 
 		# consumables
@@ -317,7 +343,7 @@ def get_inpatient_services_to_invoice(patient, company):
 				and io.parent=ip.name
 				and io.left=1
 				and io.invoiced=0
-			Order By 
+			Order By
 				ip.scheduled_date DESC
 		""",
 		(patient.name, company),
@@ -350,7 +376,7 @@ def get_inpatient_services_to_invoice(patient, company):
 					"reference_name": inpatient_occupancy.name,
 					"service": service_unit_type.item,
 					"qty": qty,
-					"date": inpatient_occupancy.scheduled_date
+					"date": inpatient_occupancy.scheduled_date,
 				}
 			)
 
@@ -369,7 +395,7 @@ def get_therapy_plans_to_invoice(patient, company):
 			"therapy_plan_template": ("!=", ""),
 			"docstatus": 1,
 		},
-		order_by="start_date desc"
+		order_by="start_date desc",
 	)
 	for plan in therapy_plans:
 		therapy_plans_to_invoice.append(
@@ -379,7 +405,7 @@ def get_therapy_plans_to_invoice(patient, company):
 				"service": frappe.db.get_value(
 					"Therapy Plan Template", plan.therapy_plan_template, "linked_item"
 				),
-				"date" : plan.start_date
+				"date": plan.start_date,
 			}
 		)
 
@@ -404,7 +430,7 @@ def get_therapy_sessions_to_invoice(patient, company):
 			"docstatus": 1,
 			"service_request": "",
 		},
-		order_by="start_date desc"
+		order_by="start_date desc",
 	)
 	for therapy in therapy_sessions:
 		if not therapy.appointment:
@@ -416,7 +442,7 @@ def get_therapy_sessions_to_invoice(patient, company):
 						"reference_type": "Therapy Session",
 						"reference_name": therapy.name,
 						"service": frappe.db.get_value("Therapy Type", therapy.therapy_type, "item"),
-						"date" : therapy.start_date
+						"date": therapy.start_date,
 					}
 				)
 
@@ -434,7 +460,7 @@ def get_service_requests_to_invoice(patient, company):
 			"billing_status": ["!=", "Invoiced"],
 			"docstatus": 1,
 		},
-		order_by= "order_date desc"
+		order_by="order_date desc",
 	)
 	for service_request in service_requests:
 		item, is_billable = frappe.get_cached_value(
@@ -458,7 +484,7 @@ def get_service_requests_to_invoice(patient, company):
 					"reference_name": service_request.name,
 					"service": item,
 					"qty": service_request.quantity if service_request.quantity else 1,
-					"date": service_request.order_date 
+					"date": service_request.order_date,
 				}
 			)
 	return orders_to_invoice
@@ -478,9 +504,7 @@ def get_appointment_billing_item_and_rate(doc):
 	is_inpatient = doc.inpatient_record
 
 	if doc.get("practitioner"):
-		service_item, practitioner_charge = get_practitioner_billing_details(
-			doc.practitioner, is_inpatient
-		)
+		service_item, practitioner_charge = get_practitioner_billing_details(doc.practitioner, is_inpatient)
 
 	if not service_item and doc.get("appointment_type"):
 		service_item, appointment_charge = get_appointment_type_billing_details(
@@ -531,7 +555,7 @@ def throw_config_service_item(is_inpatient):
 	)
 
 	msg = _(
-		("Please Configure {0} in ").format(service_item_label)
+		(f"Please Configure {service_item_label} in ")
 		+ """<b><a href='/app/Form/Healthcare Settings'>Healthcare Settings</a></b>"""
 	)
 	frappe.throw(msg, title=_("Missing Configuration"))
@@ -541,8 +565,8 @@ def throw_config_practitioner_charge(is_inpatient, practitioner):
 	charge_name = _("Inpatient Visit Charge") if is_inpatient else _("OP Consulting Charge")
 
 	msg = _(
-		("Please Configure {0} for Healthcare Practitioner").format(charge_name)
-		+ """ <b><a href='/app/Form/Healthcare Practitioner/{0}'>{0}</a></b>""".format(practitioner)
+		(f"Please Configure {charge_name} for Healthcare Practitioner")
+		+ f""" <b><a href='/app/Form/Healthcare Practitioner/{practitioner}'>{practitioner}</a></b>"""
 	)
 	frappe.throw(msg, title=_("Missing Configuration"))
 
@@ -551,8 +575,8 @@ def throw_config_appointment_type_charge(is_inpatient, appointment_type):
 	charge_name = _("Inpatient Visit Charge") if is_inpatient else _("OP Consulting Charge")
 
 	msg = _(
-		("Please Configure {0} for Appointment Type").format(charge_name)
-		+ """ <b><a href='/app/Form/Appointment type/{0}'>{0}</a></b>""".format(appointment_type)
+		(f"Please Configure {charge_name} for Appointment Type")
+		+ f""" <b><a href='/app/Form/Appointment type/{appointment_type}'>{appointment_type}</a></b>"""
 	)
 	frappe.throw(msg, title=_("Missing Configuration"))
 
@@ -635,7 +659,9 @@ def manage_invoice_submit_cancel(doc, method):
 		):
 			for item in doc.items:
 				if item.reference_dt == "Patient Appointment":
-					fee_validity = frappe.db.exists("Fee Validity", {"patient_appointment": item.reference_dn})
+					fee_validity = frappe.db.exists(
+						"Fee Validity", {"patient_appointment": item.reference_dn}
+					)
 					if fee_validity:
 						frappe.db.set_value("Fee Validity", fee_validity, "sales_invoice_ref", doc.name)
 
@@ -656,8 +682,10 @@ def manage_invoice_submit_cancel(doc, method):
 						},
 					)
 
+
 def update_therapy_plan(self, method):
 	from healthcare.healthcare.doctype.therapy_plan.therapy_plan import get_invoiced_details
+
 	for row in self.items:
 		if row.reference_dt == "Therapy Plan":
 			doc = frappe.get_doc(row.reference_dt, row.reference_dn)
@@ -666,7 +694,7 @@ def update_therapy_plan(self, method):
 			# doc.flags.ignore_permissions = True
 			# doc.save()
 			total_paid_amount = data.get("paid_amount") or data.get("grand_total")
-			no_of_session = data.get("no_of_session") 
+			no_of_session = data.get("no_of_session")
 
 			frappe.db.set_value("Therapy Plan", row.reference_dn, "invoiced_amount", total_paid_amount)
 			frappe.db.set_value("Therapy Plan", row.reference_dn, "invoice_json", data.get("data"))
@@ -681,7 +709,7 @@ def update_therapy_plan(self, method):
 				no_of_session = data.get("no_of_session")
 
 				total_paid_amount = data.get("grand_total")
-				no_of_session = data.get("no_of_session") 
+				no_of_session = data.get("no_of_session")
 
 				frappe.db.set_value("Therapy Plan", therapy_plan, "invoice_json", data.get("data"))
 				frappe.db.set_value("Therapy Plan", therapy_plan, "total_invoiced_session", no_of_session)
@@ -694,9 +722,7 @@ def set_invoiced(item, method, ref_invoice=None):
 		invoiced = True
 
 	if item.reference_dt == "Clinical Procedure":
-		service_item = frappe.db.get_single_value(
-			"Healthcare Settings", "clinical_procedure_consumable_item"
-		)
+		service_item = frappe.db.get_single_value("Healthcare Settings", "clinical_procedure_consumable_item")
 		if service_item == item.item_code:
 			frappe.db.set_value(item.reference_dt, item.reference_dn, "consumption_invoiced", invoiced)
 		else:
@@ -713,9 +739,7 @@ def set_invoiced(item, method, ref_invoice=None):
 		manage_doc_for_appointment(dt_from_appointment, item.reference_dn, invoiced)
 
 	elif item.reference_dt == "Lab Prescription":
-		manage_prescriptions(
-			invoiced, item.reference_dt, item.reference_dn, "Lab Test", "lab_test_created"
-		)
+		manage_prescriptions(invoiced, item.reference_dt, item.reference_dn, "Lab Test", "lab_test_created")
 
 	elif item.reference_dt == "Procedure Prescription":
 		manage_prescriptions(
@@ -734,7 +758,7 @@ def set_invoiced(item, method, ref_invoice=None):
 			template_map = {
 				"Clinical Procedure Template": "Clinical Procedure",
 				"Therapy Type": "Therapy Session",
-				"Lab Test Template": "Lab Test"
+				"Lab Test Template": "Lab Test",
 				# 'Healthcare Service Unit': 'Inpatient Occupancy'
 			}
 
@@ -783,9 +807,7 @@ def manage_prescriptions(invoiced, ref_dt, ref_dn, dt, created_check_field):
 
 
 def manage_doc_for_appointment(dt_from_appointment, appointment, invoiced):
-	dn_from_appointment = frappe.db.get_value(
-		dt_from_appointment, filters={"appointment": appointment}
-	)
+	dn_from_appointment = frappe.db.get_value(dt_from_appointment, filters={"appointment": appointment})
 	if dn_from_appointment:
 		frappe.db.set_value(dt_from_appointment, dn_from_appointment, "invoiced", invoiced)
 
@@ -821,7 +843,9 @@ def get_drugs_to_invoice(encounter, customer, link_customer=False):
 
 				description = ""
 				if medication_request.dosage and medication_request.period:
-					description = _("{0} for {1}").format(medication_request.dosage, medication_request.period)
+					description = _("{0} for {1}").format(
+						medication_request.dosage, medication_request.period
+					)
 
 				if medication_request.medication_item and is_billable:
 					billable_order_qty = medication_request.get("quantity", 1) - medication_request.get(
@@ -835,7 +859,8 @@ def get_drugs_to_invoice(encounter, customer, link_customer=False):
 							billable_order_qty = medication_request.get("quantity", 1)
 						else:
 							billable_order_qty = (
-								medication_request.total_dispensable_quantity - medication_request.get("qty_invoiced", 0)
+								medication_request.total_dispensable_quantity
+								- medication_request.get("qty_invoiced", 0)
 							)
 
 					orders_to_invoice.append(
@@ -891,7 +916,7 @@ def get_children(doctype, parent=None, company=None, is_root=False):
 				},
 			)
 			# set occupancy status of group node
-			each["occupied_of_available"] = f"{str(occupied_count)} Occupied of {str(available_count)}"
+			each["occupied_of_available"] = f"{occupied_count!s} Occupied of {available_count!s}"
 
 	return service_units
 
@@ -941,21 +966,19 @@ def render_doc_as_html(doctype, docname, exclude_fields=None):
 				doc_html += section_html + html + "</div>"
 
 			elif has_data and not col_on and sec_on:
-				doc_html += """
+				doc_html += f"""
 					<br>
 					<div class='row'>
 						<div class='col-md-12 col-sm-12'>
-							<b>{0}</b>
+							<b>{section_label}</b>
 						</div>
 					</div>
 					<div class='row'>
 						<div class='col-md-12 col-sm-12'>
-							{1} {2}
+							{section_html} {html}
 						</div>
 					</div>
-				""".format(
-					section_label, section_html, html
-				)
+				"""
 
 			# close divs for columns
 			while col_on:
@@ -974,34 +997,30 @@ def render_doc_as_html(doctype, docname, exclude_fields=None):
 		# on column break append html to section html or doc html
 		if df.fieldtype == "Column Break":
 			if sec_on and not col_on and has_data:
-				section_html += """
+				section_html += f"""
 					<br>
 					<div class='row'>
 						<div class='col-md-12 col-sm-12'>
-							<b>{0}</b>
+							<b>{section_label}</b>
 						</div>
 					</div>
 					<div class='row'>
 						<div class='col-md-4 col-sm-4'>
-							{1}
+							{html}
 						</div>
-				""".format(
-					section_label, html
-				)
+				"""
 			elif col_on == 1 and has_data:
 				section_html += "<div class='col-md-4 col-sm-4'>" + html + "</div>"
 			elif col_on > 1 and has_data:
 				doc_html += "<div class='col-md-4 col-sm-4'>" + html + "</div>"
 			else:
-				doc_html += """
+				doc_html += f"""
 					<div class='row'>
 						<div class='col-md-12 col-sm-12'>
-							{0}
+							{html}
 						</div>
 					</div>
-				""".format(
-					html
-				)
+				"""
 
 			html = ""
 			col_on += 1
@@ -1039,21 +1058,17 @@ def render_doc_as_html(doctype, docname, exclude_fields=None):
 				table_row += "</tr>"
 
 			if sec_on:
-				section_html += """
+				section_html += f"""
 					<table class='table table-condensed bordered'>
-						{0} {1}
+						{table_head} {table_row}
 					</table>
-				""".format(
-					table_head, table_row
-				)
+				"""
 			else:
-				html += """
+				html += f"""
 					<table class='table table-condensed table-bordered'>
-						{0} {1}
+						{table_head} {table_row}
 					</table>
-				""".format(
-					table_head, table_row
-				)
+				"""
 			continue
 
 		# on any other field type add label and value to html
@@ -1064,7 +1079,7 @@ def render_doc_as_html(doctype, docname, exclude_fields=None):
 			and df.fieldname not in exclude_fields
 		):
 			formatted_value = format_value(doc.get(df.fieldname), meta.get_field(df.fieldname), doc)
-			html += "<br>{0} : {1}".format(df.label or df.fieldname, formatted_value)
+			html += f"<br>{df.label or df.fieldname} : {formatted_value}"
 
 			if not has_data:
 				has_data = True
@@ -1072,15 +1087,13 @@ def render_doc_as_html(doctype, docname, exclude_fields=None):
 	if sec_on and col_on and has_data:
 		doc_html += section_html + html + "</div></div>"
 	elif sec_on and not col_on and has_data:
-		doc_html += """
+		doc_html += f"""
 			<div class='col-md-12 col-sm-12'>
 				<div class='col-md-12 col-sm-12'>
-					{0} {1}
+					{section_html} {html}
 				</div>
 			</div>
-		""".format(
-			section_html, html
-		)
+		"""
 	return {"html": doc_html}
 
 
@@ -1202,6 +1215,7 @@ def get_medical_codes(template_dt, template_dn, code_standard=None):
 			"system",
 			"definition",
 			"code_system",
+			"code_value_set",
 		],
 	)
 
@@ -1279,7 +1293,10 @@ def create_sample_collection_and_observation(doc):
 		if meta.has_field("patient"):
 			sample_collection = create_sample_collection(doc, patient)
 			for obs in out_data[grp]:
-				(sample_collection, diag_report_required,) = insert_observation_and_sample_collection(
+				(
+					sample_collection,
+					diag_report_required,
+				) = insert_observation_and_sample_collection(
 					doc, patient, obs, sample_collection, obs.get("child")
 				)
 			if sample_collection and len(sample_collection.get("observation_sample_collection")) > 0:
@@ -1454,9 +1471,7 @@ def insert_observation_and_sample_collection(
 
 def has_direct_leaf_component(template_name):
 	"""Return True if the given template has at least one direct leaf child."""
-	sample_reqd_component_obs, non_sample_reqd_component_obs = get_observation_template_details(
-		template_name
-	)
+	sample_reqd_component_obs, non_sample_reqd_component_obs = get_observation_template_details(template_name)
 	all_components = sample_reqd_component_obs + non_sample_reqd_component_obs
 
 	for comp in all_components:
@@ -1506,59 +1521,73 @@ def add_node():
 	frappe.get_doc(args).insert()
 
 
+@frappe.whitelist()
+def get_codification_row_code_data(code, code_system=None):
+	if not code_system:
+		frappe.throw("Code System is required")
+
+	row_data = frappe.get_list(
+		"Code Value",
+		fields=["value_set"],
+		filters={"code_system": code_system, "code_value": code},
+		limit_page_length=1,
+	)
+
+	return {"row_data": row_data}
+
+
 class PatientDuplicateChecker:
 	def __init__(self, patient_doc):
 		self.patient = patient_doc
 		self.settings = frappe.get_doc("Healthcare Settings")
 		self.duplicate_check_enabled = self.settings.get("enable_patient_duplicate_check", 0)
-		
+
 	def check_duplicates(self):
 		"""Check for duplicate patients based on configured rules"""
 		if not self.duplicate_check_enabled:
 			return {"status": "allow", "matches": []}
-			
+
 		# Get the configuration
 		rule_links = self.settings.get("patient_duplicate_check_rules", [])
-		
+
 		if not rule_links:
 			return {"status": "allow", "matches": []}
-			
+
 		# Get all rules and sort by priority
 		rules = []
 		for rule_link in rule_links:
 			if rule_link.rule_configuration:
-				rule_doc = frappe.get_doc("Patient Duplicate Check Rule Configuration", rule_link.rule_configuration)
+				rule_doc = frappe.get_doc(
+					"Patient Duplicate Check Rule Configuration", rule_link.rule_configuration
+				)
 				rules.append(rule_doc)
-		
+
 		if not rules:
 			return {"status": "allow", "matches": []}
-			
+
 		# Sort rules by priority
 		sorted_rules = sorted(rules, key=lambda x: x.priority)
-		
+
 		# Check each rule
 		for rule in sorted_rules:
 			result = self._check_rule(rule)
 			if result["status"] != "allow":
 				return result
-				
+
 		return {"status": "allow", "matches": []}
-	
+
 	def _check_rule(self, rule):
 		"""Check a specific rule against existing patients"""
-		if not hasattr(rule, 'duplicate_fields') or not rule.duplicate_fields:
+		if not hasattr(rule, "duplicate_fields") or not rule.duplicate_fields:
 			return {"status": "allow", "matches": []}
-		
+
 		filters = {}
-		
+
 		# Build filters based on rule fields
 		filters = {}
 
 		# Collect all field values
-		field_values = {
-			f.field_name: self.patient.get(f.field_name)
-			for f in rule.duplicate_fields
-		}
+		field_values = {f.field_name: self.patient.get(f.field_name) for f in rule.duplicate_fields}
 
 		# Check if all required fields have values
 		if all(value not in (None, "") for value in field_values.values()):
@@ -1567,36 +1596,34 @@ class PatientDuplicateChecker:
 			# If any field is missing, skip filters or handle accordingly
 			filters = {}
 
-		
 		if not filters:
 			return {"status": "allow", "matches": []}
-			
+
 		# Add filter to exclude current patient if it exists
 		if self.patient.name and not self.patient.flags.is_new_doc:
 			filters["name"] = ["!=", self.patient.name]
-			
+
 		# Query for matching patients
 		matches = frappe.get_all(
-			"Patient", 
-			filters=filters, 
-			fields=["name", "patient_name", "sex", "dob", "mobile", "email"]
+			"Patient", filters=filters, fields=["name", "patient_name", "sex", "dob", "mobile", "email"]
 		)
 
 		if matches:
 			return {
 				"status": rule.action.lower(),
 				"message": rule.message or _("Duplicate patient record(s) found"),
-				"matches": matches
+				"matches": matches,
 			}
-			
+
 		return {"status": "allow", "matches": []}
+
 
 @frappe.whitelist()
 def check_patient_duplicates(patient):
 	"""Utility function to check for patient duplicates from frontend"""
 	if isinstance(patient, str):
 		patient = frappe.parse_json(patient)
-		
+
 	doc = frappe.get_doc(dict(patient))
 	checker = PatientDuplicateChecker(doc)
 	return checker.check_duplicates()

--- a/healthcare/public/js/utils.js
+++ b/healthcare/public/js/utils.js
@@ -1,0 +1,93 @@
+frappe.provide("healthcare.utils");
+
+healthcare.utils.set_codification_table_query = function (frm) {
+	const grid = frm.fields_dict["codification_table"]?.grid;
+	if (!grid) return;
+
+	grid.get_field("code_value_set").get_query = function (doc, cdt, cdn) {
+		let row = locals[cdt][cdn];
+		if (!row) return;
+
+		if (row.code_system) {
+			return {
+				filters: {
+					code_system: row.code_system,
+				},
+			};
+		}
+	};
+
+	grid.get_field("code_value").get_query = function (doc, cdt, cdn) {
+		let row = locals[cdt][cdn];
+		if (!row) return;
+
+		if (row.code_system && row.code_value_set) {
+			return {
+				filters: {
+					code_system: row.code_system,
+					value_set: row.code_value_set,
+				},
+			};
+		}
+
+		if (row.code_system) {
+			return {
+				filters: {
+					code_system: row.code_system,
+				},
+			};
+		}
+	};
+};
+
+healthcare.utils.before_save_check = async function (frm) {
+	for (const row of frm.doc.codification_table) {
+		try {
+			const response = await frappe.call({
+				method: "healthcare.healthcare.utils.get_codification_row_code_data",
+				args: {
+					code: row.code,
+					code_system: row.code_system,
+				},
+			});
+
+			const server_value_set = response?.message?.row_data?.[0]?.value_set;
+
+			if (row.code_value_set && row.code_value_set !== server_value_set) {
+				frappe.msgprint(__("Mismatch in Code-data for row {0}", [row.idx]));
+				frappe.validated = false;
+				return false;
+			}
+		} catch (e) {
+			frappe.msgprint(__("Error checking row {0}: {1}", [row.idx, e.message]));
+			frappe.validated = false;
+			return false;
+		}
+	}
+};
+
+healthcare.utils.auto_table_code_val_set = function (frm, cdt, cdn) {
+	var row = locals[cdt][cdn];
+
+	if (!row.code_value_set && row.code_value) {
+		frappe.call({
+			method: "frappe.client.get_value",
+			args: {
+				doctype: "Code Value",
+				filters: { code_value: row.code },
+				fieldname: ["value_set"],
+			},
+			callback: function (response) {
+				if (response.message && response.message.value_set) {
+					frappe.model.set_value(
+						cdt,
+						cdn,
+						"code_value_set",
+						response.message.value_set,
+					);
+					frm.refresh_field("codification_table");
+				}
+			},
+		});
+	}
+};


### PR DESCRIPTION
## Summary

Ports the Codification Enhancement from [earthians/marley#953](https://github.com/earthians/marley/pull/953) into `biograph-fh`. This adds a **Code Value Set** field to the Codification Table, enabling sub-classification of code systems (e.g., grouping ICD-10 codes into Musculoskeletal, Cardiovascular categories).

**Key changes:**

- **New shared utility** (`healthcare/public/js/utils.js`): Three functions extracted into a reusable module:
  - `set_codification_table_query` — cascading filters: `code_system` → `code_value_set` → `code_value`
  - `before_save_check` — server-side validation of codification rows before save
  - `auto_table_code_val_set` — auto-populates `code_value_set` when a code value is selected

- **Schema**: `code_value_set` Link field added to `codification_table.json`; field added to `get_medical_codes()` return

- **New server function**: `get_codification_row_code_data()` (whitelisted) for before-save validation lookups

- **15 JS doctype files** updated with identical pattern: refresh hook → `set_codification_table_query`, `before_save` → `before_save_check`, and `Codification Table` child event handlers

- **Skipped**: version bump from upstream PR (biograph-fh has its own versioning)

> **Note:** `clinical_procedure_template.js` has a large diff due to prettier reformatting (single → double quotes). `utils.py` includes ruff auto-format changes (f-string conversions, whitespace) alongside the functional additions.

## Review & Testing Checklist for Human

- [ ] **Verify `before_save_check` behavior with async/await**: The handler sets `frappe.validated = false` inside an async function — confirm this actually prevents save in Frappe's lifecycle. Test with an intentional mismatch to ensure validation blocks the save.
- [ ] **Test cascading filters on Codification Table**: On at least 2-3 doctypes (e.g., Patient Encounter, Clinical Procedure, Lab Test Template), add a codification row and verify: selecting a `code_system` filters `code_value_set`, and selecting `code_value_set` further filters `code_value`.
- [ ] **Test auto-populate of `code_value_set`**: Select a `code_value` without first setting `code_value_set` — confirm it auto-fills from the Code Value record. Note: `auto_table_code_val_set` filters by `{ code_value: row.code }` (the code string, not the Link field name) — verify this matches your data model.
- [ ] **Check `get_codification_row_code_data` security**: This is `@frappe.whitelist()` with no explicit permission check — confirm this is acceptable for your security model, or add role-based guards.
- [ ] **Regression: existing codification without Code Value Set**: Verify that doctypes with existing codification rows (no `code_value_set` populated) still save and display correctly.

**Suggested test plan:** Open Patient Encounter → add a Codification Table row → select ICD-10 code system → verify code_value_set dropdown filters correctly → select a code_value → save → confirm no validation errors. Repeat on at least Clinical Procedure Template and Lab Test to confirm the pattern works across doctypes.

### Notes
- The 5 ruff lint errors that block pre-commit (`price_list`, `args`, `reference_flag`, `template_map` unused variables) are all **pre-existing** in `utils.py` and unrelated to this PR.
- `medication_request.js` contains a Jinja `{% include %}` directive which prettier cannot parse — this is expected and pre-existing.
- Some files (therapy_session.js, therapy_type.js, patient_encounter.js) retain their original `frm.set_query("code_value", "codification_table", ...)` alongside the new `set_codification_table_query` call. The new utility overrides via `grid.get_field().get_query` which takes precedence, so this is functionally fine but slightly redundant.

