### PR TITLE
Fix patient appointment coverage status

### DIFF
--- a/healthcare/healthcare/doctype/insurance_claim/insurance_claim.py
+++ b/healthcare/healthcare/doctype/insurance_claim/insurance_claim.py
@@ -12,6 +12,10 @@ from frappe.utils import get_link_to_form, getdate, unique
 
 from erpnext.accounts.doctype.sales_invoice.sales_invoice import get_bank_cash_account
 
+from healthcare.healthcare.doctype.patient_insurance_coverage.patient_insurance_coverage import (
+	sync_coverage_status_to_linked_docs,
+)
+
 
 class InsuranceClaim(Document):
 	def validate(self):
@@ -286,6 +290,8 @@ def update_insurance_coverage_status(coverage):
 		"paid_amount": coverage.paid_amount,
 		"status": coverage.status,
 	})
+
+	sync_coverage_status_to_linked_docs(coverage.insurance_coverage, coverage.status)
 
 	coverage_doc.add_comment(
 		"Comment",

--- a/healthcare/healthcare/doctype/patient_appointment/patient_appointment.json
+++ b/healthcare/healthcare/doctype/patient_appointment/patient_appointment.json
@@ -52,6 +52,7 @@
   "section_break_16",
   "insurance_policy",
   "insurance_coverage",
+  "coverage_status",
   "mode_of_payment",
   "billing_item",
   "invoiced",
@@ -231,6 +232,14 @@
    "fieldtype": "Link",
    "label": "Insurance Coverage",
    "options": "Patient Insurance Coverage",
+   "read_only": 1
+  },
+  {
+   "fetch_from": "insurance_coverage.status",
+   "fetch_if_empty": 1,
+   "fieldname": "coverage_status",
+   "fieldtype": "Data",
+   "label": "Coverage Status",
    "read_only": 1
   },
   {

--- a/healthcare/healthcare/doctype/patient_appointment/patient_appointment.json
+++ b/healthcare/healthcare/doctype/patient_appointment/patient_appointment.json
@@ -236,7 +236,6 @@
   },
   {
    "fetch_from": "insurance_coverage.status",
-   "fetch_if_empty": 1,
    "fieldname": "coverage_status",
    "fieldtype": "Data",
    "label": "Coverage Status",

--- a/healthcare/healthcare/doctype/patient_appointment/patient_appointment.py
+++ b/healthcare/healthcare/doctype/patient_appointment/patient_appointment.py
@@ -135,16 +135,24 @@ class PatientAppointment(Document):
 		if not billing_detail.get("service_item"):
 			return
 
-		make_insurance_coverage(
+		coverage = make_insurance_coverage(
 			patient=self.patient,
+			policy=self.insurance_policy,
 			company=self.company,
-			insurance_policy=self.insurance_policy,
-			billing_item=billing_detail.get("service_item"),
+			template_dt="Appointment Type",
+			template_dn=self.appointment_type,
+			item_code=billing_detail.get("service_item"),
 			qty=1,
 			rate=billing_detail.get("practitioner_charge"),
-			reference_dt="Patient Appointment",
-			reference_dn=self.name,
 		)
+
+		if coverage and coverage.get("coverage"):
+			self.db_set(
+				{
+					"insurance_coverage": coverage.get("coverage"),
+					"coverage_status": coverage.get("coverage_status"),
+				}
+			)
 
 	def validate_practitioner_unavailability(self):
 		"""Validate that the appointment doesn't conflict with practitioner unavailability."""

--- a/healthcare/healthcare/doctype/patient_insurance_coverage/patient_insurance_coverage.py
+++ b/healthcare/healthcare/doctype/patient_insurance_coverage/patient_insurance_coverage.py
@@ -109,6 +109,11 @@ class PatientInsuranceCoverage(Document):
 
 		self.flags.silent = False
 
+	def on_update(self):
+		doc_before = self.get_doc_before_save()
+		if doc_before and doc_before.status != self.status:
+			sync_coverage_status_to_linked_docs(self.name, self.status)
+
 	def update_invoice_details(self, qty, amount):
 		"""
 		updates qty_invoiced, coverage_amount_invoiced and sets status
@@ -131,6 +136,7 @@ class PatientInsuranceCoverage(Document):
 				"status": status,
 			}
 		)
+		sync_coverage_status_to_linked_docs(self.name, status)
 
 	def before_cancel(self):
 		allowed = ["Draft", "Approved", "Rejected"]
@@ -353,6 +359,29 @@ def make_insurance_coverage(
 		coverage.submit(ignore_permissions=True)
 
 	return {"coverage": coverage.name, "coverage_status": coverage.status}
+
+
+def sync_coverage_status_to_linked_docs(coverage_name, status):
+	"""Push Patient Insurance Coverage status to linked healthcare documents."""
+	if not coverage_name or not status:
+		return
+
+	for doctype in ("Patient Appointment", "Service Request"):
+		for docname in frappe.get_all(
+			doctype, filters={"insurance_coverage": coverage_name}, pluck="name"
+		):
+			frappe.db.set_value(
+				doctype, docname, "coverage_status", status, update_modified=False
+			)
+
+	for row in frappe.get_all(
+		"Inpatient Occupancy",
+		filters={"insurance_coverage": coverage_name},
+		pluck="name",
+	):
+		frappe.db.set_value(
+			"Inpatient Occupancy", row, "coverage_status", status, update_modified=False
+		)
 
 
 def get_item_price_list_rate(item_code, price_list, qty, company):


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR resolves the stale `coverage_status` field on `Patient Appointment` by introducing `sync_coverage_status_to_linked_docs`, a central propagation function that pushes the latest `Patient Insurance Coverage` status to every linked appointment, service request, and inpatient occupancy row whenever the coverage changes.

- **New `coverage_status` field** added to `patient_appointment.json` with `fetch_from: insurance_coverage.status`, giving a readable snapshot of coverage state directly on the appointment form.
- **`sync_coverage_status_to_linked_docs`** added to `patient_insurance_coverage.py` and called from three sites: the `on_update` hook (for UI saves), `update_invoice_details` (which uses `db_set` and therefore bypasses document events), and `update_insurance_coverage_status` in `insurance_claim.py` (also `db_set`-based).
- **`make_insurance_coverage` call in `patient_appointment.py`** updated to match the current function signature (`policy`, `template_dt/dn`, `item_code`) and to persist the returned `coverage` and `coverage_status` immediately via `db_set`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all three paths that can mutate coverage status (UI save, invoice application via db_set, and claim settlement via db_set) now propagate the change to linked documents.

The sync function is called at every reachable status-mutation site, the on_update guard correctly avoids no-op fan-outs, and neither Service Request nor Inpatient Occupancy are missing the target field. No logic gaps were found.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| healthcare/healthcare/doctype/patient_insurance_coverage/patient_insurance_coverage.py | Adds `on_update` hook (with status-change guard), explicit `sync_coverage_status_to_linked_docs` call in `update_invoice_details`, and the new `sync_coverage_status_to_linked_docs` function; logic is correct and avoids double-sync. |
| healthcare/healthcare/doctype/patient_appointment/patient_appointment.py | Updates `make_insurance_coverage` call to match the current function signature and persists the returned `coverage` and `coverage_status` via `db_set` after coverage creation. |
| healthcare/healthcare/doctype/patient_appointment/patient_appointment.json | Adds `coverage_status` Data field with `fetch_from: insurance_coverage.status` and `read_only: 1`; no `fetch_if_empty` so the client always reflects the linked doc value, consistent with server-side `db_set` keeping values in sync. |
| healthcare/healthcare/doctype/insurance_claim/insurance_claim.py | Imports `sync_coverage_status_to_linked_docs` (no circular import risk) and calls it inside `update_insurance_coverage_status` after the `db_set`, correctly covering the claim-driven status path. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant PA as PatientAppointment
    participant PIC as PatientInsuranceCoverage
    participant IC as InsuranceClaim
    participant SyncFn as sync_coverage_status_to_linked_docs

    PA->>PIC: make_insurance_coverage(patient, policy, ...)
    PIC-->>PA: "{coverage, coverage_status}"
    PA->>PA: "db_set({insurance_coverage, coverage_status})"

    Note over PIC: Status changes (UI save)
    PIC->>PIC: "on_update() [doc_before.status != self.status]"
    PIC->>SyncFn: sync_coverage_status_to_linked_docs(name, status)
    SyncFn->>PA: db_set(coverage_status)
    SyncFn->>SyncFn: update Service Request
    SyncFn->>SyncFn: update Inpatient Occupancy

    Note over PIC: Invoice applied (db_set path)
    PIC->>PIC: update_invoice_details(qty, amount)
    PIC->>PIC: "db_set({qty_invoiced, status})"
    PIC->>SyncFn: sync_coverage_status_to_linked_docs(name, status)
    SyncFn->>PA: db_set(coverage_status)

    Note over IC: Claim approved/rejected
    IC->>PIC: update_insurance_coverage_status(coverage)
    IC->>PIC: "coverage_doc.db_set({approved_amount, status})"
    IC->>SyncFn: sync_coverage_status_to_linked_docs(coverage, status)
    SyncFn->>PA: db_set(coverage_status)
```

<sub>Reviews (2): Last reviewed commit: ["fix: keep Patient Appointment coverage\_s..."](https://github.com/tacten/biograph/commit/a29bc76d5ebbbc13ac9fae4a018c4d66b3bfd97b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37614971)</sub>

<!-- /greptile_comment -->