### PR TITLE
fix: port insurance coverage integration for appointments and inpatient

### DIFF
--- a/healthcare/healthcare/doctype/inpatient_occupancy/inpatient_occupancy.json
+++ b/healthcare/healthcare/doctype/inpatient_occupancy/inpatient_occupancy.json
@@ -9,7 +9,9 @@
   "check_in",
   "left",
   "check_out",
-  "invoiced"
+  "invoiced",
+  "insurance_coverage",
+  "coverage_status"
  ],
  "fields": [
   {
@@ -44,6 +46,20 @@
    "fieldname": "invoiced",
    "fieldtype": "Check",
    "label": "Invoiced",
+   "read_only": 1
+  },
+  {
+   "fieldname": "insurance_coverage",
+   "fieldtype": "Link",
+   "label": "Insurance Coverage",
+   "options": "Patient Insurance Coverage",
+   "read_only": 1
+  },
+  {
+   "fieldname": "coverage_status",
+   "fieldtype": "Select",
+   "label": "Coverage Status",
+   "options": "\nPending\nApproved\nRejected\nInvoiced",
    "read_only": 1
   }
  ],

--- a/healthcare/healthcare/doctype/inpatient_record/inpatient_record.js
+++ b/healthcare/healthcare/doctype/inpatient_record/inpatient_record.js
@@ -28,6 +28,16 @@ frappe.ui.form.on('Inpatient Record', {
 				}
 			};
 		});
+
+		frm.set_query('insurance_policy', function() {
+			return {
+				filters: {
+					patient: frm.doc.patient,
+					docstatus: 1,
+				},
+			};
+		});
+
 		if (!frm.doc.__islocal) {
 			if (frm.doc.status == 'Admitted') {
 				frm.add_custom_button(__('Schedule Discharge'), function() {
@@ -44,6 +54,11 @@ frappe.ui.form.on('Inpatient Record', {
 				frm.add_custom_button(__('Discharge'), function() {
 					discharge_patient(frm);
 				} );
+				if (frm.doc.insurance_policy) {
+					frm.add_custom_button(__('Create Insurance Coverage'), function() {
+						create_insurance_coverage(frm);
+					});
+				}
 			}
 		}
 
@@ -325,4 +340,16 @@ let cancel_ip_order = function(frm) {
 			}
 		});
 	}, __('Reason for Cancellation'), __('Submit'));
-}
+};
+
+let create_insurance_coverage = function(frm) {
+	frappe.call({
+		doc: frm.doc,
+		method: 'create_insurance_coverage',
+		freeze: true,
+		freeze_message: __('Creating Insurance Coverage'),
+		callback: function() {
+			frm.reload_doc();
+		},
+	});
+};

--- a/healthcare/healthcare/doctype/inpatient_record/inpatient_record.json
+++ b/healthcare/healthcare/doctype/inpatient_record/inpatient_record.json
@@ -22,6 +22,12 @@
   "scheduled_date",
   "admitted_datetime",
   "expected_discharge",
+  "insurance_section",
+  "insurance_policy",
+  "insurance_coverage",
+  "column_break_insurance",
+  "insurance_payor",
+  "approval_status",
   "references",
   "admission_encounter",
   "admission_practitioner",
@@ -205,6 +211,45 @@
    "fieldtype": "Date",
    "in_list_view": 1,
    "label": "Expected Discharge",
