### PR TITLE
fix: address Greptile review for insurance coverage integration

### DIFF
--- a/healthcare/healthcare/doctype/inpatient_record/inpatient_record.json
+++ b/healthcare/healthcare/doctype/inpatient_record/inpatient_record.json
@@ -244,7 +244,7 @@
    "read_only": 1
   },
   {
-   "fetch_from": "insurance_coverage.approval_status",
+   "fetch_from": "insurance_coverage.status",
    "fetch_if_empty": 1,
    "fieldname": "approval_status",
    "fieldtype": "Select",

--- a/healthcare/healthcare/doctype/inpatient_record/inpatient_record.py
+++ b/healthcare/healthcare/doctype/inpatient_record/inpatient_record.py
@@ -25,10 +25,7 @@ from healthcare.healthcare.doctype.nursing_task.nursing_task import NursingTask
 from healthcare.healthcare.doctype.patient_insurance_coverage.patient_insurance_coverage import (
 	make_insurance_coverage,
 )
-from healthcare.healthcare.utils import (
-	get_appointment_billing_item_and_rate,
-	validate_nursing_tasks,
-)
+from healthcare.healthcare.utils import validate_nursing_tasks
 
 
 class InpatientRecord(Document):
@@ -143,10 +140,10 @@ class InpatientRecord(Document):
 							decimal_part = actual_qty - floored_qty
 							if decimal_part > 0.5:
 								qty = rounded(floored_qty + 1, 1)
-							elif decimal_part < 0.5 and decimal_part > 0:
+							elif decimal_part > 0:
 								qty = rounded(floored_qty + 0.5, 1)
-							if qty <= 0:
-								qty = 0.5
+							else:
+								qty = max(floored_qty, 0.5)
 						coverage = self.make_insurance_coverage(service_unit_type.name, qty)
 						if coverage and coverage.get("coverage"):
 							frappe.db.set_value(
@@ -161,14 +158,12 @@ class InpatientRecord(Document):
 				frappe.throw(_("Claim already created for all Inpatient Occupancies"))
 
 	def make_insurance_coverage(self, service_unit_type, qty):
-		billing_detail = get_appointment_billing_item_and_rate(self)
 		return make_insurance_coverage(
 			patient=self.patient,
 			policy=self.insurance_policy,
 			company=self.company,
 			template_dt="Healthcare Service Unit Type",
 			template_dn=service_unit_type,
-			item_code=billing_detail.get("service_item"),
 			qty=qty,
 		)
 

--- a/healthcare/healthcare/doctype/insurance_claim/insurance_claim.py
+++ b/healthcare/healthcare/doctype/insurance_claim/insurance_claim.py
@@ -12,6 +12,10 @@ from frappe.utils import get_link_to_form, getdate, unique
 
 from erpnext.accounts.doctype.sales_invoice.sales_invoice import get_bank_cash_account
 
+from healthcare.healthcare.doctype.patient_insurance_coverage.patient_insurance_coverage import (
+	sync_coverage_status_to_linked_docs,
+)
+
 
 class InsuranceClaim(Document):
 	def validate(self):
@@ -286,6 +290,8 @@ def update_insurance_coverage_status(coverage):
 		"paid_amount": coverage.paid_amount,
 		"status": coverage.status,
 	})
