### PR TITLE
fix: resolve insurance workflow bugs causing "Item None not found" error

### DIFF
--- a/healthcare/healthcare/doctype/item_insurance_eligibility/item_insurance_eligibility.py
+++ b/healthcare/healthcare/doctype/item_insurance_eligibility/item_insurance_eligibility.py
@@ -89,16 +89,12 @@ class ItemInsuranceEligibility(Document):
 						& (item_eligibility.valid_till >= self.valid_from)
 					)
 				)
-				| (
-					(item_eligibility.valid_till.isnull())
-					& (item_eligibility.valid_from <= self.valid_till)
-				)
+				| ((item_eligibility.valid_till.isnull()) & (item_eligibility.valid_from <= self.valid_till))
 			)
 		else:
 			# Open-ended new record: conflicts with any existing record that hasn't ended before our start
 			query = query.where(
-				(item_eligibility.valid_till.isnull())
-				| (item_eligibility.valid_till >= self.valid_from)
+				(item_eligibility.valid_till.isnull()) | (item_eligibility.valid_till >= self.valid_from)
 			)
 
 		overlap = query.run(as_dict=True)
@@ -158,7 +154,7 @@ def get_insurance_eligibility(
 				(Eligibility.is_active == 1)
 				& (Coalesce(Eligibility.insurance_plan, "") == (insurance_plan or ""))
 				& (
-					(Coalesce(Eligibility.item_code, "") == item_code)
+					(Coalesce(Eligibility.item_code, "") == (item_code or ""))
 					| (
 						(Coalesce(Eligibility.template_dt, "") == (template_dt or ""))
 						& (Coalesce(Eligibility.template_dn, "") == (template_dn or ""))

--- a/healthcare/healthcare/doctype/patient_insurance_coverage/patient_insurance_coverage.py
+++ b/healthcare/healthcare/doctype/patient_insurance_coverage/patient_insurance_coverage.py
@@ -162,7 +162,7 @@ class PatientInsuranceCoverage(Document):
 				field_list.extend(["medical_code", "medical_code_standard"])
 
 			if field_list:
-				details = frappe.db.get_value(self.template_dt, self.template_dn, field_list, as_dict=1)
+				details = frappe.db.get_value(self.template_dt, self.template_dn, field_list, as_dict=1) or {}
 			else:
 				details = {}
 

--- a/healthcare/healthcare/doctype/patient_insurance_coverage/patient_insurance_coverage.py
+++ b/healthcare/healthcare/doctype/patient_insurance_coverage/patient_insurance_coverage.py
@@ -141,7 +141,8 @@ class PatientInsuranceCoverage(Document):
 			)
 
 	def set_title(self):
-		self.title = f"{self.patient_name} - {self.template_dn} - {self.status}"
+		service_label = self.template_dn or self.item_code or ""
+		self.title = f"{self.patient_name} - {service_label} - {self.status}"
 
 	def set_and_validate_template_details(self):
 		"""
@@ -151,13 +152,21 @@ class PatientInsuranceCoverage(Document):
 		"""
 		details = {}
 		if self.template_dt and self.template_dn and self.template_dt != "Appointment Type":
-			field_list = ["is_billable", "item"]
-			if frappe.get_meta(self.template_dt).has_field("medical_code"):
+			meta = frappe.get_meta(self.template_dt)
+			field_list = []
+			if meta.has_field("is_billable"):
+				field_list.append("is_billable")
+			if meta.has_field("item"):
+				field_list.append("item")
+			if meta.has_field("medical_code"):
 				field_list.extend(["medical_code", "medical_code_standard"])
 
-			details = frappe.db.get_value(self.template_dt, self.template_dn, field_list, as_dict=1)
+			if field_list:
+				details = frappe.db.get_value(self.template_dt, self.template_dn, field_list, as_dict=1)
+			else:
+				details = {}
 
-			if not details.get("is_billable"):
+			if "is_billable" in field_list and not details.get("is_billable"):
 				frappe.throw(
 					_(
 						"Invalid Service Template, Insurance Coverage can only be created for Templates marked <b>Is Billable</b>"
@@ -165,7 +174,8 @@ class PatientInsuranceCoverage(Document):
 					title=_("Not Allowed"),
 				)
 
-			self.item_code = details.get("item")
+			if details.get("item"):
+				self.item_code = details.get("item")
 			self.medical_code = details.get("medical_code")
 			self.medical_code_standard = details.get("medical_code_standard")
 
@@ -205,6 +215,8 @@ class PatientInsuranceCoverage(Document):
 			self.mode_of_approval = eligibility.get("mode_of_approval")
 			self.coverage = eligibility.get("coverage")
 			self.discount = eligibility.get("discount")
+			if not self.item_code and eligibility.get("item_code"):
+				self.item_code = eligibility.get("item_code")
 			# reset coverage_validity_end_date if coverage validity is less than policy end date (default)
 			if eligibility.get("valid_till") and getdate(eligibility.get("valid_till")) < getdate(
 				self.coverage_validity_end_date
@@ -217,6 +229,14 @@ class PatientInsuranceCoverage(Document):
 		Fetch Item price for Price List in this order: 1: Insurance Plan 2: Insurance Payor 3: Default Selling Price List
 		Retruns True if Item Price found else show alert and return False
 		"""
+		if not self.item_code:
+			frappe.msgprint(
+				_("Cannot fetch price list rate: Item Code is missing."),
+				alert=True,
+				indicator="error",
+			)
+			return
+
 		insurance_price_lists = get_insurance_price_lists(self.insurance_policy, self.company)
 		price_list = price_list_rate = None
 
@@ -365,8 +385,8 @@ def create_insurance_eligibility(doc):
 	item_eligibility.insurance_plan = doc.insurance_plan
 	item_eligibility.template_dt = doc.template_dt
 	item_eligibility.template_dn = doc.template_dn
-	item_eligibility.item = doc.item_code
+	item_eligibility.item_code = doc.item_code
 
-	item_eligibility.start_date = doc.posting_date or getdate()
+	item_eligibility.valid_from = doc.posting_date or getdate()
 
 	return item_eligibility


### PR DESCRIPTION
## Summary

Fixes the "Item None not found" error when saving `Patient Insurance Coverage` records. The root cause: when eligibility is matched, `item_code` from the eligibility record was never propagated back to the coverage — so downstream calls to `get_item_details(item_code=None)` exploded.

**Key changes:**

1. **`set_insurance_coverage`** — propagate `item_code` from matched eligibility when coverage has none:
   ```python
   if not self.item_code and eligibility.get("item_code"):
       self.item_code = eligibility.get("item_code")
   ```

2. **`get_insurance_eligibility` query** — `Coalesce(item_code, "") == item_code` generates `= NULL` in SQL (always FALSE) when `item_code` is `None`. Fixed to `== (item_code or "")` to match the upstream raw-SQL intent.

3. **`set_insurance_price_list_rate`** — early-return with user message when `item_code` is still missing, instead of passing `None` to `get_item_details`.

4. **`set_and_validate_template_details`** — dynamically checks whether the template DocType actually has `is_billable`/`item` fields before querying them (e.g. `Medication` has neither), preventing `FieldDoesNotExistError`.

5. **`create_insurance_eligibility`** — wrong field names: `item_eligibility.item` → `.item_code`, `.start_date` → `.valid_from`.

6. **`set_title`** — uses `template_dn or item_code or ""` instead of raw `template_dn` to avoid `"None"` in titles.

Cross-referenced against [earthians/marley `healthcare-insurance-wip`](https://github.com/earthians/marley/tree/healthcare-insurance-wip) — upstream has the same bugs in its raw-SQL version.

Link to Devin session: https://app.devin.ai/sessions/6ec55396542744499b792964889c434d
Requested by: @pythonpen

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved overlap detection for insurance eligibility to correctly treat open-ended records as overlapping
  * Better handling when item codes are missing, with early validation and clearer pricing error messages

* **New Features**
  * Coverage titles now auto-populate a service label from templates with an item-code fallback

* **Chores**
  * Adjusted data mapping for eligibility creation to accept posting date and populate item code
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes several bugs in the insurance coverage workflow that caused crashes when `item_code` was `None`, including wrong field names in `create_insurance_eligibility`, a `None`-propagating title, and a missing guard before `get_item_details`.

- **`patient_insurance_coverage.py`**: `set_and_validate_template_details` now checks field existence before querying (fixing `FieldDoesNotExistError` on doctypes like `Medication`); `set_insurance_coverage` propagates `item_code` from matched eligibility; `set_insurance_price_list_rate` returns early with a user message when `item_code` is absent; `create_insurance_eligibility` corrects field names (`.item` → `.item_code`, `.start_date` → `.valid_from`).
- **`item_insurance_eligibility.py`**: Fixes a SQL `= NULL` comparison by changing `== item_code` to `== (item_code or \"\")` in the `get_insurance_eligibility` query, and reformats the overlap-detection conditions (logic unchanged).

<h3>Confidence Score: 3/5</h3>

The eligibility query change can silently return the wrong eligibility record when multiple null-item_code entries exist for the same insurance plan.

The Coalesce(item_code, "") == (item_code or "") change in get_insurance_eligibility over-broadens the match: when item_code=None, every eligibility row with a null item_code in the same insurance plan becomes a candidate, and the most-recently-valid one wins regardless of its template.

The eligibility query in item_insurance_eligibility.py (get_insurance_eligibility, line 157) deserves a second look before merging.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| healthcare/healthcare/doctype/item_insurance_eligibility/item_insurance_eligibility.py | Overlap detection reformatted (logic unchanged); Coalesce comparison fixed for NULL item_code, but the fix broadens matching to all null-item_code records in the same plan when item_code=None, risking wrong eligibility being returned for template-based searches |
| healthcare/healthcare/doctype/patient_insurance_coverage/patient_insurance_coverage.py | Multiple targeted fixes: dynamic field-list in set_and_validate_template_details, item_code propagation from eligibility, early-return guard in set_insurance_price_list_rate, correct field names in create_insurance_eligibility, and improved set_title; logic is sound aside from the now-broader eligibility query upstream |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: guard against None return from frap..."](https://github.com/tacten/biograph/commit/a2e8daeebc9009db76a8eef8886022cc6404a372) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37240222)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->