+   "read_only": 1
+  },
+  {
+   "fieldname": "insurance_section",
+   "fieldtype": "Section Break",
+   "label": "Insurance"
+  },
+  {
+   "fieldname": "insurance_policy",
+   "fieldtype": "Link",
+   "label": "Insurance Policy",
+   "options": "Patient Insurance Policy"
+  },
+  {
+   "fieldname": "insurance_coverage",
+   "fieldtype": "Link",
+   "label": "Insurance Coverage",
+   "options": "Patient Insurance Coverage",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_insurance",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fetch_from": "insurance_policy.insurance_payor",
+   "fieldname": "insurance_payor",
+   "fieldtype": "Link",
+   "label": "Insurance Payor",
+   "options": "Insurance Payor",
+   "read_only": 1
+  },
+  {
+   "fetch_from": "insurance_coverage.approval_status",
+   "fetch_if_empty": 1,
+   "fieldname": "approval_status",
+   "fieldtype": "Select",
+   "label": "Claim Status",
+   "options": "\nPending\nApproved\nRejected\nInvoiced",
    "read_only": 1
   },
   {

--- a/healthcare/healthcare/doctype/inpatient_record/inpatient_record.py
+++ b/healthcare/healthcare/doctype/inpatient_record/inpatient_record.py
@@ -4,15 +4,31 @@
 
 
 import json
+from math import floor
 
 import frappe
 from frappe import _
 from frappe.desk.reportview import get_match_cond
 from frappe.model.document import Document
-from frappe.utils import get_datetime, get_link_to_form, getdate, now_datetime, today
+from frappe.utils import (
+	flt,
+	get_datetime,
+	get_link_to_form,
+	getdate,
+	now_datetime,
+	rounded,
+	time_diff_in_hours,
+	today,
+)
 
 from healthcare.healthcare.doctype.nursing_task.nursing_task import NursingTask
-from healthcare.healthcare.utils import validate_nursing_tasks
+from healthcare.healthcare.doctype.patient_insurance_coverage.patient_insurance_coverage import (
+	make_insurance_coverage,
+)
+from healthcare.healthcare.utils import (
+	get_appointment_billing_item_and_rate,
+	validate_nursing_tasks,
+)
 
 
 class InpatientRecord(Document):
@@ -107,6 +123,55 @@ class InpatientRecord(Document):
 		if service_unit:
 			transfer_patient(self, service_unit, check_in)
 
+	@frappe.whitelist()
+	def create_insurance_coverage(self):
+		if self.insurance_policy and self.inpatient_occupancies:
+			if any(not data_row.insurance_coverage for data_row in self.inpatient_occupancies):
+				for inpatient_occupancy in self.inpatient_occupancies:
+					if inpatient_occupancy.left and not inpatient_occupancy.insurance_coverage:
+						service_unit_type = frappe.db.get_value(
+							"Healthcare Service Unit", inpatient_occupancy.service_unit, "service_unit_type"
+						)
+						service_unit_type = frappe.get_doc("Healthcare Service Unit Type", service_unit_type)
+						hours_occupied = flt(
+							time_diff_in_hours(inpatient_occupancy.check_out, inpatient_occupancy.check_in), 2
+						)
+						qty = 0.5
+						if hours_occupied > 0 and service_unit_type.no_of_hours:
+							actual_qty = hours_occupied / service_unit_type.no_of_hours
+							floored_qty = floor(actual_qty)
+							decimal_part = actual_qty - floored_qty
+							if decimal_part > 0.5:
+								qty = rounded(floored_qty + 1, 1)
+							elif decimal_part < 0.5 and decimal_part > 0:
+								qty = rounded(floored_qty + 0.5, 1)
+							if qty <= 0:
+								qty = 0.5
+						coverage = self.make_insurance_coverage(service_unit_type.name, qty)
+						if coverage and coverage.get("coverage"):
+							frappe.db.set_value(
+								"Inpatient Occupancy",
+								inpatient_occupancy.name,
+								{
+									"insurance_coverage": coverage.get("coverage"),
+									"coverage_status": coverage.get("coverage_status"),
+								},
+							)
+			else:
+				frappe.throw(_("Claim already created for all Inpatient Occupancies"))
+
+	def make_insurance_coverage(self, service_unit_type, qty):
+		billing_detail = get_appointment_billing_item_and_rate(self)
+		return make_insurance_coverage(
+			patient=self.patient,
+			policy=self.insurance_policy,
+			company=self.company,
+			template_dt="Healthcare Service Unit Type",
+			template_dn=service_unit_type,
+			item_code=billing_detail.get("service_item"),
+			qty=qty,
+		)
+
 
 @frappe.whitelist()
 def schedule_inpatient(args):
@@ -158,6 +223,7 @@ def schedule_inpatient(args):
 		inpatient_record.therapy_plan = encounter.therapy_plan
 		set_ip_child_records(inpatient_record, "therapies", encounter.therapies)
 
+	inpatient_record.insurance_policy = encounter.insurance_policy
 	inpatient_record.status = "Admission Scheduled"
 	inpatient_record.save(ignore_permissions=True)
 

--- a/healthcare/healthcare/doctype/patient_appointment/patient_appointment.js
+++ b/healthcare/healthcare/doctype/patient_appointment/patient_appointment.js
@@ -63,6 +63,15 @@ frappe.ui.form.on('Patient Appointment', {
 			};
 		});
 
