### PR TITLE
fix: add missing `is_ot` field to Healthcare Service Unit Type

### DIFF
--- a/healthcare/healthcare/doctype/healthcare_service_unit_type/healthcare_service_unit_type.json
+++ b/healthcare/healthcare/doctype/healthcare_service_unit_type/healthcare_service_unit_type.json
@@ -1,205 +1,226 @@
 {
- "actions": [],
- "allow_import": 1,
- "allow_rename": 1,
- "autoname": "field:service_unit_type",
- "creation": "2018-07-11 16:47:51.414675",
- "doctype": "DocType",
- "editable_grid": 1,
- "engine": "InnoDB",
- "field_order": [
-  "disabled",
-  "service_unit_type",
-  "allow_appointments",
-  "overlap_appointments",
-  "inpatient_occupancy",
-  "is_billable",
-  "item_details",
-  "item",
-  "item_code",
-  "item_group",
-  "uom",
-  "no_of_hours",
-  "column_break_11",
-  "rate",
-  "description",
-  "change_in_item"
- ],
- "fields": [
-  {
-   "fieldname": "service_unit_type",
-   "fieldtype": "Data",
-   "hide_days": 1,
-   "hide_seconds": 1,
-   "in_list_view": 1,
-   "label": "Service Unit Type",
-   "no_copy": 1,
-   "reqd": 1,
-   "unique": 1
-  },
-  {
-   "bold": 1,
-   "default": "0",
-   "depends_on": "eval:doc.inpatient_occupancy != 1",
-   "fieldname": "allow_appointments",
-   "fieldtype": "Check",
-   "hide_days": 1,
-   "hide_seconds": 1,
-   "label": "Allow Appointments"
-  },
-  {
-   "bold": 1,
-   "default": "0",
-   "depends_on": "eval:doc.allow_appointments == 1 && doc.inpatient_occupany != 1",
-   "fieldname": "overlap_appointments",
-   "fieldtype": "Check",
-   "hide_days": 1,
-   "hide_seconds": 1,
-   "label": "Allow Overlap"
-  },
-  {
-   "bold": 1,
-   "default": "0",
-   "depends_on": "eval:doc.allow_appointments != 1",
-   "fieldname": "inpatient_occupancy",
-   "fieldtype": "Check",
-   "hide_days": 1,
-   "hide_seconds": 1,
-   "label": "Inpatient Occupancy"
-  },
-  {
-   "bold": 1,
-   "default": "0",
-   "depends_on": "eval:doc.inpatient_occupancy == 1 && doc.allow_appointments != 1",
-   "fieldname": "is_billable",
-   "fieldtype": "Check",
-   "hide_days": 1,
-   "hide_seconds": 1,
-   "label": "Is Billable"
-  },
-  {
-   "depends_on": "is_billable",
-   "fieldname": "item_details",
-   "fieldtype": "Section Break",
-   "hide_days": 1,
-   "hide_seconds": 1,
-   "label": "Item Details"
-  },
-  {
-   "fieldname": "item",
-   "fieldtype": "Link",
-   "hide_days": 1,
-   "hide_seconds": 1,
-   "label": "Item",
-   "no_copy": 1,
-   "options": "Item",
-   "read_only": 1
-  },
-  {
-   "fetch_from": "item.item_name",
-   "fieldname": "item_code",
-   "fieldtype": "Data",
-   "hide_days": 1,
-   "hide_seconds": 1,
-   "label": "Item Code",
-   "mandatory_depends_on": "eval: doc.is_billable == 1",
-   "no_copy": 1
-  },
-  {
-   "fieldname": "item_group",
-   "fieldtype": "Link",
-   "hide_days": 1,
-   "hide_seconds": 1,
-   "label": "Item Group",
-   "mandatory_depends_on": "eval: doc.is_billable == 1",
-   "options": "Item Group"
-  },
-  {
-   "fieldname": "uom",
-   "fieldtype": "Link",
-   "hide_days": 1,
-   "hide_seconds": 1,
-   "label": "UOM",
-   "mandatory_depends_on": "eval: doc.is_billable == 1",
-   "options": "UOM"
-  },
-  {
-   "fieldname": "no_of_hours",
-   "fieldtype": "Int",
-   "hide_days": 1,
-   "hide_seconds": 1,
-   "label": "UOM Conversion in Hours",
-   "mandatory_depends_on": "eval: doc.is_billable == 1"
-  },
-  {
-   "fieldname": "column_break_11",
-   "fieldtype": "Column Break",
-   "hide_days": 1,
-   "hide_seconds": 1
-  },
-  {
-   "fieldname": "rate",
-   "fieldtype": "Currency",
-   "hide_days": 1,
-   "hide_seconds": 1,
-   "label": "Rate / UOM"
-  },
-  {
-   "default": "0",
-   "fieldname": "disabled",
-   "fieldtype": "Check",
-   "hide_days": 1,
-   "hide_seconds": 1,
-   "label": "Disabled",
-   "no_copy": 1
-  },
-  {
-   "fetch_from": "item.description",
-   "fieldname": "description",
-   "fieldtype": "Small Text",
-   "hide_days": 1,
-   "hide_seconds": 1,
-   "label": "Description"
-  },
-  {
-   "default": "0",
-   "fieldname": "change_in_item",
-   "fieldtype": "Check",
-   "hidden": 1,
-   "hide_days": 1,
-   "hide_seconds": 1,
-   "label": "Change in Item"
-  }
- ],
- "links": [
-  {
-   "link_doctype": "Healthcare Service Unit",
-   "link_fieldname": "service_unit_type"
-  }
- ],
- "modified": "2025-09-25 15:04:43.831015",
- "modified_by": "Administrator",
- "module": "Healthcare",
- "name": "Healthcare Service Unit Type",
- "owner": "Administrator",
- "permissions": [
-  {
-   "create": 1,
-   "delete": 1,
-   "email": 1,
-   "export": 1,
-   "print": 1,
-   "read": 1,
-   "report": 1,
-   "role": "Healthcare Administrator",
-   "share": 1,
-   "write": 1
-  }
- ],
- "restrict_to_domain": "Healthcare",
- "row_format": "Dynamic",
- "sort_field": "modified",
- "sort_order": "DESC",
- "states": [],
- "title_field": "service_unit_type"
+	"actions": [],
+	"allow_import": 1,
+	"allow_rename": 1,
+	"autoname": "field:service_unit_type",
+	"creation": "2018-07-11 16:47:51.414675",
+	"doctype": "DocType",
+	"editable_grid": 1,
+	"engine": "InnoDB",
+	"field_order": [
+		"disabled",
+		"service_unit_type",
+		"allow_appointments",
+		"overlap_appointments",
+		"inpatient_occupancy",
+		"is_ot",
+		"is_billable",
+		"item_details",
+		"item",
+		"item_code",
+		"item_group",
+		"uom",
+		"no_of_hours",
+		"column_break_11",
+		"rate",
+		"description",
+		"change_in_item"
+	],
+	"fields": [
+		{
+			"fieldname": "service_unit_type",
+			"fieldtype": "Data",
+			"hide_days": 1,
+			"hide_seconds": 1,
+			"in_list_view": 1,
+			"label": "Service Unit Type",
+			"no_copy": 1,
+			"reqd": 1,
+			"unique": 1
+		},
+		{
+			"bold": 1,
+			"default": "0",
+			"depends_on": "eval:doc.inpatient_occupancy != 1",
+			"fieldname": "allow_appointments",
+			"fieldtype": "Check",
+			"hide_days": 1,
+			"hide_seconds": 1,
+			"label": "Allow Appointments"
+		},
+		{
+			"bold": 1,
+			"default": "0",
+			"depends_on": "eval:doc.allow_appointments == 1 && doc.inpatient_occupany != 1",
+			"fieldname": "overlap_appointments",
+			"fieldtype": "Check",
+			"hide_days": 1,
+			"hide_seconds": 1,
+			"label": "Allow Overlap"
+		},
+		{
+			"bold": 1,
+			"default": "0",
+			"depends_on": "eval:doc.allow_appointments != 1",
+			"fieldname": "inpatient_occupancy",
+			"fieldtype": "Check",
+			"hide_days": 1,
+			"hide_seconds": 1,
+			"label": "Inpatient Occupancy"
+		},
+		{
+			"bold": 1,
+			"default": "0",
+			"depends_on": "eval:doc.inpatient_occupancy == 1",
+			"fieldname": "is_ot",
+			"fieldtype": "Check",
+			"hide_days": 1,
+			"hide_seconds": 1,
+			"label": "Is OT"
+		},
+		{
+			"bold": 1,
+			"default": "0",
+			"depends_on": "eval:doc.inpatient_occupancy == 1 && doc.allow_appointments != 1",
+			"fieldname": "is_billable",
+			"fieldtype": "Check",
+			"hide_days": 1,
+			"hide_seconds": 1,
+			"label": "Is Billable"
+		},
+		{
+			"depends_on": "is_billable",
+			"fieldname": "item_details",
+			"fieldtype": "Section Break",
+			"hide_days": 1,
+			"hide_seconds": 1,
+			"label": "Item Details"
+		},
+		{
+			"fieldname": "item",
+			"fieldtype": "Link",
+			"hide_days": 1,
+			"hide_seconds": 1,
+			"label": "Item",
+			"no_copy": 1,
+			"options": "Item",
+			"read_only": 1
+		},
+		{
+			"fetch_from": "item.item_name",
+			"fieldname": "item_code",
+			"fieldtype": "Data",
+			"hide_days": 1,
+			"hide_seconds": 1,
+			"label": "Item Code",
+			"mandatory_depends_on": "eval: doc.is_billable == 1",
+			"no_copy": 1
+		},
+		{
+			"fieldname": "item_group",
+			"fieldtype": "Link",
+			"hide_days": 1,
+			"hide_seconds": 1,
+			"label": "Item Group",
+			"mandatory_depends_on": "eval: doc.is_billable == 1",
+			"options": "Item Group"
+		},
+		{
+			"fieldname": "uom",
+			"fieldtype": "Link",
+			"hide_days": 1,
+			"hide_seconds": 1,
+			"label": "UOM",
+			"mandatory_depends_on": "eval: doc.is_billable == 1",
+			"options": "UOM"
+		},
+		{
+			"fieldname": "no_of_hours",
+			"fieldtype": "Int",
+			"hide_days": 1,
+			"hide_seconds": 1,
+			"label": "UOM Conversion in Hours",
+			"mandatory_depends_on": "eval: doc.is_billable == 1"
+		},
+		{
+			"fieldname": "column_break_11",
+			"fieldtype": "Column Break",
+			"hide_days": 1,
+			"hide_seconds": 1
+		},
+		{
+			"fieldname": "rate",
+			"fieldtype": "Currency",
+			"hide_days": 1,
+			"hide_seconds": 1,
+			"label": "Rate / UOM"
+		},
+		{
+			"default": "0",
+			"fieldname": "disabled",
+			"fieldtype": "Check",
+			"hide_days": 1,
+			"hide_seconds": 1,
+			"label": "Disabled",
+			"no_copy": 1
+		},
+		{
+			"fetch_from": "item.description",
+			"fieldname": "description",
+			"fieldtype": "Small Text",
+			"hide_days": 1,
+			"hide_seconds": 1,
+			"label": "Description"
+		},
+		{
+			"default": "0",
+			"fieldname": "change_in_item",
+			"fieldtype": "Check",
+			"hidden": 1,
+			"hide_days": 1,
+			"hide_seconds": 1,
+			"label": "Change in Item"
+		}
+	],
+	"links": [
+		{
+			"link_doctype": "Healthcare Service Unit",
+			"link_fieldname": "service_unit_type"
+		}
+	],
+	"modified": "2025-09-25 15:04:43.831015",
+	"modified_by": "Administrator",
+	"module": "Healthcare",
+	"name": "Healthcare Service Unit Type",
+	"owner": "Administrator",
+	"permissions": [
+		{
+			"create": 1,
+			"delete": 1,
+			"email": 1,
+			"export": 1,
+			"print": 1,
+			"read": 1,
+			"report": 1,
+			"role": "Healthcare Administrator",
+			"share": 1,
+			"write": 1
+		},
+		{
+			"read": 1,
+			"role": "Physician",
+			"select": 1
+		},
+		{
+			"read": 1,
+			"role": "Nursing User",
+			"select": 1
+		}
+	],
+	"restrict_to_domain": "Healthcare",
+	"row_format": "Dynamic",
+	"sort_field": "modified",
+	"sort_order": "DESC",
+	"states": [],
+	"title_field": "service_unit_type"
 }


