### PR TITLE
fix: align insurance parity flows with marley

### DIFF
--- a/healthcare/healthcare/dashboard_chart_source/insurance_claim_status/insurance_claim_status.py
+++ b/healthcare/healthcare/dashboard_chart_source/insurance_claim_status/insurance_claim_status.py
@@ -49,6 +49,9 @@ def get(
 		.groupby(claim.insurance_payor)
 	)
 
+	if filters and filters.get("company"):
+		query = query.where(claim.company == filters.get("company"))
+
 	data = query.run(as_dict=True)
 
 	labels = []

--- a/healthcare/healthcare/doctype/insurance_claim/insurance_claim.py
+++ b/healthcare/healthcare/doctype/insurance_claim/insurance_claim.py
@@ -2,6 +2,9 @@
 # For license information, please see license.txt
 
 
+from pypika.enums import Order
+from pypika.terms import ValueWrapper
+
 import frappe
 from frappe import _
 from frappe.model.document import Document
@@ -191,73 +194,76 @@ class InsuranceClaim(Document):
 				_("Company and Insurance Provider are mandatory"), title=_("Missing Mandatory Fields")
 			)
 
-		valid_statuses = ["Partly Invoiced", "Invoiced"]  # allow user selection?
+		valid_statuses = ["Partly Invoiced", "Invoiced"]
 
-		coverages = frappe.db.sql(
-			"""
-			SELECT
-				pic.name AS insurance_coverage,
-				pic.posting_date AS insurance_coverage_posting_date,
-				pic.patient AS patient,
-				pic.patient_name,
-				pic.template_dt,
-				pic.template_dn,
-				pic.coverage,
-				pic.discount,
-				pic.coverage_amount,
-				pic.discount_amount,
-				pic.code_system,
-				pic.code_value,
-				pic.code_description,
-				pic.mode_of_approval,
-				pic.insurance_plan,
-				pic.gender,
-				pic.birth_date,
-				pic.policy_number,
-				pic.policy_expiry_date,
-				si.name AS sales_invoice,
-				si.posting_date AS sales_invoice_posting_date,
-				sii.item_code,
-				sii.amount AS sales_invoice_item_amount,
-				sii.coverage_percentage AS claim_coverage,
-				sii.insurance_coverage_amount AS claim_amount,
-				sii.discount_percentage AS invoice_discount,
-				sii.discount_amount AS invoice_discount_amount,
-				jea.credit_in_account_currency AS allocated_amount,
-				jea.parent AS journal_entry,
-				'Draft' AS status
-			FROM `tabPatient Insurance Coverage` AS pic
-			INNER JOIN `tabSales Invoice Item` AS sii ON
-				(pic.name=sii.insurance_coverage AND sii.docstatus=1)
-			INNER JOIN `tabSales Invoice` AS si ON
-				(si.name=sii.parent AND si.docstatus=1)
-			INNER JOIN `tabJournal Entry Account` AS jea ON
-				(jea.docstatus=1 AND jea.reference_detail_no=sii.name )
-			WHERE
-				pic.docstatus=1 AND
-				pic.company=%(company)s AND
-				pic.insurance_payor=%(insurance_payor)s AND
-				pic.patient=%(patient)s AND
-				pic.insurance_policy=%(insurance_policy)s AND
-				({filter_date_based_on} BETWEEN %(from_date)s AND %(to_date)s) AND
-				pic.status IN %(statuses)s AND
-				pic.paid_amount < pic.coverage_amount_invoiced
-			ORDER BY patient ASC, {filter_date_based_on} DESC
-			""".format(
-				filter_date_based_on="si.posting_date"
-				if self.posting_date_based_on == "Sales Invoice"
-				else "pic.posting_date"
-			),
-			{
-				"patient": self.patient,
-				"insurance_policy": self.insurance_policy,
-				"company": self.company,
-				"insurance_payor": self.insurance_payor,
-				"from_date": self.from_date,
-				"to_date": self.to_date,
-				"statuses": tuple(valid_statuses),
-			},
-			as_dict=1,
+		PatientInsuranceCoverage = frappe.qb.DocType("Patient Insurance Coverage")
+		SalesInvoiceItem = frappe.qb.DocType("Sales Invoice Item")
+		SalesInvoice = frappe.qb.DocType("Sales Invoice")
+		JournalEntryAccount = frappe.qb.DocType("Journal Entry Account")
+
+		filter_date_based_on = (
+			SalesInvoice.posting_date
+			if self.posting_date_based_on == "Sales Invoice"
+			else PatientInsuranceCoverage.posting_date
+		)
+
+		coverages = (
+			frappe.qb.from_(PatientInsuranceCoverage)
+			.inner_join(SalesInvoiceItem)
+			.on(
+				(PatientInsuranceCoverage.name == SalesInvoiceItem.insurance_coverage)
+				& (SalesInvoiceItem.docstatus == 1)
+			)
+			.inner_join(SalesInvoice)
+			.on((SalesInvoice.name == SalesInvoiceItem.parent) & (SalesInvoice.docstatus == 1))
+			.inner_join(JournalEntryAccount)
+			.on(
+				(JournalEntryAccount.docstatus == 1)
+				& (JournalEntryAccount.reference_detail_no == SalesInvoiceItem.name)
+			)
+			.select(
+				PatientInsuranceCoverage.name.as_("insurance_coverage"),
+				PatientInsuranceCoverage.posting_date.as_("insurance_coverage_posting_date"),
+				PatientInsuranceCoverage.patient,
+				PatientInsuranceCoverage.patient_name,
+				PatientInsuranceCoverage.template_dt,
+				PatientInsuranceCoverage.template_dn,
+				PatientInsuranceCoverage.coverage,
+				PatientInsuranceCoverage.discount,
+				PatientInsuranceCoverage.coverage_amount,
+				PatientInsuranceCoverage.discount_amount,
+				PatientInsuranceCoverage.code_system,
+				PatientInsuranceCoverage.code_value,
+				PatientInsuranceCoverage.code_description,
+				PatientInsuranceCoverage.mode_of_approval,
+				PatientInsuranceCoverage.insurance_plan,
+				PatientInsuranceCoverage.gender,
+				PatientInsuranceCoverage.birth_date,
+				PatientInsuranceCoverage.policy_number,
+				PatientInsuranceCoverage.policy_expiry_date,
+				SalesInvoice.name.as_("sales_invoice"),
+				SalesInvoice.posting_date.as_("sales_invoice_posting_date"),
+				SalesInvoiceItem.item_code,
+				SalesInvoiceItem.amount.as_("sales_invoice_item_amount"),
+				SalesInvoiceItem.coverage_percentage.as_("claim_coverage"),
+				SalesInvoiceItem.insurance_coverage_amount.as_("claim_amount"),
+				SalesInvoiceItem.discount_percentage.as_("invoice_discount"),
+				SalesInvoiceItem.discount_amount.as_("invoice_discount_amount"),
+				JournalEntryAccount.credit_in_account_currency.as_("allocated_amount"),
+				JournalEntryAccount.parent.as_("journal_entry"),
+				ValueWrapper("Draft").as_("status"),
+			)
+			.where(PatientInsuranceCoverage.docstatus == 1)
+			.where(PatientInsuranceCoverage.company == self.company)
+			.where(PatientInsuranceCoverage.insurance_payor == self.insurance_payor)
+			.where(PatientInsuranceCoverage.patient == self.patient)
+			.where(PatientInsuranceCoverage.insurance_policy == self.insurance_policy)
+			.where(filter_date_based_on.between(self.from_date, self.to_date))
+			.where(PatientInsuranceCoverage.status.isin(valid_statuses))
+			.where(PatientInsuranceCoverage.paid_amount < PatientInsuranceCoverage.coverage_amount_invoiced)
+			.orderby(PatientInsuranceCoverage.patient, order=Order.asc)
+			.orderby(filter_date_based_on, order=Order.desc)
+			.run(as_dict=True)
 		)
 
 		if not coverages:

--- a/healthcare/healthcare/doctype/insurance_claim/test_insurance_claim.py
+++ b/healthcare/healthcare/doctype/insurance_claim/test_insurance_claim.py
@@ -2,42 +2,64 @@
 # See license.txt
 
 import frappe
-from frappe.tests import IntegrationTestCase
-from frappe.utils import add_years, today
-
-from erpnext.accounts.party import get_dashboard_info
-from erpnext.accounts.utils import get_balance_on
+from frappe.utils import add_years, nowdate, today
 
 from healthcare.healthcare.doctype.insurance_claim.insurance_claim import create_payment_entry
 from healthcare.healthcare.doctype.insurance_payor_contract.test_insurance_payor_contract import (
-	create_insurance_payor,
+	get_new_payor_contract_doc,
 )
 from healthcare.healthcare.doctype.patient_insurance_coverage.test_patient_insurance_coverage import (
-	create_insurance_test_docs,
+	create_appointment,
+	create_item_insurance_eligibility,
+	create_payor_insurance_eligibility_plan,
+	create_sales_invoice,
 )
+from healthcare.healthcare.doctype.patient_insurance_policy.test_patient_insurance_policy import (
+	get_new_insurance_policy,
+)
+from healthcare.healthcare.utils import get_appointments_to_invoice
+from healthcare.tests.utils import HealthcareTestSuite
 
 
-class TestInsuranceClaim(IntegrationTestCase):
-	def test_insurance_claim(self):
+class TestInsuranceClaim(HealthcareTestSuite):
+	def setUp(self):
+		super().setUp()
+		self.patient = frappe.get_list("Patient", pluck="name")[0]
+		self.practitioner = frappe.get_list("Healthcare Practitioner", pluck="name")[0]
+
+	def test_insurance_claim_and_payment(self):
 		frappe.db.sql("""delete from `tabAppointment Type` where name = '_Test Appointment'""")
 		frappe.db.sql("""delete from `tabPatient Appointment` where appointment_type = '_Test Appointment'""")
 		frappe.db.sql(
 			"""delete from `tabInsurance Payor Contract` where insurance_payor = '_Test Insurance Payor'"""
 		)
-		test_docs = create_insurance_test_docs()
 
-		# Patient balance should be 20% of 400
-		info = get_dashboard_info("Customer", test_docs["customer"], None)
-		balance = next(item["total_unpaid"] for item in info if item["company"] == "_Test Company")
+		eligibility_plan = create_payor_insurance_eligibility_plan()
+		contract = get_new_payor_contract_doc(today(), add_years(today(), 1))
+		contract.submit()
 
-		self.assertEqual(balance, 80)
+		insurance_policy = get_new_insurance_policy(self.patient, eligibility_plan)
+		insurance_policy.submit()
+
+		appointment_type = "_Test Appointment Type"
+		create_item_insurance_eligibility("Service", "Appointment Type", appointment_type, eligibility_plan)
+
+		# Book Appointment and Invoice
+		# invoice total 400 (after 20% discount) coverage 80%
+		appointment = create_appointment(
+			self.patient, self.practitioner, nowdate(), appointment_type, insurance_policy.name
+		)
+		appointments_to_invoice = get_appointments_to_invoice(
+			frappe.get_doc("Patient", self.patient), "_Test Company"
+		)
+		create_sales_invoice(appointment, appointments_to_invoice)
 
 		# Create Insurance Claim
-		claim_name, claim_doc = create_insurance_claim(test_docs["Patient"], test_docs["Insurance Policy"])
+		claim_name, claim_doc = create_insurance_claim(self.patient, insurance_policy.name)
 
-		self.assertEqual(claim_doc.insurance_claim_amount, 320)
-		self.assertEqual(claim_doc.approved_amount, 320)
-		self.assertEqual(claim_doc.outstanding_amount, 320)
+		self.assertEqual(claim_doc.insurance_claim_amount, 192)
+		self.assertEqual(claim_doc.approved_amount, 192)
+		self.assertEqual(claim_doc.outstanding_amount, 192)
 		self.assertEqual(claim_doc.paid_amount, 0)
 
 		# Create Payment Entry of the Insurance Claim
@@ -50,13 +72,12 @@ class TestInsuranceClaim(IntegrationTestCase):
 			["approved_amount", "outstanding_amount", "paid_amount"],
 			as_dict=1,
 		)