+		frm.set_query('insurance_policy', function() {
+			return {
+				filters: {
+					patient: frm.doc.patient,
+					docstatus: 1,
+				},
+			};
+		});
+
 		frm.trigger('set_therapy_type_filter');
 
 		if (frm.is_new()) {

--- a/healthcare/healthcare/doctype/patient_appointment/patient_appointment.json
+++ b/healthcare/healthcare/doctype/patient_appointment/patient_appointment.json
@@ -43,6 +43,12 @@
   "add_video_conferencing",
   "event",
   "google_meet_link",
+  "insurance_section",
+  "insurance_policy",
+  "insurance_payor",
+  "column_break_insurance",
+  "insurance_coverage",
+  "coverage_status",
   "section_break_16",
   "mode_of_payment",
   "billing_item",
@@ -205,6 +211,46 @@
    "fieldname": "section_break_16",
    "fieldtype": "Section Break",
    "label": "Payments"
+  },
+  {
+   "depends_on": "patient",
+   "fieldname": "insurance_section",
+   "fieldtype": "Section Break",
+   "label": "Insurance"
+  },
+  {
+   "fieldname": "insurance_policy",
+   "fieldtype": "Link",
+   "label": "Insurance Policy",
+   "options": "Patient Insurance Policy",
+   "read_only_depends_on": "eval:doc.insurance_coverage"
+  },
+  {
+   "fetch_from": "insurance_policy.insurance_payor",
+   "fieldname": "insurance_payor",
+   "fieldtype": "Link",
+   "label": "Insurance Payor",
+   "options": "Insurance Payor",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_insurance",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "insurance_coverage",
+   "fieldtype": "Link",
+   "label": "Insurance Coverage",
+   "options": "Patient Insurance Coverage",
+   "read_only": 1
+  },
+  {
+   "fetch_from": "insurance_coverage.status",
+   "fetch_if_empty": 1,
+   "fieldname": "coverage_status",
+   "fieldtype": "Data",
+   "label": "Coverage Status",
+   "read_only": 1
   },
   {
    "fetch_from": "patient.patient_name",

--- a/healthcare/healthcare/doctype/patient_appointment/patient_appointment.py
+++ b/healthcare/healthcare/doctype/patient_appointment/patient_appointment.py
@@ -24,6 +24,9 @@ from healthcare.healthcare.doctype.healthcare_settings.healthcare_settings impor
 	get_income_account,
 	get_receivable_account,
 )
+from healthcare.healthcare.doctype.patient_insurance_coverage.patient_insurance_coverage import (
+	make_insurance_coverage,
+)
 from healthcare.healthcare.utils import get_appointment_billing_item_and_rate
 
 
@@ -54,15 +57,55 @@ class PatientAppointment(Document):
 		):
 			update_fee_validity(self)
 
+		doc_before_save = self.get_doc_before_save()
+		if doc_before_save and not doc_before_save.insurance_policy == self.insurance_policy:
+			self.make_insurance_coverage()
+
 	def after_insert(self):
 		self.update_prescription_details()
 		self.set_payment_details()
 		send_confirmation_msg(self)
 		self.insert_calendar_event()
 
