### PR TITLE
fix: resolve insurance workflow bugs causing "Item None not found" error

### DIFF
--- a/healthcare/healthcare/doctype/item_insurance_eligibility/item_insurance_eligibility.py
+++ b/healthcare/healthcare/doctype/item_insurance_eligibility/item_insurance_eligibility.py
@@ -89,16 +89,12 @@ class ItemInsuranceEligibility(Document):
 						& (item_eligibility.valid_till >= self.valid_from)
 					)
 				)
-				| (
-					(item_eligibility.valid_till.isnull())
-					& (item_eligibility.valid_from <= self.valid_till)
-				)
+				| ((item_eligibility.valid_till.isnull()) & (item_eligibility.valid_from <= self.valid_till))
 			)
 		else:
 			# Open-ended new record: conflicts with any existing record that hasn't ended before our start
 			query = query.where(
-				(item_eligibility.valid_till.isnull())
-				| (item_eligibility.valid_till >= self.valid_from)
+				(item_eligibility.valid_till.isnull()) | (item_eligibility.valid_till >= self.valid_from)
 			)
 
 		overlap = query.run(as_dict=True)
@@ -158,7 +154,7 @@ def get_insurance_eligibility(
 				(Eligibility.is_active == 1)
 				& (Coalesce(Eligibility.insurance_plan, "") == (insurance_plan or ""))
 				& (
-					(Coalesce(Eligibility.item_code, "") == item_code)
+					(Coalesce(Eligibility.item_code, "") == (item_code or ""))
 					| (
 						(Coalesce(Eligibility.template_dt, "") == (template_dt or ""))
 						& (Coalesce(Eligibility.template_dn, "") == (template_dn or ""))

--- a/healthcare/healthcare/doctype/patient_insurance_coverage/patient_insurance_coverage.py
+++ b/healthcare/healthcare/doctype/patient_insurance_coverage/patient_insurance_coverage.py
@@ -162,7 +162,7 @@ class PatientInsuranceCoverage(Document):
 				field_list.extend(["medical_code", "medical_code_standard"])
 
 			if field_list:
-				details = frappe.db.get_value(self.template_dt, self.template_dn, field_list, as_dict=1)
+				details = frappe.db.get_value(self.template_dt, self.template_dn, field_list, as_dict=1) or {}
 			else:
 				details = {}
 

--- a/healthcare/healthcare/doctype/patient_insurance_coverage/patient_insurance_coverage.py
+++ b/healthcare/healthcare/doctype/patient_insurance_coverage/patient_insurance_coverage.py
@@ -141,7 +141,8 @@ class PatientInsuranceCoverage(Document):
 			)
 
 	def set_title(self):
-		self.title = f"{self.patient_name} - {self.template_dn} - {self.status}"
+		service_label = self.template_dn or self.item_code or ""
+		self.title = f"{self.patient_name} - {service_label} - {self.status}"
 
 	def set_and_validate_template_details(self):
 		"""
@@ -151,13 +152,21 @@ class PatientInsuranceCoverage(Document):
 		"""
 		details = {}
 		if self.template_dt and self.template_dn and self.template_dt != "Appointment Type":
-			field_list = ["is_billable", "item"]
-			if frappe.get_meta(self.template_dt).has_field("medical_code"):
+			meta = frappe.get_meta(self.template_dt)
+			field_list = []
+			if meta.has_field("is_billable"):
+				field_list.append("is_billable")
+			if meta.has_field("item"):
+				field_list.append("item")
+			if meta.has_field("medical_code"):
 				field_list.extend(["medical_code", "medical_code_standard"])
 
-			details = frappe.db.get_value(self.template_dt, self.template_dn, field_list, as_dict=1)
+			if field_list:
+				details = frappe.db.get_value(self.template_dt, self.template_dn, field_list, as_dict=1)
+			else:
+				details = {}
 
-			if not details.get("is_billable"):
+			if "is_billable" in field_list and not details.get("is_billable"):
 				frappe.throw(
 					_(
 						"Invalid Service Template, Insurance Coverage can only be created for Templates marked <b>Is Billable</b>"
@@ -165,7 +174,8 @@ class PatientInsuranceCoverage(Document):
 					title=_("Not Allowed"),
 				)
 
-			self.item_code = details.get("item")
+			if details.get("item"):
+				self.item_code = details.get("item")
 			self.medical_code = details.get("medical_code")
 			self.medical_code_standard = details.get("medical_code_standard")
 
@@ -205,6 +215,8 @@ class PatientInsuranceCoverage(Document):
 			self.mode_of_approval = eligibility.get("mode_of_approval")
 			self.coverage = eligibility.get("coverage")
 			self.discount = eligibility.get("discount")
+			if not self.item_code and eligibility.get("item_code"):
+				self.item_code = eligibility.get("item_code")
 			# reset coverage_validity_end_date if coverage validity is less than policy end date (default)
 			if eligibility.get("valid_till") and getdate(eligibility.get("valid_till")) < getdate(
 				self.coverage_validity_end_date
@@ -217,6 +229,14 @@ class PatientInsuranceCoverage(Document):
 		Fetch Item price for Price List in this order: 1: Insurance Plan 2: Insurance Payor 3: Default Selling Price List
 		Retruns True if Item Price found else show alert and return False
 		"""
+		if not self.item_code:
+			frappe.msgprint(
+				_("Cannot fetch price list rate: Item Code is missing."),
+				alert=True,
+				indicator="error",
+			)
+			return
+
 		insurance_price_lists = get_insurance_price_lists(self.insurance_policy, self.company)
 		price_list = price_list_rate = None
 
@@ -276,7 +296,14 @@ class PatientInsuranceCoverage(Document):
 
 
 def make_insurance_coverage(
-	patient, policy, company, template_dt=None, template_dn=None, item_code=None, qty=1, rate=0
+	patient,
+	policy,
+	company,
+	template_dt=None,
+	template_dn=None,
+	item_code=None,
+	qty=1,
+	rate=0,
 ):
 	"""
 	Inserts a new Insurance Coverage for the service
@@ -365,8 +392,8 @@ def create_insurance_eligibility(doc):
 	item_eligibility.insurance_plan = doc.insurance_plan
 	item_eligibility.template_dt = doc.template_dt
 	item_eligibility.template_dn = doc.template_dn
-	item_eligibility.item = doc.item_code
+	item_eligibility.item_code = doc.item_code
 
-	item_eligibility.start_date = doc.posting_date or getdate()
+	item_eligibility.valid_from = doc.posting_date or getdate()
 
 	return item_eligibility


### PR DESCRIPTION
## Summary

Same fixes as PR #263 (targeting `biograph-fh`), applied to the `insurance/feat-for-v15` branch.

Fixes the "Item None not found" error when saving `Patient Insurance Coverage` records. The root cause: when eligibility is matched, `item_code` from the eligibility record was never propagated back to the coverage — so downstream calls to `get_item_details(item_code=None)` exploded.

**Key changes:**

1. **`set_insurance_coverage`** — propagate `item_code` from matched eligibility when coverage has none:
   ```python
   if not self.item_code and eligibility.get("item_code"):
       self.item_code = eligibility.get("item_code")
   ```

2. **`get_insurance_eligibility` query** — `Coalesce(item_code, "") == item_code` generates `= NULL` in SQL (always FALSE) when `item_code` is `None`. Fixed to `== (item_code or "")` to match the upstream raw-SQL intent.

3. **`set_insurance_price_list_rate`** — early-return with user message when `item_code` is still missing, instead of passing `None` to `get_item_details`.

4. **`set_and_validate_template_details`** — dynamically checks whether the template DocType actually has `is_billable`/`item` fields before querying them (e.g. `Medication` has neither), preventing `FieldDoesNotExistError`.

5. **`create_insurance_eligibility`** — wrong field names: `item_eligibility.item` → `.item_code`, `.start_date` → `.valid_from`.

6. **`set_title`** — uses `template_dn or item_code or ""` instead of raw `template_dn` to avoid `"None"` in titles.

Cross-referenced against [earthians/marley `healthcare-insurance-wip`](https://github.com/earthians/marley/tree/healthcare-insurance-wip) — upstream has the same bugs.

Link to Devin session: https://app.devin.ai/sessions/6ec55396542744499b792964889c434d
Requested by: @pythonpen

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR applies six targeted bug fixes to the insurance workflow to resolve "Item None not found" crashes when saving `PatientInsuranceCoverage` records — mirroring the same fixes already applied to the `biograph-fh` branch in PR #263.

- Fixes a SQL NULL-comparison bug in `get_insurance_eligibility` (`Coalesce(item_code, "") == item_code` → `== (item_code or "")`), propagates `item_code` from matched eligibility back onto the coverage, and adds an early-return guard in `set_insurance_price_list_rate` to avoid passing `None` to `get_item_details`.
- Makes `set_and_validate_template_details` dynamically check field existence before querying (preventing `FieldDoesNotExistError` for DocTypes like Medication), fixes wrong field names (`item` → `item_code`, `start_date` → `valid_from`) in `create_insurance_eligibility`, and improves `set_title` to avoid a literal `"None"` in the title string.

<h3>Confidence Score: 4/5</h3>

Safe to merge with one fix needed: `set_service_item` in `item_insurance_eligibility.py` still queries the "item" field without checking its existence, so saving an eligibility record for a Medication (or similar) template will still raise the same error the rest of this PR was built to eliminate.

The core fixes in `patient_insurance_coverage.py` are sound and address the described crash paths. The outstanding gap is in `item_insurance_eligibility.py`: `set_service_item` unconditionally queries the template's "item" field — the same pattern corrected elsewhere in this PR — meaning `ItemInsuranceEligibility` records for field-deficient DocTypes like Medication remain broken on save.

`item_insurance_eligibility.py` — `set_service_item` needs the same `meta.has_field("item")` guard that was applied to `set_and_validate_template_details`.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| healthcare/healthcare/doctype/item_insurance_eligibility/item_insurance_eligibility.py | Fixes `Coalesce(item_code, "") == item_code` NULL-comparison bug and reformats multi-line conditionals; `set_service_item` still queries the "item" field without an existence guard, leaving the same `FieldDoesNotExistError` risk for Medication templates. |
| healthcare/healthcare/doctype/patient_insurance_coverage/patient_insurance_coverage.py | Adds `item_code` propagation from eligibility, dynamic field-existence checks for template DocTypes, a null-guard before `get_item_details`, a safer `set_title`, and correct field names in `create_insurance_eligibility`; core logic changes look sound. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: guard against None return from frap..."](https://github.com/tacten/biograph/commit/fa6ef7b2830e3e36b586452ef29d1a31cd5807a4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37240970)</sub>

<!-- /greptile_comment -->