### PR TITLE
fix: correct make_insurance_coverage args on Patient Appointment

### DIFF
--- a/healthcare/healthcare/doctype/patient_appointment/patient_appointment.py
+++ b/healthcare/healthcare/doctype/patient_appointment/patient_appointment.py
@@ -135,16 +135,24 @@ class PatientAppointment(Document):
 		if not billing_detail.get("service_item"):
 			return
 
-		make_insurance_coverage(
+		coverage = make_insurance_coverage(
 			patient=self.patient,
+			policy=self.insurance_policy,
 			company=self.company,
-			insurance_policy=self.insurance_policy,
-			billing_item=billing_detail.get("service_item"),
+			template_dt="Appointment Type",
+			template_dn=self.appointment_type,
+			item_code=billing_detail.get("service_item"),
 			qty=1,
 			rate=billing_detail.get("practitioner_charge"),
-			reference_dt="Patient Appointment",
-			reference_dn=self.name,
 		)
+
+		if coverage and coverage.get("coverage"):
+			self.db_set(
+				{
+					"insurance_coverage": coverage.get("coverage"),
+					"coverage_status": coverage.get("coverage_status"),
+				}
+			)
 
 	def validate_practitioner_unavailability(self):
 		"""Validate that the appointment doesn't conflict with practitioner unavailability."""


### PR DESCRIPTION
## Summary

- Fixes `TypeError: make_insurance_coverage() got an unexpected keyword argument 'insurance_policy'` when saving a Patient Appointment with an insurance policy selected.
- Aligns `PatientAppointment.make_insurance_coverage()` with the shared helper signature (`policy`, `template_dt`, `template_dn`, `item_code`).
- Persists `insurance_coverage` and `coverage_status` on the appointment after coverage is created.

## Test plan

- [ ] Create a Patient Appointment with a valid Insurance Policy and save — no TypeError
- [ ] Confirm `insurance_coverage` and `coverage_status` are set on the appointment
- [ ] Run `bench --site <site> run-tests --module healthcare.healthcare.doctype.patient_insurance_coverage.test_patient_insurance_coverage`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR corrects the call to `make_insurance_coverage()` in `PatientAppointment.make_insurance_coverage()`, replacing invalid kwargs (`insurance_policy`, `billing_item`, `reference_dt`, `reference_dn`) with the actual function signature (`policy`, `template_dt`, `template_dn`, `item_code`). It also captures the return value and persists it on the appointment.

- The kwarg alignment is correct and resolves the `TypeError` described in the PR.
- The new `db_set` call writes `coverage_status` to the appointment, but `coverage_status` is not a field in the Patient Appointment DocType — only `insurance_coverage` is — so the save will still raise a database error at that point.

<h3>Confidence Score: 3/5</h3>

The kwarg fix is correct, but the db_set call writes a field that does not exist in the DocType, so saving an appointment with an insurance policy will still fail at runtime.

The original TypeError is resolved, but the new db_set call introduces an equally breaking runtime error: coverage_status has no column in tabPatient Appointment. A round-trip test (create appointment, select insurance policy, save) will still crash at the persist step.

healthcare/healthcare/doctype/patient_appointment/patient_appointment.py — the db_set call and, if coverage_status is truly needed, the corresponding patient_appointment.json DocType definition.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| healthcare/healthcare/doctype/patient_appointment/patient_appointment.py | Fixes wrong kwargs passed to make_insurance_coverage() and persists the result, but db_set tries to write coverage_status which has no corresponding column in the Patient Appointment DocType, replacing one runtime error with another. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant PA as PatientAppointment.after_insert
    participant MIC as make_insurance_coverage()
    participant COV as PatientInsuranceCoverage.insert()
    participant DB as Database (tabPatient Appointment)

    PA->>PA: get_appointment_billing_item_and_rate()
    PA->>MIC: policy, company, template_dt, template_dn, item_code, qty, rate
    MIC->>COV: "coverage.insert(ignore_permissions=True)"
    COV-->>MIC: "returns {coverage: name, coverage_status: status}"
    MIC-->>PA: "{coverage, coverage_status}"
    PA->>DB: "db_set({insurance_coverage: ..., coverage_status: ...})"
    Note over DB: coverage_status column does not exist in tabPatient Appointment → DB error
```

<sub>Reviews (1): Last reviewed commit: ["fix: correct make\_insurance\_coverage arg..."](https://github.com/tacten/biograph/commit/564633b20240fb3ddb65d0048dc1f5337dcc434d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37604160)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->