+
+	sync_coverage_status_to_linked_docs(coverage.insurance_coverage, coverage.status)
 
 	coverage_doc.add_comment(
 		"Comment",

--- a/healthcare/healthcare/doctype/patient_appointment/patient_appointment.json
+++ b/healthcare/healthcare/doctype/patient_appointment/patient_appointment.json
@@ -246,7 +246,6 @@
   },
   {
    "fetch_from": "insurance_coverage.status",
-   "fetch_if_empty": 1,
    "fieldname": "coverage_status",
    "fieldtype": "Data",
    "label": "Coverage Status",

--- a/healthcare/healthcare/doctype/patient_appointment/patient_appointment.py
+++ b/healthcare/healthcare/doctype/patient_appointment/patient_appointment.py
@@ -58,8 +58,18 @@ class PatientAppointment(Document):
 			update_fee_validity(self)
 
 		doc_before_save = self.get_doc_before_save()
-		if doc_before_save and not doc_before_save.insurance_policy == self.insurance_policy:
-			self.make_insurance_coverage()
+		if doc_before_save and doc_before_save.insurance_policy != self.insurance_policy:
+			if self.insurance_policy and self.appointment_type and not check_fee_validity(self):
+				if frappe.db.get_single_value("Healthcare Settings", "show_payment_popup"):
+					frappe.msgprint(
+						_(
+							"Insurance Coverage not created!<br>Not supported as <b>Automate Appointment Invoicing</b> enabled"
+						),
+						alert=True,
+						indicator="warning",
+					)
+				else:
+					self.make_insurance_coverage()
 
 	def after_insert(self):
 		self.update_prescription_details()

--- a/healthcare/healthcare/doctype/patient_insurance_coverage/patient_insurance_coverage.py
+++ b/healthcare/healthcare/doctype/patient_insurance_coverage/patient_insurance_coverage.py
@@ -109,6 +109,11 @@ class PatientInsuranceCoverage(Document):
 
 		self.flags.silent = False
 
+	def on_update(self):
+		doc_before = self.get_doc_before_save()
+		if doc_before and doc_before.status != self.status:
+			sync_coverage_status_to_linked_docs(self.name, self.status)
+
 	def update_invoice_details(self, qty, amount):
 		"""
 		updates qty_invoiced, coverage_amount_invoiced and sets status
@@ -131,6 +136,7 @@ class PatientInsuranceCoverage(Document):
 				"status": status,
 			}
 		)
+		sync_coverage_status_to_linked_docs(self.name, status)
 
 	def before_cancel(self):
 		allowed = ["Draft", "Approved", "Rejected"]
@@ -360,6 +366,29 @@ def make_insurance_coverage(
 		coverage.submit(ignore_permissions=True)
 
 	return {"coverage": coverage.name, "coverage_status": coverage.status}
+
+
+def sync_coverage_status_to_linked_docs(coverage_name, status):
+	"""Push Patient Insurance Coverage status to linked healthcare documents."""
+	if not coverage_name or not status:
+		return
+
+	for doctype in ("Patient Appointment", "Service Request"):
+		for docname in frappe.get_all(
+			doctype, filters={"insurance_coverage": coverage_name}, pluck="name"
+		):
+			frappe.db.set_value(
+				doctype, docname, "coverage_status", status, update_modified=False
+			)
+
+	for row in frappe.get_all(
+		"Inpatient Occupancy",
+		filters={"insurance_coverage": coverage_name},
+		pluck="name",
+	):
+		frappe.db.set_value(
+			"Inpatient Occupancy", row, "coverage_status", status, update_modified=False
+		)
 
 
 def get_item_price_list_rate(item_code, price_list, qty, company):


### PR DESCRIPTION
Guard appointment coverage creation on policy update, fix inpatient occupancy qty for whole-unit stays, resolve item from service unit type template, and correct Claim Status fetch_from field.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR addresses several correctness issues in the insurance coverage integration: it guards appointment coverage creation on policy update (aligning `on_update` with `after_insert` semantics), fixes inpatient occupancy quantity for whole-unit stays, resolves item code from the service unit type template instead of the appointment's billing item, corrects the `fetch_from` field on `InpatientRecord` from the non-existent `approval_status` to `status`, and introduces `sync_coverage_status_to_linked_docs` to propagate coverage status changes to linked appointments, service requests, and occupancies.

- **Occupancy qty fix** — the previous logic left `qty` at `0.5` for exact whole-unit stays (`decimal_part == 0`); the new `else: qty = max(floored_qty, 0.5)` branch correctly returns `floored_qty` for whole durations and also fixes the missed `decimal_part == 0.5` case.
- **Status sync** — `sync_coverage_status_to_linked_docs` is called from three distinct paths; the `db_set`-based paths correctly bypass `on_update`, so there is no double-sync risk.
- **Stale link on policy change** — when coverage cannot be created, the existing `insurance_coverage` link pointing to the old policy's coverage is left in place, which may cause incorrect billing references.

<h3>Confidence Score: 3/5</h3>

Safe to merge with awareness that an appointment's old insurance coverage link is not cleared when a policy change cannot produce a new coverage, which can produce incorrect billing references.

The occupancy qty fix, fetch_from correction, and status-sync additions are all straightforward and correct. The main concern is in patient_appointment.py: when a policy change occurs but coverage creation is blocked (payment popup enabled or fee validity present), the appointment retains its previous insurance_coverage link pointing at the old policy. Downstream billing that reads this field directly would then bill against the wrong policy.

patient_appointment.py warrants a second look around the on_update coverage-creation block — specifically the case where new coverage is intentionally skipped but the old link is not cleared.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| healthcare/healthcare/doctype/patient_appointment/patient_appointment.py | Adds guards for insurance coverage creation on policy change (matching after_insert logic), but leaves stale insurance_coverage link when coverage cannot be created |
| healthcare/healthcare/doctype/patient_insurance_coverage/patient_insurance_coverage.py | Adds on_update hook and sync_coverage_status_to_linked_docs to push status changes to linked Patient Appointment, Service Request, and Inpatient Occupancy; no double-sync risk since db_set paths do not trigger on_update |
| healthcare/healthcare/doctype/inpatient_record/inpatient_record.py | Fixes occupancy qty calculation for whole-unit stays and removes unnecessary item_code override that was pulling from appointment billing instead of the service unit type template |
| healthcare/healthcare/doctype/insurance_claim/insurance_claim.py | Adds sync_coverage_status_to_linked_docs call after db_set in update_insurance_coverage_status so claim status changes propagate to linked documents |
| healthcare/healthcare/doctype/inpatient_record/inpatient_record.json | Corrects fetch_from field from the non-existent approval_status to the actual status field on Patient Insurance Coverage |
| healthcare/healthcare/doctype/patient_appointment/patient_appointment.json | Removes fetch_if_empty from coverage_status field so it always reflects the linked coverage current status |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant PA as PatientAppointment
    participant PIC as PatientInsuranceCoverage
    participant IC as InsuranceClaim
    participant Linked as Linked Docs

    Note over PA: on_update - policy changed
    PA->>PA: check show_payment_popup and check_fee_validity
    alt can create coverage
        PA->>PIC: make_insurance_coverage()
        PIC-->>PA: coverage name and status
        PA->>PA: db_set insurance_coverage and coverage_status
    else blocked
        PA->>PA: show warning or silent skip
        Note over PA: old insurance_coverage link remains
    end

    Note over PIC: status change via UI save
    PIC->>PIC: on_update()
    PIC->>Linked: sync_coverage_status_to_linked_docs()

    Note over PIC: invoice created or cancelled
    PIC->>PIC: update_invoice_details db_set
    PIC->>Linked: sync_coverage_status_to_linked_docs()

    Note over IC: claim status updated
    IC->>PIC: db_set status
    IC->>Linked: sync_coverage_status_to_linked_docs()
```

<sub>Reviews (1): Last reviewed commit: ["fix: keep Patient Appointment coverage\_s..."](https://github.com/tacten/biograph/commit/3577cc1fa3fc5a6c33d6c0333d92cbf3ba438beb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37615771)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->