### PR TITLE
feat: add date column to "Get Items from Healthcare Services" dialog

### DIFF
--- a/healthcare/healthcare/utils.py
+++ b/healthcare/healthcare/utils.py
@@ -323,6 +323,7 @@ def get_clinical_procedures_to_invoice(patient, company):
 					"service": service_item,
 					"rate": procedure.consumable_total_amount,
 					"description": procedure.consumption_details,
+					"date": procedure.start_date,
 				}
 			)
 

--- a/healthcare/public/js/sales_invoice.js
+++ b/healthcare/public/js/sales_invoice.js
@@ -162,7 +162,7 @@ var get_healthcare_services_to_invoice = function (frm, link_customer) {
 				company: frm.doc.company,
 				link_customer: link_customer,
 			};
-			var columns = ["service", "reference_name", "reference_type"];
+			var columns = ["service", "date", "reference_name", "reference_type"];
 			get_healthcare_items(
 				frm,
 				true,


### PR DESCRIPTION
Adds a Date column to the billable services table shown when invoking "Get Items > Healthcare Services" on the Sales Invoice form. The date value is already returned by each service collector (appointment, encounter, lab test, etc.); only the JS columns array needed updating.

Also sets `date` on the clinical-procedure consumables entry, the one collector that previously omitted it, so the new cell does not render as `undefined`.