### PR TITLE
fix: handle return invoices (Credit Notes) in healthcare invoice hooks

### DIFF
--- a/healthcare/healthcare/utils.py
+++ b/healthcare/healthcare/utils.py
@@ -466,10 +466,10 @@ def get_service_requests_to_invoice(patient, company):
 		item, is_billable = frappe.get_cached_value(
 			service_request.template_dt, service_request.template_dn, ["item", "is_billable"]
 		)
-		price_list, price_list_currency = frappe.db.get_values(
+		_price_list, _price_list_currency = frappe.db.get_values(
 			"Price List", {"selling": 1}, ["name", "currency"]
 		)[0]
-		args = {
+		_args = {
 			"doctype": "Sales Invoice",
 			"item_code": item,
 			"company": service_request.get("company"),
@@ -620,14 +620,20 @@ def manage_invoice_submit_cancel(doc, method):
 	if not doc.patient:
 		return
 
+	# For return invoices (Credit Notes), flip the effective method:
+	# submitting a return should un-invoice, cancelling a return should re-invoice.
+	is_return = doc.get("is_return")
+	if is_return:
+		effective_method = "on_cancel" if method == "on_submit" else "on_submit"
+	else:
+		effective_method = method
+
 	if doc.items:
-		reference_flag = False
 		for item in doc.items:
 			if item.get("reference_dt") and item.get("reference_dn"):
-				reference_flag = True
 				# TODO check
 				# if frappe.get_meta(item.reference_dt).has_field("invoiced"):
-				set_invoiced(item, method, doc.name)
+				set_invoiced(item, effective_method, doc.name)
 
 				# set patient as active if registration invoice
 				if item.get("reference_dt") == "Patient":
@@ -640,15 +646,17 @@ def manage_invoice_submit_cancel(doc, method):
 						is_registration = item.item_name == "Registration Fee"
 
 					if is_registration:
-						status = "Active" if method == "on_submit" else "Disabled"
+						status = "Active" if effective_method == "on_submit" else "Disabled"
 						frappe.db.set_value("Patient", item.reference_dn, "status", status)
 
-		if method == "on_submit" and frappe.db.get_single_value(
-			"Healthcare Settings", "create_observation_on_si_submit"
+		if (
+			effective_method == "on_submit"
+			and not is_return
+			and frappe.db.get_single_value("Healthcare Settings", "create_observation_on_si_submit")
 		):
 			create_sample_collection_and_observation(doc)
 
-	if method == "on_submit":
+	if effective_method == "on_submit" and not is_return:
 		if frappe.db.get_single_value("Healthcare Settings", "create_lab_test_on_si_submit"):
 			create_multiple("Sales Invoice", doc.name)
 
@@ -665,7 +673,7 @@ def manage_invoice_submit_cancel(doc, method):
 					if fee_validity:
 						frappe.db.set_value("Fee Validity", fee_validity, "sales_invoice_ref", doc.name)
 
-	if method == "on_cancel":
+	if effective_method == "on_cancel":
 		if doc.items and (doc.additional_discount_percentage or doc.discount_amount):
 			for item in doc.items:
 				if (
@@ -755,7 +763,7 @@ def set_invoiced(item, method, ref_invoice=None):
 
 		# service transaction linking to HSO
 		if item.reference_dt == "Service Request":
-			template_map = {
+			_template_map = {
 				"Clinical Procedure Template": "Clinical Procedure",
 				"Therapy Type": "Therapy Session",
 				"Lab Test Template": "Lab Test",


### PR DESCRIPTION
## Summary

Fixes the "The item referenced by Patient Appointment - HLC-APP-2026-00139 is already invoiced" error that occurs when creating a Credit Note / Return Invoice against a Sales Invoice with Patient Appointment references.

**Root Cause:** `manage_invoice_submit_cancel` (hooked to Sales Invoice `on_submit`) had no awareness of return invoices (`is_return`). When a Credit Note was submitted, it ran the same validation and invoicing logic as a regular invoice — calling `validate_invoiced_on_submit` which correctly found the appointment was already invoiced by the original invoice, and threw an error.

**Fix:** Introduced an `effective_method` that flips the hook behavior for return invoices:
- **Submitting a return** → acts like a cancellation (skips `validate_invoiced_on_submit`, sets `invoiced = False` on referenced healthcare documents)
- **Cancelling a return** → acts like a submit (re-marks documents as `invoiced = True`)
- Side-effect actions (creating lab tests, observations, fee validity updates) are correctly skipped for return invoices since they should only fire on original invoice submission.

Also cleaned up pre-existing ruff lint warnings (unused variables) in the same file to pass pre-commit hooks.

## Review & Testing Checklist for Human

- [ ] **Create a Credit Note / Return Invoice** against a submitted Sales Invoice that has Patient Appointment references (e.g., SINV-26-00087) — verify it submits without the "already invoiced" error
- [ ] **Verify the original appointment's `invoiced` field** is set to `False` after the return invoice is submitted (check Patient Appointment doc)
- [ ] **Cancel the return invoice** and verify the appointment's `invoiced` field is restored to `True`
- [ ] **Submit a normal (non-return) Sales Invoice** with healthcare references and verify existing behavior is unchanged (items get marked as invoiced, lab tests/observations created if configured)
- [ ] **Cancel a normal Sales Invoice** and verify items are un-invoiced as before

### Notes

- The `effective_method` approach mirrors how ERPNext handles stock/accounting reversals for return invoices — the return's submit acts as the original's cancel.
- Pre-existing unused variable warnings (`price_list`, `price_list_currency`, `args`, `reference_flag`, `template_map`) were prefixed with `_` or removed to satisfy ruff linter in pre-commit hooks.

Link to Devin session: https://app.devin.ai/sessions/9df2c581e00f4af1976c04aa20e588b0
Requested by: @pythonpen