### PR DESCRIPTION
## Summary

The **Transfer → For Procedure** option in Inpatient Record throws a permission error (`"You do not have permission to access field: Healthcare Service Unit Type.is_ot"`) when selecting a Service Unit.

**Root cause:** The `inpatient_record.js` transfer dialog filters `Healthcare Service Unit Type` with `is_ot: 1` (line 575), but this field was missing from the DocType definition JSON. When Frappe validates the filter field against the schema and doesn't find it, it raises a permission error.

The locale file (`main.pot`) confirms the field was intended to exist: `"Label of the is_ot (Check) field in DocType 'Healthcare Service Unit Type'"`.

**Changes:**
1. **Added `is_ot` (Check) field** to `Healthcare Service Unit Type` — visible when `inpatient_occupancy` is checked, placed logically between `inpatient_occupancy` and `is_billable`
2. **Added `read`/`select` permissions** for `Physician` and `Nursing User` roles on `Healthcare Service Unit Type` — previously only `Healthcare Administrator` had access, so non-admin clinical users couldn't query this DocType from the transfer dialog

## Review & Testing Checklist for Human

- [ ] After `bench migrate`, verify the `is_ot` field appears on `Healthcare Service Unit Type` form when `Inpatient Occupancy` is checked
- [ ] Mark an OT-type Service Unit Type with `is_ot = 1`, then test the **Inpatient Record → Transfer → For Procedure** flow — the Service Unit Type dropdown should filter correctly and no permission error should appear
- [ ] Verify a user with only `Physician` or `Nursing User` role can complete the transfer flow without permission errors

### Notes
- The diff appears large due to Prettier reformatting (single-space → tab indentation); the semantic changes are only the `is_ot` field addition and two new permission entries
- Existing Service Unit Types will have `is_ot = 0` by default — admin will need to check `Is OT` on the appropriate types (e.g., Operating Theatre)

Link to Devin session: https://app.devin.ai/sessions/9e712242c6814ecab21b9e6a648d0933
Requested by: @pythonpen