+		if self.insurance_policy and self.appointment_type and not check_fee_validity(self):
+			if frappe.db.get_single_value("Healthcare Settings", "show_payment_popup"):
+				frappe.msgprint(
+					_(
+						"Insurance Coverage not created!<br>Not supported as <b>Automate Appointment Invoicing</b> enabled"
+					),
+					alert=True,
+					indicator="warning",
+				)
+			else:
+				self.make_insurance_coverage()
+
 		if self.service_request:
 			frappe.db.set_value(
 				"Service Request", self.service_request, "status", "completed-Request Status"
+			)
+
+	def make_insurance_coverage(self):
+		billing_detail = get_appointment_billing_item_and_rate(self)
+		if not billing_detail.get("service_item"):
+			return
+
+		coverage = make_insurance_coverage(
+			patient=self.patient,
+			policy=self.insurance_policy,
+			company=self.company,
+			template_dt="Appointment Type",
+			template_dn=self.appointment_type,
+			item_code=billing_detail.get("service_item"),
+			qty=1,
+			rate=billing_detail.get("practitioner_charge"),
+		)
+
+		if coverage and coverage.get("coverage"):
+			self.db_set(
+				{
+					"insurance_coverage": coverage.get("coverage"),
+					"coverage_status": coverage.get("coverage_status"),
+				}
 			)
 
 	def set_title(self):


### PR DESCRIPTION
## Summary

- Ports missing Patient Appointment insurance integration: coverage creation on insert/update, DocType fields, and client-side policy filter.
- Ports Inpatient Record insurance integration: coverage creation for completed occupancies, insurance fields on IP record and occupancy child table, and **Create Insurance Coverage** button on Discharge Scheduled.
- Uses the correct `make_insurance_coverage()` API throughout (`policy`, `template_dt`, `template_dn`, `item_code`).

## Test plan

- [ ] Patient Appointment: save with insurance policy → coverage created, no errors
- [ ] Inpatient Record: admit, transfer, schedule discharge → **Create Insurance Coverage** → occupancy rows populated
- [ ] Run `bench --site <site> run-tests --module healthcare.healthcare.doctype.patient_insurance_coverage.test_patient_insurance_coverage`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR ports insurance coverage integration to Patient Appointment and Inpatient Record, adding policy fields and DocType definitions, coverage auto-creation on appointment insert/update, and a "Create Insurance Coverage" button on the discharge flow. The JS changes are clean, but several logic bugs in the Python and JSON layers need fixing before the feature behaves correctly.

- **Patient Appointment** (`patient_appointment.py`): coverage creation is triggered on policy _clear_ (empty policy) causing an `AttributeError`, and the `on_update` path skips the `show_payment_popup` guard that `after_insert` correctly enforces.
- **Inpatient Record** (`inpatient_record.py`): the occupancy-billing qty calculation silently drops to `0.5` for stays that are an exact multiple of `no_of_hours`, and `get_appointment_billing_item_and_rate(self)` resolves `is_inpatient=None` for an `InpatientRecord`, causing the outpatient billing item to be fetched.
- **Inpatient Record JSON** (`inpatient_record.json`): the `approval_status` field fetches from `insurance_coverage.approval_status`, but `Patient Insurance Coverage` only has a `status` field, so the \"Claim Status\" column will always be blank.

<h3>Confidence Score: 2/5</h3>

Not safe to merge as-is: clearing the insurance policy on a saved appointment will crash the save, inpatient occupancy billing quantities are wrong for whole-unit stays, and the Claim Status field on Inpatient Record will always show blank.

Multiple independent defects affect the core paths this PR introduces. Clearing an insurance policy crashes on_update with an unhandled AttributeError. The occupancy qty calculation silently uses the wrong quantity for exact-integer stays. The fetch_from target for approval_status points to a non-existent field. And get_appointment_billing_item_and_rate treats every InpatientRecord as an outpatient case. Together these would cause visible failures in normal use.

