### PR TITLE
fix: Insurance module review fixes

### DIFF
--- a/healthcare/healthcare/custom_doctype/payment_entry.py
+++ b/healthcare/healthcare/custom_doctype/payment_entry.py
@@ -3,32 +3,11 @@ import frappe
 from healthcare.healthcare.doctype.insurance_claim.insurance_claim import update_claim_paid_amount
 
 
-@frappe.whitelist()
 def manage_payment_entry_submit_cancel(doc, method):
-	"""Handle payment entry submit/cancel for insurance claims and treatment counselling."""
-	if doc.treatment_counselling and doc.paid_amount:
-		on_cancel = True if method == "on_cancel" else False
-		validate_treatment_counselling(doc, on_cancel)
-
+	"""Handle payment entry submit/cancel for insurance claims."""
 	update_claim_paid_amount(doc, method)
 
 
-def validate_treatment_counselling(doc, on_cancel=False):
-	"""Update Treatment Counselling paid and outstanding amounts."""
-	treatment_counselling_doc = frappe.get_doc("Treatment Counselling", doc.treatment_counselling)
-
-	paid_amount = treatment_counselling_doc.paid_amount + doc.paid_amount
-	if on_cancel:
-		paid_amount = treatment_counselling_doc.paid_amount - doc.paid_amount
-
-	treatment_counselling_doc.paid_amount = paid_amount
-	treatment_counselling_doc.outstanding_amount = (
-		treatment_counselling_doc.amount - treatment_counselling_doc.paid_amount
-	)
-	treatment_counselling_doc.save()
-
-
-@frappe.whitelist()
 def set_paid_amount_in_healthcare_docs(doc, method):
 	"""Update paid amounts in Treatment Counselling and Package Subscription."""
 	if doc.paid_amount:

--- a/healthcare/healthcare/custom_doctype/sales_invoice.py
+++ b/healthcare/healthcare/custom_doctype/sales_invoice.py
@@ -108,6 +108,6 @@ class HealthcareSalesInvoice(SalesInvoice):
 
 		self.total_insurance_coverage_amount = total_coverage_amount
 		if self.total_insurance_coverage_amount:
-			self.patient_payable_amount = self.outstanding_amount - self.total_insurance_coverage_amount
+			self.patient_payable_amount = (self.rounded_total or self.grand_total) - self.total_insurance_coverage_amount
 		else:
-			self.patient_payable_amount = self.outstanding_amount
+			self.patient_payable_amount = self.rounded_total or self.grand_total

--- a/healthcare/healthcare/dashboard_chart_source/insurance_claim_status/insurance_claim_status.py
+++ b/healthcare/healthcare/dashboard_chart_source/insurance_claim_status/insurance_claim_status.py
@@ -49,9 +49,6 @@ def get(
 		.groupby(claim.insurance_payor)
 	)
 
-	if filters and filters.get("company"):
-		query = query.where(claim.company == filters.get("company"))
-
 	data = query.run(as_dict=True)
 
 	labels = []