-		self.assertEqual(claim_dict.approved_amount, 320)
+		self.assertEqual(claim_dict.approved_amount, 192)
 		self.assertEqual(claim_dict.outstanding_amount, 0)
-		self.assertEqual(claim_dict.paid_amount, 320)
+		self.assertEqual(claim_dict.paid_amount, 192)
 
 
 def create_insurance_claim(patient, insurance_policy):
-	create_insurance_payor()
 	claim = frappe.new_doc("Insurance Claim")
 	claim.insurance_payor = "_Test Insurance Payor"
 	claim.mode_of_payment = "Cash"

--- a/healthcare/healthcare/doctype/insurance_payor/test_insurance_payor.py
+++ b/healthcare/healthcare/doctype/insurance_payor/test_insurance_payor.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests import IntegrationTestCase
+from healthcare.tests.utils import HealthcareTestSuite
 
 
-class TestInsurancePayor(IntegrationTestCase):
+class TestInsurancePayor(HealthcareTestSuite):
 	pass

--- a/healthcare/healthcare/doctype/insurance_payor_contract/test_insurance_payor_contract.py
+++ b/healthcare/healthcare/doctype/insurance_payor_contract/test_insurance_payor_contract.py
@@ -2,17 +2,17 @@
 # See license.txt
 
 import frappe
-from frappe.tests import IntegrationTestCase
 from frappe.utils import add_days, add_years, getdate, today
 
 from healthcare.healthcare.doctype.insurance_payor_contract.insurance_payor_contract import (
 	OverlapError,
 )
+from healthcare.tests.utils import HealthcareTestSuite
 
 
-class TestInsurancePayorContract(IntegrationTestCase):
-	def test_overlap(self):
-		create_insurance_payor()
+class TestInsurancePayorContract(HealthcareTestSuite):
+	def test_insurance_payor_contract_overlap(self):
+		self.payor = frappe.get_list("Insurance Payor", pluck="name")[0]
 		frappe.db.sql(
 			"""delete from `tabInsurance Payor Contract` where insurance_payor = '_Test Insurance Payor'"""
 		)
@@ -32,27 +32,6 @@ class TestInsurancePayorContract(IntegrationTestCase):
 		# contract cannot have overlapping with start_date > and end_date <
 		contract = get_new_payor_contract_doc(add_days(start_date, 1), add_days(end_date, -1))
 		self.assertRaises(OverlapError, contract.save)
-
-
-def create_insurance_payor():
-	if not frappe.db.exists("Insurance Payor", "_Test Insurance Payor"):
-		insurance_payor = frappe.get_doc(
-			{
-				"doctype": "Insurance Payor",
-				"insurance_payor_name": "_Test Insurance Payor",
-				"abbr": "HIC",
-				"default_currency": "IND",
-				"country": "India",
-			}
-		)
-		insurance_payor.append(
-			"claims_receivable_accounts", {"company": "_Test Company", "account": "Debtors - _TC"}
-		)
-		insurance_payor.append(
-			"rejected_claims_expense_accounts",
-			{"company": "_Test Company", "account": "Debtors - _TC"},
-		)
-		insurance_payor.insert()
 
 
 def get_new_payor_contract_doc(start_date, end_date):

--- a/healthcare/healthcare/doctype/item_insurance_eligibility/item_insurance_eligibility.js
+++ b/healthcare/healthcare/doctype/item_insurance_eligibility/item_insurance_eligibility.js
@@ -35,6 +35,7 @@ frappe.ui.form.on("Item Insurance Eligibility", {
 				},
 			};
 		});