inpatient_record.py and patient_appointment.py have the most issues and should be reviewed carefully; inpatient_record.json needs a one-line fix to the fetch_from value.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| healthcare/healthcare/doctype/patient_appointment/patient_appointment.py | Adds insurance coverage creation on insert and policy-change update. Two bugs: on_update crashes when policy is cleared (no empty-policy guard), and it skips the show_payment_popup check present in after_insert. |
| healthcare/healthcare/doctype/inpatient_record/inpatient_record.py | Adds create_insurance_coverage whitelisted method and qty calculation for occupancy billing. Two bugs: qty calculation drops to 0.5 for exact-integer unit stays, and get_appointment_billing_item_and_rate is called with self (InpatientRecord), which always resolves is_inpatient=None and fetches the OPD item instead of IPD. |
| healthcare/healthcare/doctype/inpatient_record/inpatient_record.json | Adds insurance section fields. approval_status field uses fetch_from: insurance_coverage.approval_status but the linked doctype only has a status field, so Claim Status will always be blank. |
| healthcare/healthcare/doctype/inpatient_record/inpatient_record.js | Adds insurance policy filter query and Create Insurance Coverage custom button on Discharge Scheduled status. Logic is straightforward and correct. |
| healthcare/healthcare/doctype/patient_appointment/patient_appointment.js | Adds set_query filter for insurance_policy to show only policies matching the current patient with docstatus 1. Clean and correct. |
| healthcare/healthcare/doctype/patient_appointment/patient_appointment.json | Adds insurance section fields to Patient Appointment. coverage_status correctly uses fetch_from: insurance_coverage.status. insurance_policy uses read_only_depends_on to lock the field once coverage exists. |
| healthcare/healthcare/doctype/inpatient_occupancy/inpatient_occupancy.json | Adds insurance_coverage Link and coverage_status Select fields to the child table. Field definitions are consistent; Select options include blank, Pending, Approved, Rejected, Invoiced. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant PatientAppointment
    participant InpatientRecord
    participant make_insurance_coverage
    participant PatientInsuranceCoverage

    User->>PatientAppointment: Save with insurance_policy set
    PatientAppointment->>PatientAppointment: after_insert / on_update
    PatientAppointment->>PatientAppointment: make_insurance_coverage()
    PatientAppointment->>make_insurance_coverage: "policy, template_dt=Appointment Type, item_code"
    make_insurance_coverage->>PatientInsuranceCoverage: insert + submit (if Approved)
    PatientInsuranceCoverage-->>make_insurance_coverage: coverage name and status
    make_insurance_coverage-->>PatientAppointment: coverage name + status
    PatientAppointment->>PatientAppointment: db_set insurance_coverage and coverage_status

    User->>InpatientRecord: Click Create Insurance Coverage on Discharge Scheduled
    InpatientRecord->>InpatientRecord: create_insurance_coverage()
    loop Each left occupancy without coverage
        InpatientRecord->>InpatientRecord: calc qty from hours_occupied divided by no_of_hours
        InpatientRecord->>make_insurance_coverage: "policy, template_dt=Healthcare Service Unit Type, item_code"
        make_insurance_coverage->>PatientInsuranceCoverage: insert + submit if Approved
        PatientInsuranceCoverage-->>make_insurance_coverage: coverage name and status
        make_insurance_coverage-->>InpatientRecord: coverage name + status
        InpatientRecord->>InpatientRecord: db_set on Inpatient Occupancy row
    end
```

<sub>Reviews (1): Last reviewed commit: ["fix: port insurance coverage integration..."](https://github.com/tacten/biograph/commit/d3fc5cc6fe65d13893c5a6b2581ca3891938475b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37604161)</sub>

> Greptile also left **5 inline comments** on this PR.

<!-- /greptile_comment -->