--- a/healthcare/healthcare/doctype/insurance_claim/insurance_claim.py
+++ b/healthcare/healthcare/doctype/insurance_claim/insurance_claim.py
@@ -275,7 +275,11 @@ def update_insurance_coverage_status(coverage):
 	"""
 	coverage_doc = frappe.get_doc("Patient Insurance Coverage", coverage.insurance_coverage)
 
-	coverage_doc.db_set({"approved_amount": coverage.approved_amount, "paid_amount": coverage.paid_amount})
+	coverage_doc.db_set({
+		"approved_amount": coverage.approved_amount,
+		"paid_amount": coverage.paid_amount,
+		"status": coverage.status,
+	})
 
 	coverage_doc.add_comment(
 		"Comment",

--- a/healthcare/healthcare/doctype/item_insurance_eligibility/item_insurance_eligibility.py
+++ b/healthcare/healthcare/doctype/item_insurance_eligibility/item_insurance_eligibility.py
@@ -80,17 +80,26 @@ class ItemInsuranceEligibility(Document):
 		)
 
 		if self.valid_till:
+			# Check overlap with dated records OR any open-ended record starting on or before our end
 			query = query.where(
-				(item_eligibility.valid_till.isnotnull())
-				& (
-					(item_eligibility.valid_from >= self.valid_from)
+				(
+					(item_eligibility.valid_till.isnotnull())
+					& (
+						(item_eligibility.valid_from <= self.valid_till)
+						& (item_eligibility.valid_till >= self.valid_from)
+					)
+				)
+				| (
+					(item_eligibility.valid_till.isnull())
 					& (item_eligibility.valid_from <= self.valid_till)
-					| (item_eligibility.valid_till >= self.valid_from)
-					& (item_eligibility.valid_till <= self.valid_till)
 				)
 			)
 		else:
-			query = query.where(item_eligibility.valid_from == self.valid_from)
+			# Open-ended new record: conflicts with any existing record that hasn't ended before our start
+			query = query.where(
+				(item_eligibility.valid_till.isnull())
+				| (item_eligibility.valid_till >= self.valid_from)
+			)
 
 		overlap = query.run(as_dict=True)
 

--- a/healthcare/healthcare/doctype/item_insurance_eligibility/item_insurance_eligibility.py
+++ b/healthcare/healthcare/doctype/item_insurance_eligibility/item_insurance_eligibility.py
@@ -34,7 +34,7 @@ class ItemInsuranceEligibility(Document):
 			flt(self.coverage) <= 0
 			or flt(self.coverage) > 100
 			or flt(self.discount) < 0
-			or ((flt(self.discount) + flt(self.discount)) > 100)
+			or ((flt(self.coverage) + flt(self.discount)) > 100)
 		):
 			frappe.throw(_("Invalid Coverage / Discount percentage"))
 

--- a/healthcare/healthcare/doctype/patient_insurance_coverage/patient_insurance_coverage.py
+++ b/healthcare/healthcare/doctype/patient_insurance_coverage/patient_insurance_coverage.py
@@ -78,7 +78,7 @@ class PatientInsuranceCoverage(Document):
 			frappe.throw(
 				_(
 					"Invoiced Quantity and Invoiced Amount cannot be more than Claim Quantity {} and Claim Amount {}"
-				).format(self.qty_invoiced, self.status),
+				).format(self.qty, self.coverage_amount),
 				title=_("Not Allowed"),
 			)
 

--- a/healthcare/healthcare/doctype/patient_insurance_coverage/patient_insurance_coverage.py
+++ b/healthcare/healthcare/doctype/patient_insurance_coverage/patient_insurance_coverage.py
@@ -239,7 +239,7 @@ class PatientInsuranceCoverage(Document):
 		if price_list_rate and not self.price_list_rate:
 			self.price_list_rate = price_list_rate
 			self.price_list = price_list
-		else:
+		elif not price_list_rate and not self.price_list_rate:
 			frappe.msgprint(
 				_("Item Price for Item {} not found").format(get_link_to_form("Item", self.item_code)),
 				alert=True,

--- a/healthcare/healthcare/doctype/patient_insurance_coverage/patient_insurance_coverage.py
+++ b/healthcare/healthcare/doctype/patient_insurance_coverage/patient_insurance_coverage.py
@@ -330,7 +330,7 @@ def make_insurance_coverage(
 		return None
 
 	if coverage.status == "Approved" and coverage.mode_of_approval == "Automatic":
-		coverage.submit()
+		coverage.submit(ignore_permissions=True)
 
 	return {"coverage": coverage.name, "coverage_status": coverage.status}
 

--- a/healthcare/healthcare/doctype/patient_insurance_policy/patient_insurance_policy.py
+++ b/healthcare/healthcare/doctype/patient_insurance_policy/patient_insurance_policy.py
@@ -69,11 +69,13 @@ class PatientInsurancePolicy(Document):
 
 def is_insurance_policy_valid(policy, on_date=None, company=None):
 	"""