+		frm.set_df_property("template_dt", "only_select", true);
 
 		frm.set_query("template_dn", function () {
 			if (frm.doc.template_dt != "Appointment Type") {

--- a/healthcare/healthcare/doctype/item_insurance_eligibility/test_item_insurance_eligibility.py
+++ b/healthcare/healthcare/doctype/item_insurance_eligibility/test_item_insurance_eligibility.py
@@ -2,29 +2,25 @@
 # See license.txt
 
 import frappe
-from frappe.tests import IntegrationTestCase
 from frappe.utils import add_to_date, getdate
 
 from healthcare.healthcare.doctype.item_insurance_eligibility.item_insurance_eligibility import (
 	CoverageOverlapError,
 	get_insurance_eligibility,
 )
-from healthcare.healthcare.doctype.patient_appointment.test_patient_appointment import (
-	create_appointment_type,
-	create_medical_department,
-)
+from healthcare.tests.utils import HealthcareTestSuite
 
 
-class TestItemInsuranceEligibility(IntegrationTestCase):
-	def test_validate_overlap(self):
+class TestItemInsuranceEligibility(HealthcareTestSuite):
+	def test_validate_eligibility_overlap(self):
 		frappe.db.sql("""delete from `tabAppointment Type` where name = '_Test Appointment'""")
 		frappe.db.sql("""delete from `tabItem Insurance Eligibility`""")
 
-		medical_department = create_medical_department()
+		medical_department = "_Test Medical Department"
 		args = {
 			"medical_department": medical_department,
 		}
-		appointment_type = create_appointment_type(args).name
+		appointment_type = "_Test Appointment Type"
 
 		args = frappe._dict(
 			{
@@ -53,7 +49,7 @@ class TestItemInsuranceEligibility(IntegrationTestCase):
 		item_insurance_eligibility = create_insurance_eligibility(**args).insert()
 		self.assertTrue(item_insurance_eligibility)
 
-		# create an overlaping eligibility
+		# create an overlapping eligibility
 		args["valid_till"] = add_to_date(getdate(), months=1)
 
 		with self.assertRaises(CoverageOverlapError):
@@ -62,11 +58,11 @@ class TestItemInsuranceEligibility(IntegrationTestCase):
 	def test_item_insurance_eligibility(self):
 		frappe.db.sql("""delete from `tabItem Insurance Eligibility`""")
 
-		medical_department = create_medical_department()
+		medical_department = "_Test Medical Department"
 		args = {
 			"medical_department": medical_department,
 		}
-		appointment_type = create_appointment_type(args).name
+		appointment_type = "_Test Appointment Type"
 
 		args = frappe._dict(
 			{

--- a/healthcare/healthcare/doctype/patient_insurance_coverage/patient_insurance_coverage.py
+++ b/healthcare/healthcare/doctype/patient_insurance_coverage/patient_insurance_coverage.py
@@ -369,6 +369,7 @@ def get_item_price_list_rate(item_code, price_list, qty, company):
 			"item_code": item_code,
 			"qty": qty,
 			"selling_price_list": price_list,
+			"currency": frappe.get_value("Price List", price_list, "currency"),
 			"company": company,
 			"plc_conversion_rate": 1.0,
 			"conversion_rate": 1.0,

--- a/healthcare/healthcare/doctype/patient_insurance_coverage/test_patient_insurance_coverage.py
+++ b/healthcare/healthcare/doctype/patient_insurance_coverage/test_patient_insurance_coverage.py
@@ -1,91 +1,69 @@
 # Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
 
-import json
-
 import frappe
-from frappe.tests import IntegrationTestCase
 from frappe.utils import add_years, flt, getdate, nowdate, nowtime, today
 
 from healthcare.healthcare.doctype.healthcare_settings.healthcare_settings import (
 	get_receivable_account,
 )
 from healthcare.healthcare.doctype.insurance_payor_contract.test_insurance_payor_contract import (
-	create_insurance_payor,
 	get_new_payor_contract_doc,
 )
 from healthcare.healthcare.doctype.patient_appointment.patient_appointment import (
 	get_appointment_item,
 )
-from healthcare.healthcare.doctype.patient_appointment.test_patient_appointment import (
-	create_appointment_type,
-	create_healthcare_docs,
-	create_healthcare_service_items,
-	create_medical_department,
-)
 from healthcare.healthcare.doctype.patient_insurance_policy.test_patient_insurance_policy import (
 	get_new_insurance_policy,
 )
 from healthcare.healthcare.utils import get_appointments_to_invoice
+from healthcare.tests.utils import HealthcareTestSuite
 
 
-class TestPatientInsuranceCoverage(IntegrationTestCase):
+class TestPatientInsuranceCoverage(HealthcareTestSuite):
+	def setUp(self):
+		super().setUp()
+		self.patient = frappe.get_list("Patient", pluck="name")[0]
+		self.practitioner = frappe.get_list("Healthcare Practitioner", pluck="name")[0]
+		self.payor = frappe.get_list("Insurance Payor", pluck="name")[0]
+
 	def test_insurance_coverage(self):
-		frappe.db.sql("""delete from `tabAppointment Type` where name = '_Test Appointment'""")
+		# frappe.db.sql("""delete from `tabAppointment Type` where name = '_Test Appointment'""")
 		frappe.db.sql("""delete from `tabPatient Appointment` where appointment_type = '_Test Appointment'""")
 		frappe.db.sql(
 			"""delete from `tabInsurance Payor Contract` where insurance_payor = '_Test Insurance Payor'"""
 		)
 		frappe.db.set_single_value("Healthcare Settings", "enable_free_follow_ups", 0)
 		frappe.db.set_single_value("Healthcare Settings", "show_payment_popup", 0)
-		test_docs = create_insurance_test_docs()
+
+		eligibility_plan = create_payor_insurance_eligibility_plan()
+		contract = get_new_payor_contract_doc(today(), add_years(today(), 1))
+		contract.submit()
+
+		insurance_policy = get_new_insurance_policy(self.patient, eligibility_plan)
+		insurance_policy.submit()
+
+		appointment_type = "_Test Appointment Type"
+		create_item_insurance_eligibility("Service", "Appointment Type", appointment_type, eligibility_plan)
+
+		# Book Appointment and Invoice
+		# invoice total 400 (after 20% discount) coverage 80%
+		appointment = create_appointment(
+			self.patient, self.practitioner, nowdate(), appointment_type, insurance_policy.name
+		)
+		appointments_to_invoice = get_appointments_to_invoice(
+			frappe.get_doc("Patient", self.patient), "_Test Company"
+		)
+		sales_invoice = create_sales_invoice(appointment, appointments_to_invoice)
+
 		invoice_dict = frappe.db.get_value(
 			"Sales Invoice",
-			test_docs["Sales Invoice"],
+			sales_invoice,
 			["total_insurance_coverage_amount", "patient_payable_amount"],
 			as_dict=1,
 		)
-		self.assertEqual(invoice_dict.total_insurance_coverage_amount, 320)
-		self.assertEqual(invoice_dict.patient_payable_amount, 80)
-
-
-def create_insurance_test_docs():
-	patient, practitioner = create_healthcare_docs()
-
-	# Create Insurance Payor, Contract, Item Insurance Eligibility, Eligibility Plan, Patient Insurance Policy
-	create_insurance_payor()
-	eligibility_plan = create_payor_insurance_eligibility_plan()
-	contract = get_new_payor_contract_doc(today(), add_years(today(), 1))
-	contract.submit()
-	insurance_policy = get_new_insurance_policy(patient, eligibility_plan)
-	insurance_policy.submit()
-	medical_department = create_medical_department()
-	args = {
-		"medical_department": medical_department,
-	}
-	appointment_type = create_appointment_type(args).name
-	create_item_insurance_eligibility("Service", "Appointment Type", appointment_type, eligibility_plan)
-
-	# Book Appointment and Invoice
-	# invoice total 400 (after 20% discount) coverage 80%
-	appointment = create_appointment(
-		patient, practitioner, nowdate(), appointment_type, insurance_policy.name
-	)
-	appointments_to_invoice = get_appointments_to_invoice(frappe.get_doc("Patient", patient), "_Test Company")
-	sales_invoice = create_sales_invoice(appointment, appointments_to_invoice)
-	test_docs = {
-		"Patient": patient,
-		"customer": frappe.get_cached_value("Patient", patient, "customer"),
-		"Practitioner": practitioner,
-		"Eligibility Plan": eligibility_plan,
-		"Contract": contract.name,
-		"Insurance Policy": insurance_policy.name,
-		"Medical Department": medical_department,
-		"Patient Appointment": appointment.name,
-		"appointments_to_invoice": appointments_to_invoice,
-		"Sales Invoice": sales_invoice,
-	}
-	return test_docs
+		self.assertEqual(invoice_dict.total_insurance_coverage_amount, 192)
+		self.assertEqual(invoice_dict.patient_payable_amount, 48)
 
 
 def create_item_insurance_eligibility(eligibility_for, template_dt, template_dn, eligibility_plan):
@@ -109,14 +87,14 @@ def create_item_insurance_eligibility(eligibility_for, template_dt, template_dn,
 
 
 def create_appointment(patient, practitioner, appointment_date, appointment_type, policy=None):
-	item = create_healthcare_service_items()
+	item = "HLC-SI-001"
 	frappe.db.set_single_value("Healthcare Settings", "inpatient_visit_charge_item", item)
 	frappe.db.set_single_value("Healthcare Settings", "op_consulting_charge_item", item)
 	appointment = frappe.new_doc("Patient Appointment")
 	appointment.patient = patient
 	appointment.practitioner = practitioner
 	appointment.appointment_type = appointment_type
-	appointment.department = create_medical_department()
+	appointment.department = "_Test Medical Department"
 	appointment.appointment_date = appointment_date
 	appointment.appointment_time = nowtime()
 	appointment.company = "_Test Company"

--- a/healthcare/healthcare/doctype/patient_insurance_policy/test_patient_insurance_policy.py
+++ b/healthcare/healthcare/doctype/patient_insurance_policy/test_patient_insurance_policy.py
@@ -2,23 +2,17 @@
 # See license.txt
 
 import frappe
-from frappe.tests import IntegrationTestCase
 from frappe.utils import add_days, today
 
-from healthcare.healthcare.doctype.insurance_payor_contract.test_insurance_payor_contract import (
-	create_insurance_payor,
-)
-from healthcare.healthcare.doctype.patient_appointment.test_patient_appointment import (
-	create_patient,
-)
 from healthcare.healthcare.doctype.patient_insurance_policy.patient_insurance_policy import (
 	OverlapError,
 )
+from healthcare.tests.utils import HealthcareTestSuite
 
 
-class TestPatientInsurancePolicy(IntegrationTestCase):
-	def test_policy(self):
-		patient = create_patient()
+class TestPatientInsurancePolicy(HealthcareTestSuite):
+	def test_insurance_policy_overlap(self):
+		patient = frappe.get_list("Patient", pluck="name")[0]
 		insurance_policy = get_new_insurance_policy(patient)
 		insurance_policy.submit()
 
@@ -28,7 +22,6 @@ class TestPatientInsurancePolicy(IntegrationTestCase):
 
 
 def get_new_insurance_policy(patient, eligibility_plan=None):
-	create_insurance_payor()
 	insurance_policy = frappe.new_doc("Patient Insurance Policy")
 	insurance_policy.insurance_payor = "_Test Insurance Payor"
 	insurance_policy.patient = patient

--- a/healthcare/healthcare/utils.py
+++ b/healthcare/healthcare/utils.py
@@ -801,8 +801,13 @@ def post_transfer_journal_entry_and_update_coverage(sales_invoice):
 			or not insurance_payor_details.get("receivable_account")
 			or not insurance_payor_details.get("party")
 		):
+		if (
+			not insurance_payor_details
+			or not insurance_payor_details.get("receivable_account")
+			or not insurance_payor_details.get("party")
+		):
 			frappe.throw(
-				_("Receivable Account not configured for Insurance Payor").format(item.insurance_payor)
+				_("Receivable Account not configured for Insurance Payor {0}").format(item.insurance_payor)
 			)
 
 		jv_accounts = []

--- a/healthcare/healthcare/utils.py
+++ b/healthcare/healthcare/utils.py
@@ -9,11 +9,15 @@ import math
 
 import frappe
 from frappe import _
-from frappe.utils import cint, cstr, flt, get_link_to_form, rounded, time_diff_in_hours
+from frappe.utils import cint, cstr, flt, get_link_to_form, getdate, rounded, time_diff_in_hours
 from frappe.utils.formatters import format_value
 
 from erpnext.setup.utils import insert_record
 
+from healthcare.healthcare.doctype.fee_validity.fee_validity import (
+	get_fee_validity,
+	manage_fee_validity,
+)
 from healthcare.healthcare.doctype.healthcare_settings.healthcare_settings import (
 	get_income_account,
 )
@@ -58,6 +62,59 @@ def validate_customer_created(patient, customer, link_customer):
 		frappe.msgprint(message, alert=True)
 
 
+INSURANCE_COVERAGE_FIELDS = [
+	"status",
+	"coverage",
+	"discount",
+	"price_list_rate",
+	"item_code",
+	"qty",
+	"policy_number",
+	"coverage_validity_end_date",
+	"company",
+	"insurance_payor",
+]
+
+
+def get_valid_insurance_coverage_details(insurance_coverage, company, extra_fields=None):
+	if not insurance_coverage:
+		return None
+
+	fields = list(INSURANCE_COVERAGE_FIELDS)
+	if extra_fields:
+		fields.extend(extra_fields)
+
+	coverage_details = frappe.get_cached_value(
+		"Patient Insurance Coverage", insurance_coverage, fields, as_dict=True
+	)
+	if (
+		coverage_details
+		and coverage_details.status in ["Approved", "Partly Invoiced"]
+		and getdate() <= coverage_details.coverage_validity_end_date
+		and company == coverage_details.company
+	):
+		return coverage_details
+
+	return None
+
+
+def get_insurance_invoice_line(reference_type, reference_name, insurance_coverage, coverage_details, **extra):
+	return {
+		"reference_type": reference_type,
+		"reference_name": reference_name,
+		"insurance_coverage": insurance_coverage,
+		"patient_insurance_policy": coverage_details.policy_number,
+		"insurance_payor": coverage_details.insurance_payor,
+		"service": coverage_details.item_code,
+		"rate": coverage_details.price_list_rate,
+		"coverage_percentage": coverage_details.coverage,
+		"discount_percentage": coverage_details.discount,
+		"coverage_rate": coverage_details.price_list_rate,
+		"coverage_qty": coverage_details.qty,
+		**extra,
+	}
+
+
 def get_appointments_to_invoice(patient, company):
 	appointments_to_invoice = []
 	patient_appointments = frappe.get_list(
@@ -88,10 +145,18 @@ def get_appointments_to_invoice(patient, company):
 				)
 		# Consultation Appointments, should check fee validity
 		else:
-			if frappe.db.get_single_value(
-				"Healthcare Settings", "enable_free_follow_ups"
-			) and frappe.db.exists("Fee Validity Reference", {"appointment": appointment.name}):
-				continue  # Skip invoicing, fee validty present
+			if appointment.practitioner:
+				pract_enabled = frappe.get_cached_value(
+					"Healthcare Practitioner", appointment.practitioner, "enable_free_follow_ups"
+				)
+				settings_enabled = frappe.db.get_single_value("Healthcare Settings", "enable_free_follow_ups")
+
+				if pract_enabled or settings_enabled:
+					if get_fee_validity(appointment.name, appointment.appointment_date, ignore_status=True):
+						continue  # Skip invoicing, fee validity exists
+					if frappe.db.exists("Fee Validity Reference", {"appointment": appointment.name}):
+						continue  # Skip invoicing, fee validty present
+
 			practitioner_charge = 0
 			income_account = None
 			service_item = None
@@ -100,15 +165,30 @@ def get_appointments_to_invoice(patient, company):
 				service_item = details.get("service_item")
 				practitioner_charge = details.get("practitioner_charge")
 				income_account = get_income_account(appointment.practitioner, appointment.company)
-			appointments_to_invoice.append(
-				{
-					"reference_type": "Patient Appointment",
-					"reference_name": appointment.name,
-					"service": service_item,
-					"rate": practitioner_charge,
-					"income_account": income_account,
-				}
+
+			coverage_details = get_valid_insurance_coverage_details(
+				appointment.insurance_coverage, company
 			)
+			if coverage_details:
+				appointments_to_invoice.append(
+					get_insurance_invoice_line(
+						"Patient Appointment",
+						appointment.name,
+						appointment.insurance_coverage,
+						coverage_details,
+						income_account=income_account,
+					)
+				)
+			else:
+				appointments_to_invoice.append(
+					{
+						"reference_type": "Patient Appointment",
+						"reference_name": appointment.name,
+						"service": service_item,
+						"rate": practitioner_charge,
+						"income_account": income_account,
+					}
+				)
 
 	return appointments_to_invoice
 
@@ -140,15 +220,29 @@ def get_encounters_to_invoice(patient, company):
 					practitioner_charge = details.get("practitioner_charge")
 					income_account = get_income_account(encounter.practitioner, encounter.company)
 
-				encounters_to_invoice.append(
-					{
-						"reference_type": "Patient Encounter",
-						"reference_name": encounter.name,
-						"service": service_item,
-						"rate": practitioner_charge,
-						"income_account": income_account,
-					}
+				coverage_details = get_valid_insurance_coverage_details(
+					encounter.insurance_coverage, company
 				)
+				if coverage_details:
+					encounters_to_invoice.append(
+						get_insurance_invoice_line(
+							"Patient Encounter",
+							encounter.name,
+							encounter.insurance_coverage,
+							coverage_details,
+							income_account=income_account,
+						)
+					)
+				else:
+					encounters_to_invoice.append(
+						{
+							"reference_type": "Patient Encounter",
+							"reference_name": encounter.name,
+							"service": service_item,
+							"rate": practitioner_charge,
+							"income_account": income_account,
+						}
+					)
 
 	return encounters_to_invoice
 
@@ -157,7 +251,7 @@ def get_lab_tests_to_invoice(patient, company):
 	lab_tests_to_invoice = []
 	lab_tests = frappe.get_list(
 		"Lab Test",
-		fields=["name", "template"],
+		fields=["name", "template", "insurance_coverage"],
 		filters={
 			"patient": patient.name,
 			"company": company,
@@ -171,9 +265,20 @@ def get_lab_tests_to_invoice(patient, company):
 			"Lab Test Template", lab_test.template, ["item", "is_billable"]
 		)
 		if is_billable:
-			lab_tests_to_invoice.append(
-				{"reference_type": "Lab Test", "reference_name": lab_test.name, "service": item}
-			)
+			coverage_details = get_valid_insurance_coverage_details(lab_test.insurance_coverage, company)
+			if coverage_details:
+				lab_tests_to_invoice.append(
+					get_insurance_invoice_line(
+						"Lab Test",
+						lab_test.name,
+						lab_test.insurance_coverage,
+						coverage_details,
+					)
+				)
+			else:
+				lab_tests_to_invoice.append(
+					{"reference_type": "Lab Test", "reference_name": lab_test.name, "service": item}
+				)
 
 	return lab_tests_to_invoice
 
@@ -224,9 +329,22 @@ def get_clinical_procedures_to_invoice(patient, company):
 				"Clinical Procedure Template", procedure.procedure_template, ["item", "is_billable"]
 			)
 			if procedure.procedure_template and is_billable:
-				clinical_procedures_to_invoice.append(
-					{"reference_type": "Clinical Procedure", "reference_name": procedure.name, "service": item}
+				coverage_details = get_valid_insurance_coverage_details(
+					procedure.insurance_coverage, company
 				)
+				if coverage_details:
+					clinical_procedures_to_invoice.append(
+						get_insurance_invoice_line(
+							"Clinical Procedure",
+							procedure.name,
+							procedure.insurance_coverage,
+							coverage_details,
+						)
+					)
+				else:
+					clinical_procedures_to_invoice.append(
+						{"reference_type": "Clinical Procedure", "reference_name": procedure.name, "service": item}
+					)
 
 		# consumables
 		if (
@@ -283,6 +401,21 @@ def get_inpatient_services_to_invoice(patient, company):
 		)
 		service_unit_type = frappe.get_cached_doc("Healthcare Service Unit Type", service_unit_type)
 		if service_unit_type and service_unit_type.is_billable:
+			coverage_details = get_valid_insurance_coverage_details(
+				inpatient_occupancy.insurance_coverage, company
+			)
+			if coverage_details:
+				services_to_invoice.append(
+					get_insurance_invoice_line(
+						"Inpatient Occupancy",
+						inpatient_occupancy.name,
+						inpatient_occupancy.insurance_coverage,
+						coverage_details,
+						qty=coverage_details.qty,
+					)
+				)
+				continue
+
 			hours_occupied = flt(
 				time_diff_in_hours(inpatient_occupancy.check_out, inpatient_occupancy.check_in), 2
 			)
@@ -360,13 +493,26 @@ def get_therapy_sessions_to_invoice(patient, company):
 			if therapy.therapy_type and frappe.db.get_value(
 				"Therapy Type", therapy.therapy_type, "is_billable"
 			):
-				therapy_sessions_to_invoice.append(
-					{
-						"reference_type": "Therapy Session",
-						"reference_name": therapy.name,
-						"service": frappe.db.get_value("Therapy Type", therapy.therapy_type, "item"),
-					}
+				coverage_details = get_valid_insurance_coverage_details(
+					therapy.insurance_coverage, company
 				)
+				if coverage_details:
+					therapy_sessions_to_invoice.append(
+						get_insurance_invoice_line(
+							"Therapy Session",
+							therapy.name,
+							therapy.insurance_coverage,
+							coverage_details,
+						)
+					)
+				else:
+					therapy_sessions_to_invoice.append(
+						{
+							"reference_type": "Therapy Session",
+							"reference_name": therapy.name,
+							"service": frappe.db.get_value("Therapy Type", therapy.therapy_type, "item"),
+						}
+					)
 
 	return therapy_sessions_to_invoice
 
@@ -387,26 +533,42 @@ def get_service_requests_to_invoice(patient, company):
 		item, is_billable = frappe.get_cached_value(
 			service_request.template_dt, service_request.template_dn, ["item", "is_billable"]
 		)
-		price_list, price_list_currency = frappe.db.get_values(
-			"Price List", {"selling": 1}, ["name", "currency"]
-		)[0]
-		args = {
-			"doctype": "Sales Invoice",
-			"item_code": item,
-			"company": service_request.get("company"),
-			"customer": frappe.db.get_value("Patient", service_request.get("patient"), "customer"),
-			"plc_conversion_rate": 1.0,
-			"conversion_rate": 1.0,
-		}
 		if is_billable:
-			orders_to_invoice.append(
-				{
-					"reference_type": "Service Request",
-					"reference_name": service_request.name,
-					"service": item,
-					"qty": service_request.quantity if service_request.quantity else 1,
-				}
+			billable_order_qty = service_request.get("quantity", 1) - service_request.get("qty_invoiced", 0)
+
+			coverage_details = get_valid_insurance_coverage_details(
+				service_request.insurance_coverage,
+				company,
+				extra_fields=["qty_invoiced"],
 			)
+			if coverage_details:
+				billable_coverage_qty = coverage_details.get("qty", 1) - coverage_details.get(
+					"qty_invoiced", 0
+				)
+
+				orders_to_invoice.append(
+					get_insurance_invoice_line(
+						"Service Request",
+						service_request.name,
+						service_request.insurance_coverage,
+						coverage_details,
+						qty=min(billable_coverage_qty, billable_order_qty),
+					)
+				)
+				if billable_order_qty > billable_coverage_qty:
+					billable_order_qty = billable_order_qty - billable_coverage_qty
+				else:
+					continue
+
+			if billable_order_qty:
+				orders_to_invoice.append(
+					{
+						"reference_type": "Service Request",
+						"reference_name": service_request.name,
+						"service": item,
+						"qty": billable_order_qty,
+					}
+				)
 	return orders_to_invoice
 
 
@@ -549,6 +711,9 @@ def manage_invoice_submit_cancel(doc, method):
 				# if frappe.get_meta(item.reference_dt).has_field("invoiced"):
 				set_invoiced(item, method, doc.name)
 
+				if item.reference_dt == "Patient Appointment":
+					manage_fee_validity(frappe.get_doc("Patient Appointment", item.reference_dn))
+
 				# set patient as active if registration invoice
 				if item.get("reference_dt") == "Patient":
 					registration_item = (
@@ -572,6 +737,9 @@ def manage_invoice_submit_cancel(doc, method):
 		if frappe.db.get_single_value("Healthcare Settings", "create_lab_test_on_si_submit"):
 			create_multiple("Sales Invoice", doc.name)
 
+		post_transfer_journal_entry_and_update_coverage(doc)
+		doc.reload()
+
 		if (
 			not frappe.db.get_single_value("Healthcare Settings", "show_payment_popup")
 			and frappe.db.get_single_value("Healthcare Settings", "enable_free_follow_ups")
@@ -583,7 +751,7 @@ def manage_invoice_submit_cancel(doc, method):
 					if fee_validity:
 						frappe.db.set_value("Fee Validity", fee_validity, "sales_invoice_ref", doc.name)
 
-	if method == "on_cancel":
+	elif method == "on_cancel":
 		if doc.items and (doc.additional_discount_percentage or doc.discount_amount):
 			for item in doc.items:
 				if (
@@ -599,6 +767,88 @@ def manage_invoice_submit_cancel(doc, method):
 							"ref_sales_invoice": None,
 						},
 					)
+		update_insurance_coverage(doc)
+
+
+def update_insurance_coverage(sales_invoice):
+	"""
+	Updates Insurance coverage invoice details
+	NOTE: Journal entries should be cancelled by now via Cancel All
+	"""
+	for item in sales_invoice.items:
+		if item.insurance_coverage:
+			coverage = frappe.get_doc("Patient Insurance Coverage", item.insurance_coverage)
+			coverage.update_invoice_details(item.qty * -1, item.insurance_coverage_amount * -1)
+
+
+def post_transfer_journal_entry_and_update_coverage(sales_invoice):
+	"""
+	1 - Post Journal Entry to Transfer Patient balance for each coverage
+	2 - Update Insurance Coverage
+	"""
+	for item in sales_invoice.items:
+		if not item.insurance_coverage:
+			continue
+
+		from healthcare.healthcare.doctype.insurance_payor.insurance_payor import (
+			get_insurance_payor_details,
+		)
+
+		insurance_payor_details = get_insurance_payor_details(item.insurance_payor, sales_invoice.company)
+
+		if (
+			not insurance_payor_details
+			or not insurance_payor_details.get("receivable_account")
+			or not insurance_payor_details.get("party")
+		):
+			frappe.throw(
+				_("Receivable Account not configured for Insurance Payor").format(item.insurance_payor)
+			)
+
+		jv_accounts = []
+
+		jv_accounts.append(
+			{
+				"account": insurance_payor_details.get("receivable_account"),
+				"debit_in_account_currency": item.insurance_coverage_amount,
+				"party_type": "Customer",
+				"party": insurance_payor_details.get("party"),
+				"cost_center": item.cost_center,
+			}
+		)
+
+		jv_accounts.append(
+			{
+				"account": sales_invoice.debit_to,
+				"credit_in_account_currency": item.insurance_coverage_amount,
+				"party_type": "Customer",
+				"party": sales_invoice.customer,
+				"reference_type": "Sales Invoice",
+				"reference_name": sales_invoice.name,
+				"reference_detail_no": item.name,
+				"cost_center": item.cost_center,
+			}
+		)
+
+		journal_entry = frappe.new_doc("Journal Entry")
+
+		jv_naming_series = frappe.db.get_single_value(
+			"Healthcare Settings", "naming_series_for_journal_entry"
+		)
+		if jv_naming_series:
+			journal_entry.naming_series = jv_naming_series
+
+		journal_entry.company = sales_invoice.company
+		journal_entry.posting_date = sales_invoice.posting_date
+
+		for account in jv_accounts:
+			journal_entry.append("accounts", account)
+
+		journal_entry.flags.ignore_permissions = True
+		journal_entry.submit()
+
+		coverage = frappe.get_doc("Patient Insurance Coverage", item.insurance_coverage)
+		coverage.update_invoice_details(item.qty, item.insurance_coverage_amount)
 
 
 def set_invoiced(item, method, ref_invoice=None):

--- a/healthcare/tests/utils.py
+++ b/healthcare/tests/utils.py
@@ -1,0 +1,816 @@
+import frappe
+
+from erpnext.tests.utils import ERPNextTestSuite
+
+
+class BootStrapTestData:
+	def __init__(self):
+		self.make_master_data()
+
+	def make_master_data(self):
+		self.make_company()
+		self.make_service_items()
+		self.make_stock_items()
+		self.make_diagnoses()
+		self.make_medical_departments()
+		self.make_users()
+		self.make_patients()
+		self.make_practitioners()
+		self.make_service_unit_types()
+		self.make_service_units()
+		self.make_appointment_types()
+		self.make_clinical_procedure_templates()
+		self.make_lab_test_samples()
+		self.make_lab_test_templates()
+		self.make_observation_templates()
+		self.make_care_activity()
+		self.make_nursing_checklist_templates()
+		self.make_exercise_types()
+		self.make_therapy_types()
+		self.make_therapy_plan_templates()
+		self.make_medication_classes()
+		self.make_medications()
+		self.make_treatment_plan_templates()
+		self.make_insurance_payors()
+
+	def make_insurance_payors(self):
+		records = [
+			{
+				"doctype": "Insurance Payor",
+				"insurance_payor_name": "_Test Insurance Payor",
+				"abbr": "HIC",
+				"default_currency": "INR",
+				"country": "India",
+				"claims_receivable_accounts": [{"company": "_Test Company", "account": "Debtors - _TC"}],
+				"rejected_claims_expense_accounts": [
+					{"company": "_Test Company", "account": "Debtors - _TC"},
+				],
+			},
+		]
+		self.make_records(["insurance_payor_name"], records)
+
+	def make_treatment_plan_templates(self):
+		records = [
+			{
+				"doctype": "Treatment Plan Template",
+				"template_name": "COVID19",
+				"medical_department": "_Test Medical Department",
+				"disabled": 0,
+				"is_inpatient": 1,
+				"treatment_counselling_required_for_ip": 1,
+				"items": [
+					{"type": "Observation Template", "template": "_Test COVID RT PCR", "qty": 1},
+				],
+			},
+		]
+		self.make_records(["template_name"], records)
+
+	def make_medications(self):
+		records = [
+			{
+				"doctype": "Medication",
+				"generic_name": "Paracetamol",
+				"medication_class": "Analgesics",
+				"strength": 300,
+				"strength_uom": "Milligram",
+				"dosage_form": "Tablet",
+				"linked_items": [
+					{
+						"item_code": "Paracetamol",
+						"item_group": "Drug",
+						"is_billable": 1,
+						"rate": 25,
+					},
+				],
+			},
+		]
+		self.make_records(["generic_name"], records)
+
+	def make_dosage_forms(self):
+		records = [
+			{
+				"dosage_form": "Tablet",
+			},
+			{
+				"dosage_form": "Ointment",
+			},
+		]
+		self.make_records(["dosage_form"], records)
+
+	def make_medication_classes(self):
+		records = [
+			{
+				"doctype": "Medication Class",
+				"medication_class": "Analgesics",
+			},
+			{
+				"doctype": "Medication Class",
+				"medication_class": "Antibiotics",
+			},
+		]
+		self.make_records(["medication_class"], records)
+
+	def make_therapy_plan_templates(self):
+		records = [
+			{
+				"doctype": "Therapy Plan Template",
+				"plan_name": "Complete Rehab",
+				"item_code": "Complete Rehab",
+				"item_name": "Complete Rehab",
+				"is_billable": 1,
+				"rate": 5000,
+				"item_group": "Services",
+				"therapy_types": [
+					{
+						"therapy_type": "Basic Rehab",
+						"no_of_sessions": 2,
+						"rate": 5000,
+						"amount": 2 * 5000,
+					},
+				],
+			},
+		]
+		self.make_records(["plan_name"], records)
+
+	def make_therapy_types(self):
+		records = [
+			{
+				"doctype": "Therapy Type",
+				"therapy_type": "Basic Rehab",
+				"default_duration": 30,
+				"is_billable": 1,
+				"rate": 5000,
+				"item_code": "Basic Rehab",
+				"item_name": "Basic Rehab",
+				"item_group": "Services",
+				"exercises": [
+					{
+						"exercise_type": "Sit to Stand",
+						"counts_target": 10,
+						"assistance_level": "Passive",
+					},
+				],
+			},
+		]
+		self.make_records(["therapy_type"], records)
+
+	def make_exercise_types(self):
+		records = [
+			{
+				"doctype": "Exercise Type",
+				"exercise_name": "Sit to Stand",
+				"steps_table": [
+					{
+						"title": "Step 1",
+						"description": "Squat and Rise",
+					},
+				],
+			}
+		]
+		self.make_records(["exercise_name"], records)
+
+	def make_nursing_checklist_templates(self):
+		records = [
+			{
+				"doctype": "Nursing Checklist Template",
+				"name": "Discharge checklist",
+				"title": "Discharge checklist",
+				"tasks": [
+					{
+						"doctype": "Nursing Checklist Template Task",
+						"activity": "BP Check",
+						"mandatory": 1,
+						"task_duration": 60,
+						"parent": "Discharge checklist",
+						"parentfield": "tasks",
+						"parenttype": "Nursing Checklist Template",
+					},
+				],
+			},
+		]
+		self.make_records(["name"], records)
+
+	def make_care_activity(self):
+		records = [
+			{
+				"doctype": "Healthcare Activity",
+				"name": "BP Check",
+				"activity": "BP Check",
+				"description": "BP Check",
+				"activity_duration": 60,
+				"role": "Nursing User",
+				"task_doctype": "Vital Signs",
+			},
+		]
+		self.make_records(["name"], records)
+
+	def make_observation_templates(self):
+		records = [
+			{
+				"doctype": "Observation Template",
+				"observation": "_Test Observation with Sample",
+				"abbr": "OWS",
+				"item_code": "_Test Observation with Sample",
+				"observation_category": "Laboratory",
+				"permitted_data_type": "Quantity",
+				"permitted_unit": "mg / dl",
+				"item_group": "Services",
+				"sample_collection_required": 1,
+				"is_billable": 1,
+				"rate": 300,
+			},
+			{
+				"doctype": "Observation Template",
+				"observation": "_Test Observation without Sample",
+				"abbr": "OWOS",
+				"item_code": "_Test Observation without Sample",
+				"observation_category": "Laboratory",
+				"permitted_data_type": "Quantity",
+				"permitted_unit": "mg / dl",
+				"item_group": "Services",
+				"sample_collection_required": 0,
+				"is_billable": 1,
+				"rate": 300,
+			},
+			{
+				"doctype": "Observation Template",
+				"observation": "_Test Observation Grouped with Sample",
+				"abbr": "OG",
+				"item_code": "_Test Observation Grouped with Sample",
+				"has_component": 1,
+				"observation_category": "Laboratory",
+				"permitted_data_type": "Quantity",
+				"permitted_unit": "mg / dl",
+				"item_group": "Services",
+				"sample_collection_required": 1,
+				"is_billable": 1,
+				"rate": 300,
+				"observation_component": [  # FIXME: observation_components
+					{
+						"observation_template": "_Test Observation with Sample",
+						"abbr": "OWOS",
+					},
+				],
+			},
+			{
+				"doctype": "Observation Template",
+				"observation": "_Test Observation Grouped without Sample",
+				"abbr": "OG",
+				"item_code": "_Test Observation Grouped without Sample",
+				"has_component": 1,
+				"observation_category": "Laboratory",
+				"permitted_data_type": "Quantity",
+				"permitted_unit": "mg / dl",
+				"item_group": "Services",
+				"sample_collection_required": 0,
+				"is_billable": 1,
+				"rate": 300,
+				"observation_component": [  # FIXME: observation_components
+					{
+						"observation_template": "_Test Observation without Sample",
+						"abbr": "OWOS",
+					},
+				],
+			},
+			{
+				"doctype": "Observation Template",
+				"observation": "_Test Observation Operand 2",
+				"abbr": "OWOS2",
+				"item_code": "_Test Observation Operand 2",
+				"observation_category": "Laboratory",
+				"permitted_data_type": "Quantity",
+				"permitted_unit": "mg / dl",
+				"item_group": "Services",
+				"sample_collection_required": 0,
+				"is_billable": 1,
+				"rate": 300,
+			},
+			{
+				"doctype": "Observation Template",
+				"observation": "_Test Observation Formula Result 1",
+				"abbr": "TFR1",
+				"item_code": "_Test Observation Formula Result 1",
+				"observation_category": "Laboratory",
+				"permitted_data_type": "Quantity",
+				"permitted_unit": "mg / dl",
+				"item_group": "Services",
+				"sample_collection_required": 0,
+				"is_billable": 1,
+				"rate": 300,
+			},
+			{
+				"doctype": "Observation Template",
+				"observation": "_Test Observation Formula Result 2",
+				"abbr": "TFR2",
+				"item_code": "_Test Observation Formula Result 2",
+				"observation_category": "Laboratory",
+				"permitted_data_type": "Quantity",
+				"permitted_unit": "mg / dl",
+				"item_group": "Services",
+				"sample_collection_required": 0,
+				"is_billable": 1,
+				"rate": 300,
+			},
+			{
+				"doctype": "Observation Template",
+				"observation": "_Test COVID RT PCR",
+				"abbr": "RTPCR",
+				"item_code": "_Test COVID RT PCR",
+				"observation_category": "Laboratory",
+				"permitted_data_type": "Quantity",
+				"permitted_unit": "mg / dl",
+				"item_group": "Services",
+				"sample_collection_required": 0,
+				"is_billable": 1,
+				"rate": 300,
+			},
+		]
+		self.make_records(["observation"], records)
+
+	def make_lab_test_templates(self):
+		records = [
+			{
+				"doctype": "Lab Test Template",
+				"lab_test_name": "_Test Lab Test - with Sample",
+				"lab_test_template_type": "Descriptive",
+				"lab_test_description": "Fasting Blood Sugar",
+				"lab_test_code": "_Test Lab Test - with Sample",
+				"lab_test_group": "Services",
+				"department": "_Test Medical Department",
+				"is_billable": 1,
+				"lab_test_rate": 2000,
+				"sample": "_Test Sample - Blood Sample",
+				"sample_qty": "5.0",
+				"descriptive_test_templates": [
+					{"particulars": "FBS", "allow_blank": 1},
+					{"particulars": "Insulin", "allow_blank": 0},
+					{"particulars": "IR", "allow_blank": 1},
+				],
+			},
+			{
+				"doctype": "Lab Test Template",
+				"lab_test_name": "_Test Lab Test - without Sample",
+				"lab_test_template_type": "Descriptive",
+				"lab_test_description": "Insulin Resistance",
+				"lab_test_code": "_Test Lab Test - without Sample",
+				"lab_test_group": "Services",
+				"department": "_Test Medical Department",
+				"is_billable": 1,
+				"lab_test_rate": 2000,
+				"descriptive_test_templates": [
+					{"particulars": "FBS", "allow_blank": 1},
+					{"particulars": "Insulin", "allow_blank": 0},
+					{"particulars": "IR", "allow_blank": 1},
+				],
+			},
+			{
+				"doctype": "Lab Test Template",
+				"lab_test_name": "_Test Lab Test - Sensitivity",
+				"lab_test_template_type": "Descriptive",
+				"lab_test_description": "Insulin Resistance",
+				"lab_test_code": "_Test Lab Test - Sensitivity",
+				"lab_test_group": "Services",
+				"department": "_Test Medical Department",
+				"is_billable": 1,
+				"lab_test_rate": 2000,
+				"sensitivity": 1,
+				"descriptive_test_templates": [
+					{"particulars": "FBS", "allow_blank": 1},
+					{"particulars": "Insulin", "allow_blank": 0},
+					{"particulars": "IR", "allow_blank": 1},
+				],
+			},
+		]
+		self.make_records(["lab_test_name", "lab_test_code"], records)
+
+	def make_lab_test_samples(self):
+		records = [
+			{
+				"doctype": "Lab Test Sample",
+				"sample": "_Test Sample - Blood Sample",
+				"sample_uom": "U/ml",
+			},
+			{
+				"doctype": "Lab Test Sample",
+				"sample": "_Test Sample - Urine",
+				"sample_uom": "U/ml",
+			},
+		]
+		self.make_records(["sample"], records)
+
+	def make_clinical_procedure_templates(self):
+		records = [
+			{
+				"doctype": "Clinical Procedure Template",
+				"template": "_Test Procedure - Knee Surgery and Rehab",
+				"item_code": "_Test Procedure - Knee Surgery and Rehab",
+				"item_group": "Services",
+				"description": "Knee Surgery and Rehab",
+				"is_billable": 1,
+				"rate": 50000,
+			},
+			{
+				"doctype": "Clinical Procedure Template",
+				"template": "_Test Procedure - Wound Inspection and Cleaning",
+				"item_code": "_Test Procedure - Wound Inspection and Cleaning",
+				"item_group": "Services",
+				"description": "Wound Inspection and Cleaning",
+				"is_billable": 1,
+				"rate": 1000,
+			},
+		]
+		self.make_records(["template", "item_code"], records)
+
+	def make_appointment_types(self):
+		records = [
+			{
+				"doctype": "Appointment Type",
+				"appointment_type": "_Test Appointment Type",
+				"allow_booking_for": "Practitioner",
+				"medical_department": "_Test Medical Department",
+				"default_duration": 20,
+			},
+			{
+				"doctype": "Appointment Type",
+				"appointment_type": "_Test Appointment Type for Department",
+				"allow_booking_for": "Department",
+				"medical_department": "_Test Medical Department",
+				"default_duration": 20,
+			},
+			{
+				"doctype": "Appointment Type",
+				"appointment_type": "_Test Appointment Type with Items",
+				"allow_booking_for": "Practitioner",
+				"medical_department": "_Test Medical Department",
+				"default_duration": 20,
+				"items": [
+					{
+						"dt": "Medical Department",
+						"dn": "_Test Medical Department",
+						"op_consulting_charge_item": "HLC-SI-001",
+						"op_consulting_charge": 200,
+						"inpatient_visit_charge_item": "HLC-SI-002",
+						"ip_consulting_charge": 200,
+					},
+				],
+			},
+			{
+				"doctype": "Appointment Type",
+				"appointment_type": "_Test Appointment Type with Items for Department",
+				"allow_booking_for": "Department",
+				"default_duration": 20,
+				"items": [
+					{
+						"dt": "Medical Department",
+						"dn": "_Test Medical Department",
+						"op_consulting_charge_item": "HLC-SI-001",
+						"op_consulting_charge": 1000,
+						"inpatient_visit_charge_item": "HLC-SI-002",
+						"ip_consulting_charge": 1000,
+					},
+				],
+			},
+			{
+				"doctype": "Appointment Type",
+				"appointment_type": "_Test Appointment Type with Items for Service Unit",
+				"allow_booking_for": "Service Unit",
+				"default_duration": 20,
+				"items": [
+					{
+						"dt": "Healthcare Service Unit",
+						"dn": "_Test HSU - Appointments - _TC",
+						"op_consulting_charge_item": "HLC-SI-001",
+						"op_consulting_charge": 1000,
+						"inpatient_visit_charge_item": "HLC-SI-002",
+						"ip_consulting_charge": 1000,
+					},
+				],
+			},
+		]
+		self.make_records(["appointment_type"], records)
+
+	def make_service_units(self):
+		records = [
+			{
+				"doctype": "Healthcare Service Unit",
+				"healthcare_service_unit_name": "_Test HSU - Appointments",
+				"service_unit_type": "_Test Service Unit Type - Appointments",
+				"company": "_Test Company",
+				"allow_appointments": 1,
+				"overlap_appointments": 0,
+			},
+			{
+				"doctype": "Healthcare Service Unit",
+				"healthcare_service_unit_name": "_Test HSU - Overlapping Appointments",
+				"service_unit_type": "_Test Service Unit Type - Overlapping Appointments",
+				"company": "_Test Company",
+				"allow_appointments": 1,
+				"overlap_appointments": 1,
+				"service_unit_capacity": 10,
+			},
+			{
+				"doctype": "Healthcare Service Unit",
+				"healthcare_service_unit_name": "_Test HSU - Occupancy",
+				"service_unit_type": "_Test Service Unit Type - Occupancy",
+				"company": "_Test Company",
+				"inpatient_occupancy": 1,
+				"occupancy_status": "Vacant",
+			},
+			{
+				"doctype": "Healthcare Service Unit",
+				"healthcare_service_unit_name": "_Test HSU - OT",
+				"service_unit_type": "_Test Service Unit Type - Non-billable Occupancy",
+				"company": "_Test Company",
+				"inpatient_occupancy": 1,
+				"occupancy_status": "Vacant",
+			},
+		]
+		self.make_records(["healthcare_service_unit_name"], records)
+
+	def make_service_unit_types(self):
+		records = [
+			{
+				"doctype": "Healthcare Service Unit Type",
+				"service_unit_type": "_Test Service Unit Type - Appointments",
+				"allow_appointments": 1,
+				"overlap_appointments": 0,
+			},
+			{
+				"doctype": "Healthcare Service Unit Type",
+				"service_unit_type": "_Test Service Unit Type - Overlapping Appointments",
+				"allow_appointments": 1,
+				"overlap_appointments": 1,
+			},
+			{
+				"doctype": "Healthcare Service Unit Type",
+				"service_unit_type": "_Test Service Unit Type - Non-billable Occupancy",
+				"inpatient_occupancy": 1,
+				"is_billable": 0,
+				"item_code": "_Test Service Unit Type - Occupancy",
+				"item_group": "Services",
+				"uom": "Day",
+				"no_of_hours": 24,
+				"unit_type.rate": 0,
+			},
+			{
+				"doctype": "Healthcare Service Unit Type",
+				"service_unit_type": "_Test Service Unit Type - Occupancy",
+				"inpatient_occupancy": 1,
+				"is_billable": 1,
+				"item_code": "_Test Service Unit Type - Occupancy",
+				"item_group": "Services",
+				"uom": "Day",
+				"no_of_hours": 24,
+				"unit_type.rate": 4000,
+			},
+			{
+				"doctype": "Healthcare Service Unit Type",
+				"service_unit_type": "_Test Inpatient Rooms",
+				"inpatient_occupancy": 1,
+				"is_billable": 1,
+				"item_code": "_Test Inpatient Rooms",
+				"item_group": "Services",
+				"uom": "Hour",
+				"no_of_hours": 1,
+				"unit_type.rate": 4000,
+			},
+		]
+		self.make_records(["service_unit_type"], records)
+
+	def make_users(self):
+		records = [
+			{
+				"doctype": "User",
+				"email": "test_user@marleyhealth.io",
+				"first_name": "test_user",
+				"password": "password",
+			},
+			{
+				"doctype": "User",
+				"email": "test_user_0@marleyhealth.io",
+				"first_name": "test_user_0",
+				"password": "password",
+			},
+			{
+				"doctype": "User",
+				"email": "gp@marleyhealth.io",
+				"first_name": "gp",
+				"password": "password",
+				"roles": [{"doctype": "Has Role", "role": "Physician"}],
+			},
+		]
+		self.make_records(["email"], records)
+
+	def make_patients(self):
+		records = [
+			{
+				"doctype": "Patient",
+				"first_name": "_Test Patient",
+				"sex": "Female",
+				"customer_group": "Individual",
+			},
+			{
+				"doctype": "Patient",
+				"first_name": "_Test Patient 0",
+				"sex": "Male",
+				"customer_group": "Individual",
+			},
+			{
+				"doctype": "Patient",
+				"first_name": "_Test Patient 1",
+				"sex": "Male",
+				"customer_group": "Individual",
+			},
+			{
+				"doctype": "Patient",
+				"first_name": "_Test IPD Patient",
+				"sex": "Female",
+				"customer_group": "Individual",
+			},
+			{
+				"doctype": "Patient",
+				"first_name": "_Test Patient 2",
+				"sex": "Female",
+				"customer_group": "Individual",
+			},
+			{
+				"doctype": "Patient",
+				"first_name": "_Test Patient 3",
+				"sex": "Female",
+				"customer_group": "Individual",
+			},
+		]
+		self.make_records(["first_name"], records)
+
+	def make_practitioners(self):
+		# TODO: fix practitioner naming
+		records = [
+			{
+				"doctype": "Healthcare Practitioner",
+				"first_name": "_Test",
+				"last_name": "Healthcare Practitioner 0",
+				"gender": "Female",
+				"department": "_Test Medical Department",
+				"op_consulting_charge_item": "HLC-SI-001",
+				"op_consulting_charge": 500,
+				"inpatient_visit_charge_item": "HLC-SI-002",
+				"inpatient_visit_charge": 500,
+			},
+			{
+				"doctype": "Healthcare Practitioner",
+				"first_name": "_Test",
+				"last_name": "Healthcare Practitioner 1",
+				"gender": "Male",
+				"department": "_Test Medical Department 0",
+				"op_consulting_charge_item": "HLC-SI-001",
+				"op_consulting_charge": 500,
+				"inpatient_visit_charge_item": "HLC-SI-002",
+				"inpatient_visit_charge": 500,
+			},
+			{
+				"doctype": "Healthcare Practitioner",
+				"first_name": "_Test",
+				"last_name": "Healthcare Practitioner 2",
+				"gender": "Male",
+				"department": "Cardiology",
+				"op_consulting_charge_item": "HLC-SI-001",
+				"op_consulting_charge": 300,
+				"inpatient_visit_charge_item": "HLC-SI-002",
+				"inpatient_visit_charge": 300,
+			},
+		]
+		self.make_records(["last_name", "department"], records)
+
+	def make_medical_departments(self):
+		records = [
+			{
+				"doctype": "Medical Department",
+				"department": "_Test Medical Department",
+			},
+			{
+				"doctype": "Medical Department",
+				"department": "_Test Medical Department 0",
+			},
+			{
+				"doctype": "Medical Department",
+				"department": "_Test Medical Department 1",
+			},
+			{
+				"doctype": "Medical Department",
+				"department": "Cardiology",
+			},
+		]
+		self.make_records(["department"], records)
+
+	def make_diagnoses(self):
+		records = [
+			{
+				"doctype": "Diagnosis",
+				"diagnosis": "Fever",
+			},
+			{
+				"doctype": "Diagnosis",
+				"diagnosis": "Heart Attack",
+			},
+		]
+		self.make_records(["diagnosis"], records)
+
+	def make_stock_items(self):
+		records = [
+			{
+				"doctype": "Item",
+				"item_code": "Dextromethorphan",
+				"item_name": "Dextromethorphan",
+				"item_group": "Products",
+				"stock_uom": "Nos",
+				"is_stock_item": 1,
+				"valuation_rate": 50,
+				"opening_stock": 20,
+			},
+			{
+				"doctype": "Item",
+				"item_code": "_Test_Stock_Item",
+				"item_name": "_Test_Stock_Item",
+				"item_group": "Services",
+				"is_stock_item": 1,
+				"stock_uom": "Nos",
+				"valuation_rate": 50,
+				"opening_stock": 20,
+			},
+		]
+		self.make_records(["item_code"], records)
+
+	def make_service_items(self):
+		records = [
+			{
+				"doctype": "Item",
+				"item_code": "HLC-SI-001",
+				"item_name": "OP Consulting Charges",
+				"item_group": "Services",
+				"is_stock_item": 0,
+				"stock_uom": "Nos",
+			},
+			{
+				"doctype": "Item",
+				"item_code": "HLC-SI-002",
+				"item_name": "IP Consulting Charges",
+				"item_group": "Services",
+				"is_stock_item": 0,
+				"stock_uom": "Nos",
+			},
+			{
+				"doctype": "Item",
+				"item_code": "_Test_Service_Item",
+				"item_name": "_Test_Service_Item",
+				"item_group": "Services",
+				"is_stock_item": 0,
+				"stock_uom": "Nos",
+			},
+			{
+				"doctype": "Item",
+				"item_code": "_Test Registration",
+				"item_name": "_Test Registration",
+				"item_group": "Services",
+				"is_stock_item": 0,
+				"stock_uom": "Nos",
+			},
+		]
+		self.make_records(["item_code"], records)
+
+	def make_company(self):
+		records = [
+			{
+				"abbr": "_TC",
+				"company_name": "_Test Company",
+				"country": "India",
+				"default_currency": "INR",
+				"doctype": "Company",
+				"chart_of_accounts": "Standard",
+			},
+		]
+		self.make_records(["company_name"], records)
+
+	def make_records(self, key, records):
+		doctype = records[0].get("doctype")
+
+		def get_filters(record):
+			filters = {}
+			for x in key:
+				filters[x] = record.get(x)
+			return filters
+
+		for x in records:
+			filters = get_filters(x)
+			if not frappe.db.exists(doctype, filters):
+				frappe.get_doc(x).insert()
+
+		frappe.db.commit()
+
+
+BootStrapTestData()
+
+
+class HealthcareTestSuite(ERPNextTestSuite):
+	"""Class for creating Healthcare test records"""
+
+	pass


### PR DESCRIPTION
Port insurance billing, claims, dashboard filtering, and test-suite parity updates while preserving Biograph-specific validation behavior.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR ports insurance billing, claims processing, and dashboard filtering changes from the Marley codebase while preserving Biograph-specific validation behaviour. The test suite is consolidated onto a new shared `HealthcareTestSuite` / `BootStrapTestData` base, and the raw-SQL coverage query in `InsuranceClaim` is migrated to the QueryBuilder.

- `utils.py` gains `get_valid_insurance_coverage_details` and `get_insurance_invoice_line` helpers that plumb insurance coverage data into all six invoice-source functions, plus `post_transfer_journal_entry_and_update_coverage` / `update_insurance_coverage` to create balancing journal entries on submit/cancel.
- `insurance_claim.py` replaces the raw SQL coverage fetch with an equivalent `frappe.qb` query; `patient_insurance_coverage.py` adds `currency` to the price-list rate call; the JS form adds `only_select` to the `template_dt` link field.
- All test files switch from `IntegrationTestCase` to the new `HealthcareTestSuite` with updated expected amounts (320 → 192) reflecting the revised coverage calculation.

<h3>Confidence Score: 2/5</h3>

Not safe to merge: the duplicate `if` block in `post_transfer_journal_entry_and_update_coverage` is a Python SyntaxError that prevents `utils.py` from loading, breaking every Sales Invoice submit and cancel in the application.

The duplicate `if` block introduced in `post_transfer_journal_entry_and_update_coverage` (lines 799–803 have no body) causes an `IndentationError` at import time. Because `utils.py` is imported by the invoice submit/cancel hook, this crash affects every insured and non-insured invoice submission. A second issue — missing guard before appending a zero-qty insurance line in `get_service_requests_to_invoice` — would produce malformed invoice items for partially-billed service requests.

healthcare/healthcare/utils.py requires immediate attention for both the SyntaxError in `post_transfer_journal_entry_and_update_coverage` and the missing billable-qty guard in `get_service_requests_to_invoice`.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| healthcare/healthcare/utils.py | Core invoicing hook; introduces a duplicate `if` block (Python SyntaxError) in `post_transfer_journal_entry_and_update_coverage` that prevents the module from loading, plus a missing guard for zero/negative `billable_order_qty` in the insurance coverage path of `get_service_requests_to_invoice`. |
| healthcare/healthcare/doctype/insurance_claim/insurance_claim.py | Raw SQL coverage query migrated to QueryBuilder (frappe.qb); logic is equivalent to the removed SQL, ordering and filters correctly preserved. |
| healthcare/healthcare/doctype/patient_insurance_coverage/patient_insurance_coverage.py | Adds `currency` to `get_item_price_list_rate` args so the price API resolves the correct currency; straightforward targeted fix. |
| healthcare/healthcare/dashboard_chart_source/insurance_claim_status/insurance_claim_status.py | Adds optional company filter to the insurance claim status dashboard query; safe and minimal change. |
| healthcare/tests/utils.py | New shared test-data bootstrap module; `BootStrapTestData()` is instantiated unconditionally at module level (already flagged in a previous review thread), otherwise the fixture data definitions look complete. |
| healthcare/healthcare/doctype/insurance_claim/test_insurance_claim.py | Test rewritten to use the new shared `HealthcareTestSuite`; updated claim amount assertions (320→192) to match revised coverage calculations; removes the now-centralised `create_insurance_payor` helper. |
| healthcare/healthcare/doctype/patient_insurance_coverage/test_patient_insurance_coverage.py | Migrated to `HealthcareTestSuite`; removed `create_insurance_test_docs` helper; one cleanup SQL line is commented out which may cause residual state between runs. |
| healthcare/healthcare/doctype/item_insurance_eligibility/item_insurance_eligibility.js | Sets `template_dt` field to `only_select` mode to prevent free-text entry; small UX hardening. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant SI as Sales Invoice
    participant MISC as manage_invoice_submit_cancel
    participant PIC as Patient Insurance Coverage
    participant JE as Journal Entry

    SI->>MISC: on_submit
    MISC->>MISC: set_invoiced(item)
    MISC->>MISC: manage_fee_validity(appointment) [if Patient Appointment]
    MISC->>MISC: post_transfer_journal_entry_and_update_coverage(doc)
    loop each insured item
        MISC->>MISC: get_insurance_payor_details()
        MISC->>JE: submit (debit insurer receivable, credit patient AR)
        MISC->>PIC: update_invoice_details(+qty, +amount)
    end
    MISC->>SI: doc.reload()

    SI->>MISC: on_cancel
    MISC->>MISC: set_invoiced(item)
    MISC->>MISC: update_insurance_coverage(doc)
    loop each insured item
        MISC->>PIC: update_invoice_details(-qty, -amount)
    end
```

<sub>Reviews (2): Last reviewed commit: ["Update healthcare/healthcare/utils.py"](https://github.com/tacten/biograph/commit/a3d885e109351c847a7da4d24c9a33138fc67df0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37414916)</sub>

<!-- /greptile_comment -->