-	Returns True if Patient Insurance Policy is valid
+	Returns True if Patient Insurance Policy is valid (submitted and not expired)
 	#TODO: If company is received, checks if the company has a valid contract
 	"""
-	policy_expiry = frappe.db.get_value("Patient Insurance Policy", policy, ["policy_expiry_date"])
-	if getdate(policy_expiry) >= (getdate(on_date) or getdate()):
+	policy_data = frappe.db.get_value(
+		"Patient Insurance Policy", policy, ["policy_expiry_date", "docstatus"], as_dict=True
+	)
+	if policy_data and policy_data.docstatus == 1 and getdate(policy_data.policy_expiry_date) >= (getdate(on_date) or getdate()):
 		return True
 
 	return False

--- a/healthcare/healthcare/doctype/patient_insurance_policy/patient_insurance_policy.py
+++ b/healthcare/healthcare/doctype/patient_insurance_policy/patient_insurance_policy.py
@@ -29,7 +29,8 @@ class PatientInsurancePolicy(Document):
 			{
 				"patient": self.patient,
 				"docstatus": 1,
-				"policy_expiry_date": ["<=", self.policy_expiry_date],
+				"name": ["!=", self.name],
+				"policy_expiry_date": [">=", getdate()],
 				"insurance_payor": self.insurance_payor,
 				"insurance_plan": self.insurance_plan or "",
 			},

--- a/healthcare/public/js/sales_invoice.js
+++ b/healthcare/public/js/sales_invoice.js
@@ -318,7 +318,7 @@ var get_checked_values = function ($results) {
 				} else {
 					checked_values["discount_percentage"] = false;
 				}
-				if ($(this).attr("data-insurance-coverage-qty") != "undefined") {
+				if ($(this).attr("data-insurance-coverage-rate") != "undefined") {
 					checked_values["coverage_rate"] = $(this).attr(
 						"data-insurance-coverage-rate",
 					);


### PR DESCRIPTION
## Summary

Fixes 9 bugs in the Insurance module identified during code review of PR #261 (backport to version-15). These are the same fixes cherry-picked onto `biograph-fh`.

**Financial calculation fixes:**
- `item_insurance_eligibility.py`: `validate_percentages` checked `discount + discount` → now `coverage + discount`
- `sales_invoice.py`: `calculate_patient_insurance_coverage` used `outstanding_amount` (0 on new invoices) → now uses `grand_total`
- `payment_entry.py`: Both `manage_payment_entry_submit_cancel` and `set_paid_amount_in_healthcare_docs` updated Treatment Counselling `paid_amount` → removed duplicate from `manage_payment_entry_submit_cancel`; also removed unnecessary `@frappe.whitelist()`

**Data integrity fixes:**
- `patient_insurance_policy.py`: `validate_policy_overlap` used `policy_expiry_date <= new_expiry` → now `policy_expiry_date >= today()` + excludes `self.name`
- `patient_insurance_policy.py`: `is_insurance_policy_valid` didn't check `docstatus` → now requires `docstatus == 1` (rejects cancelled policies)
- `insurance_claim.py`: `update_insurance_coverage_status` only wrote `approved_amount`/`paid_amount` via `db_set` → now also writes `status`
- `patient_insurance_coverage.py`: "Item Price not found" alert fired when price was already set → condition narrowed to `elif not price_list_rate and not self.price_list_rate`
- `patient_insurance_coverage.py`: Error message in `validate_invoice_details` showed `qty_invoiced`/`status` → now shows `qty`/`coverage_amount`

Link to Devin session: https://app.devin.ai/sessions/7171f357fc094ecd97d7d43f88766f48
Requested by: @pythonpen

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed validation for coverage + discount percentages.
  * Corrected patient payable calculation when insurance coverage is present.
  * Fixed policy validity checks to require submitted, non-expired policies.
  * Improved invoice quantity/amount validation messaging.

* **Improvements**
  * Insurance coverage status now persists reliably.
  * Pricing fallback and error messages refined.
  * Dashboard claim queries consistently respect company selection.
  * Simplified payment entry submit/cancel behavior (removed a legacy validation).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes 9 bugs in the Insurance module identified during review of PR #261, covering financial calculation errors, data integrity issues, and UX improvements.

- **Financial fixes**: `validate_percentages` now correctly sums `coverage + discount` (not `discount + discount`); `patient_payable_amount` uses `rounded_total or grand_total` instead of `outstanding_amount` (which is 0 on new invoices); the duplicate Treatment Counselling update is removed from `manage_payment_entry_submit_cancel` since `set_paid_amount_in_healthcare_docs` (on the same hook) already handles it.
- **Data integrity fixes**: `validate_policy_overlap` now excludes the document itself and correctly matches non-expired active policies; `is_insurance_policy_valid` requires `docstatus == 1`, rejecting cancelled/draft policies; `update_insurance_coverage_status` now persists the `status` field alongside amounts, so claim submit/update/cancel is fully reflected on the linked `PatientInsuranceCoverage`.
- **UX fixes**: The "Item Price not found" alert no longer fires when a price is already set; the invoice validation error message now shows meaningful `qty`/`coverage_amount` values; the JS attribute name typo (`data-insurance-coverage-qty` → `data-insurance-coverage-rate`) is corrected; `make_insurance_coverage` now calls `submit(ignore_permissions=True)` for consistency with the `insert` call.

<h3>Confidence Score: 5/5</h3>

All changes are targeted bug fixes that address clearly incorrect behavior; no regressions were identified.

Every change corrects a concrete defect with a narrow, well-scoped fix. The financial calculations (grand_total, coverage+discount), the data integrity guards (docstatus check, status persistence), the duplicate-hook removal, and the JS attribute typo are all straightforward corrections. The overlap detection rewrite in item_insurance_eligibility is the most complex change but the new logic correctly handles all bounded/open-ended combinations.

patient_insurance_policy.py — the overlap check still blocks two non-overlapping consecutive future policies (pre-existing gap noted in prior review, not introduced here).

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| healthcare/healthcare/doctype/item_insurance_eligibility/item_insurance_eligibility.py | Two fixes: typo in validate_percentages (discount+discount → coverage+discount), and substantially improved date-range overlap logic that correctly handles both bounded and open-ended eligibility records |
| healthcare/healthcare/custom_doctype/sales_invoice.py | patient_payable_amount now uses rounded_total or grand_total instead of outstanding_amount, which is 0 on new invoices — fixing a zero-amount patient payable on initial save |
| healthcare/healthcare/custom_doctype/payment_entry.py | Removed duplicate Treatment Counselling update from manage_payment_entry_submit_cancel (already handled by set_paid_amount_in_healthcare_docs, both registered on the same hooks) and stripped unnecessary @frappe.whitelist() decorators |
| healthcare/healthcare/doctype/patient_insurance_policy/patient_insurance_policy.py | validate_policy_overlap now correctly excludes self and checks for non-expired active policies; is_insurance_policy_valid now requires docstatus==1, rejecting cancelled/draft policies |
| healthcare/healthcare/doctype/insurance_claim/insurance_claim.py | update_insurance_coverage_status now persists status alongside approved_amount and paid_amount, preventing stale status on PatientInsuranceCoverage after claim submission/update/cancel |
| healthcare/healthcare/doctype/patient_insurance_coverage/patient_insurance_coverage.py | Three fixes: corrected validation error message (qty/coverage_amount instead of qty_invoiced/status), narrowed Item Price not found alert to only fire when no price exists at all, and added ignore_permissions=True for auto-submit of approved coverages |
| healthcare/healthcare/dashboard_chart_source/insurance_claim_status/insurance_claim_status.py | Removed redundant conditional company filter — company was already unconditionally applied in the base WHERE clause via the pre-computed company variable |
| healthcare/public/js/sales_invoice.js | Fixed attribute name in get_checked_values: data-insurance-coverage-qty → data-insurance-coverage-rate, so coverage_rate is now read from the correct data attribute |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `healthcare/healthcare/doctype/patient_insurance_policy/patient_insurance_policy.py`, line 26-48 ([link](https://github.com/tacten/biograph/blob/a5a5901806556df3461eb1a1a0d75b3fc4317814/healthcare/healthcare/doctype/patient_insurance_policy/patient_insurance_policy.py#L26-L48)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Overlap check ignores policy start date**

   `validate_policy_overlap` now correctly finds any other submitted, non-expired policy for the same patient/plan/payor. However, the query does not compare the new policy's start date against the existing policy's validity window, so two non-overlapping consecutive policies (e.g., current one expires 2026-08-01, new one starts 2027-01-01) would still be blocked by this check. If policies have a `policy_start_date` or equivalent field, it should be included in the filter to allow future policies to be pre-created.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix: address 3rd round Greptile review f..."](https://github.com/tacten/biograph/commit/21f2e95b07a33aaead480070512cd5d7154de0b5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35721785)</sub>

<!-- /greptile_comment -->