### PR TITLE
Fix greptile insurance coverage v15

### DIFF
--- a/healthcare/healthcare/doctype/inpatient_occupancy/inpatient_occupancy.json
+++ b/healthcare/healthcare/doctype/inpatient_occupancy/inpatient_occupancy.json
@@ -9,7 +9,9 @@
   "check_in",
   "left",
   "check_out",
-  "invoiced"
+  "invoiced",
+  "insurance_coverage",
+  "coverage_status"
  ],
  "fields": [
   {
@@ -44,6 +46,20 @@
    "fieldname": "invoiced",
    "fieldtype": "Check",
    "label": "Invoiced",
+   "read_only": 1
+  },
+  {
+   "fieldname": "insurance_coverage",
+   "fieldtype": "Link",
+   "label": "Insurance Coverage",
+   "options": "Patient Insurance Coverage",
+   "read_only": 1
+  },
+  {
+   "fieldname": "coverage_status",
+   "fieldtype": "Select",
+   "label": "Coverage Status",
+   "options": "\nPending\nApproved\nRejected\nInvoiced",
    "read_only": 1
   }
  ],

--- a/healthcare/healthcare/doctype/inpatient_record/inpatient_record.js
+++ b/healthcare/healthcare/doctype/inpatient_record/inpatient_record.js
@@ -28,6 +28,16 @@ frappe.ui.form.on('Inpatient Record', {
 				}
 			};
 		});
+
+		frm.set_query('insurance_policy', function() {
+			return {
+				filters: {
+					patient: frm.doc.patient,
+					docstatus: 1,
+				},
+			};
+		});
+
 		if (!frm.doc.__islocal) {
 			if (frm.doc.status == 'Admitted') {
 				frm.add_custom_button(__('Schedule Discharge'), function() {
@@ -44,6 +54,11 @@ frappe.ui.form.on('Inpatient Record', {
 				frm.add_custom_button(__('Discharge'), function() {
 					discharge_patient(frm);
 				} );
+				if (frm.doc.insurance_policy) {
+					frm.add_custom_button(__('Create Insurance Coverage'), function() {
+						create_insurance_coverage(frm);
+					});
+				}
 			}
 		}
 
@@ -325,4 +340,16 @@ let cancel_ip_order = function(frm) {
 			}
 		});
 	}, __('Reason for Cancellation'), __('Submit'));
-}
+};
+
+let create_insurance_coverage = function(frm) {
+	frappe.call({
+		doc: frm.doc,
+		method: 'create_insurance_coverage',
+		freeze: true,
+		freeze_message: __('Creating Insurance Coverage'),
+		callback: function() {
+			frm.reload_doc();
+		},
+	});
+};

--- a/healthcare/healthcare/doctype/inpatient_record/inpatient_record.json
+++ b/healthcare/healthcare/doctype/inpatient_record/inpatient_record.json
@@ -22,6 +22,12 @@
   "scheduled_date",
   "admitted_datetime",
   "expected_discharge",
+  "insurance_section",
+  "insurance_policy",
+  "insurance_coverage",
+  "column_break_insurance",
+  "insurance_payor",
+  "approval_status",
   "references",
   "admission_encounter",
   "admission_practitioner",
@@ -205,6 +211,45 @@
    "fieldtype": "Date",
    "in_list_view": 1,
    "label": "Expected Discharge",
+   "read_only": 1
+  },
+  {
+   "fieldname": "insurance_section",
+   "fieldtype": "Section Break",
+   "label": "Insurance"
+  },
+  {
+   "fieldname": "insurance_policy",
+   "fieldtype": "Link",
+   "label": "Insurance Policy",
+   "options": "Patient Insurance Policy"
+  },
+  {
+   "fieldname": "insurance_coverage",
+   "fieldtype": "Link",
+   "label": "Insurance Coverage",
+   "options": "Patient Insurance Coverage",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_insurance",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fetch_from": "insurance_policy.insurance_payor",
+   "fieldname": "insurance_payor",
+   "fieldtype": "Link",
+   "label": "Insurance Payor",
+   "options": "Insurance Payor",
+   "read_only": 1
+  },
+  {
+   "fetch_from": "insurance_coverage.approval_status",
+   "fetch_if_empty": 1,
+   "fieldname": "approval_status",
+   "fieldtype": "Select",
+   "label": "Claim Status",
+   "options": "\nPending\nApproved\nRejected\nInvoiced",
    "read_only": 1
   },
   {

--- a/healthcare/healthcare/doctype/inpatient_record/inpatient_record.json
+++ b/healthcare/healthcare/doctype/inpatient_record/inpatient_record.json
@@ -244,7 +244,7 @@
    "read_only": 1
   },
   {
-   "fetch_from": "insurance_coverage.approval_status",
+   "fetch_from": "insurance_coverage.status",
    "fetch_if_empty": 1,
    "fieldname": "approval_status",
    "fieldtype": "Select",

--- a/healthcare/healthcare/doctype/inpatient_record/inpatient_record.py
+++ b/healthcare/healthcare/doctype/inpatient_record/inpatient_record.py
@@ -4,15 +4,31 @@
 
 
 import json
+from math import floor
 
 import frappe
 from frappe import _
 from frappe.desk.reportview import get_match_cond
 from frappe.model.document import Document
-from frappe.utils import get_datetime, get_link_to_form, getdate, now_datetime, today
+from frappe.utils import (
+	flt,
+	get_datetime,
+	get_link_to_form,
+	getdate,
+	now_datetime,
+	rounded,
+	time_diff_in_hours,
+	today,
+)
 
 from healthcare.healthcare.doctype.nursing_task.nursing_task import NursingTask
-from healthcare.healthcare.utils import validate_nursing_tasks
+from healthcare.healthcare.doctype.patient_insurance_coverage.patient_insurance_coverage import (
+	make_insurance_coverage,
+)
+from healthcare.healthcare.utils import (
+	get_appointment_billing_item_and_rate,
+	validate_nursing_tasks,
+)
 
 
 class InpatientRecord(Document):
@@ -107,6 +123,55 @@ class InpatientRecord(Document):
 		if service_unit:
 			transfer_patient(self, service_unit, check_in)
 
+	@frappe.whitelist()
+	def create_insurance_coverage(self):
+		if self.insurance_policy and self.inpatient_occupancies:
+			if any(not data_row.insurance_coverage for data_row in self.inpatient_occupancies):
+				for inpatient_occupancy in self.inpatient_occupancies:
+					if inpatient_occupancy.left and not inpatient_occupancy.insurance_coverage:
+						service_unit_type = frappe.db.get_value(
+							"Healthcare Service Unit", inpatient_occupancy.service_unit, "service_unit_type"
+						)
+						service_unit_type = frappe.get_doc("Healthcare Service Unit Type", service_unit_type)
+						hours_occupied = flt(
+							time_diff_in_hours(inpatient_occupancy.check_out, inpatient_occupancy.check_in), 2
+						)
+						qty = 0.5
+						if hours_occupied > 0 and service_unit_type.no_of_hours:
+							actual_qty = hours_occupied / service_unit_type.no_of_hours
+							floored_qty = floor(actual_qty)
+							decimal_part = actual_qty - floored_qty
+							if decimal_part > 0.5:
+								qty = rounded(floored_qty + 1, 1)
+							elif decimal_part < 0.5 and decimal_part > 0:
+								qty = rounded(floored_qty + 0.5, 1)
+							if qty <= 0:
+								qty = 0.5
+						coverage = self.make_insurance_coverage(service_unit_type.name, qty)
+						if coverage and coverage.get("coverage"):
+							frappe.db.set_value(
+								"Inpatient Occupancy",
+								inpatient_occupancy.name,
+								{
+									"insurance_coverage": coverage.get("coverage"),
+									"coverage_status": coverage.get("coverage_status"),
+								},
+							)
+			else:
+				frappe.throw(_("Claim already created for all Inpatient Occupancies"))
+
+	def make_insurance_coverage(self, service_unit_type, qty):
+		billing_detail = get_appointment_billing_item_and_rate(self)
+		return make_insurance_coverage(
+			patient=self.patient,
+			policy=self.insurance_policy,
+			company=self.company,
+			template_dt="Healthcare Service Unit Type",
+			template_dn=service_unit_type,
+			item_code=billing_detail.get("service_item"),
+			qty=qty,
+		)
+
 
 @frappe.whitelist()
 def schedule_inpatient(args):
@@ -158,6 +223,7 @@ def schedule_inpatient(args):
 		inpatient_record.therapy_plan = encounter.therapy_plan
 		set_ip_child_records(inpatient_record, "therapies", encounter.therapies)
 
+	inpatient_record.insurance_policy = encounter.insurance_policy
 	inpatient_record.status = "Admission Scheduled"
 	inpatient_record.save(ignore_permissions=True)
 

--- a/healthcare/healthcare/doctype/inpatient_record/inpatient_record.py
+++ b/healthcare/healthcare/doctype/inpatient_record/inpatient_record.py
@@ -25,10 +25,7 @@ from healthcare.healthcare.doctype.nursing_task.nursing_task import NursingTask
 from healthcare.healthcare.doctype.patient_insurance_coverage.patient_insurance_coverage import (
 	make_insurance_coverage,
 )
-from healthcare.healthcare.utils import (
-	get_appointment_billing_item_and_rate,
-	validate_nursing_tasks,
-)
+from healthcare.healthcare.utils import validate_nursing_tasks
 
 
 class InpatientRecord(Document):
@@ -143,10 +140,10 @@ class InpatientRecord(Document):
 							decimal_part = actual_qty - floored_qty
 							if decimal_part > 0.5:
 								qty = rounded(floored_qty + 1, 1)
-							elif decimal_part < 0.5 and decimal_part > 0:
+							elif decimal_part > 0:
 								qty = rounded(floored_qty + 0.5, 1)
-							if qty <= 0:
-								qty = 0.5
+							else:
+								qty = max(floored_qty, 0.5)
 						coverage = self.make_insurance_coverage(service_unit_type.name, qty)
 						if coverage and coverage.get("coverage"):
 							frappe.db.set_value(
@@ -161,14 +158,12 @@ class InpatientRecord(Document):
 				frappe.throw(_("Claim already created for all Inpatient Occupancies"))
 
 	def make_insurance_coverage(self, service_unit_type, qty):
-		billing_detail = get_appointment_billing_item_and_rate(self)
 		return make_insurance_coverage(
 			patient=self.patient,
 			policy=self.insurance_policy,
 			company=self.company,
 			template_dt="Healthcare Service Unit Type",
 			template_dn=service_unit_type,
-			item_code=billing_detail.get("service_item"),
 			qty=qty,
 		)
 

--- a/healthcare/healthcare/doctype/insurance_claim/insurance_claim.py
+++ b/healthcare/healthcare/doctype/insurance_claim/insurance_claim.py
@@ -12,6 +12,10 @@ from frappe.utils import get_link_to_form, getdate, unique
 
 from erpnext.accounts.doctype.sales_invoice.sales_invoice import get_bank_cash_account
 
+from healthcare.healthcare.doctype.patient_insurance_coverage.patient_insurance_coverage import (
+	sync_coverage_status_to_linked_docs,
+)
+
 
 class InsuranceClaim(Document):
 	def validate(self):
@@ -286,6 +290,8 @@ def update_insurance_coverage_status(coverage):
 		"paid_amount": coverage.paid_amount,
 		"status": coverage.status,
 	})
+
+	sync_coverage_status_to_linked_docs(coverage.insurance_coverage, coverage.status)
 
 	coverage_doc.add_comment(
 		"Comment",

--- a/healthcare/healthcare/doctype/patient_appointment/patient_appointment.js
+++ b/healthcare/healthcare/doctype/patient_appointment/patient_appointment.js
@@ -63,6 +63,15 @@ frappe.ui.form.on('Patient Appointment', {
 			};
 		});
 
+		frm.set_query('insurance_policy', function() {
+			return {
+				filters: {
+					patient: frm.doc.patient,
+					docstatus: 1,
+				},
+			};
+		});
+
 		frm.trigger('set_therapy_type_filter');
 
 		if (frm.is_new()) {

--- a/healthcare/healthcare/doctype/patient_appointment/patient_appointment.json
+++ b/healthcare/healthcare/doctype/patient_appointment/patient_appointment.json
@@ -246,7 +246,6 @@
   },
   {
    "fetch_from": "insurance_coverage.status",
-   "fetch_if_empty": 1,
    "fieldname": "coverage_status",
    "fieldtype": "Data",
    "label": "Coverage Status",

--- a/healthcare/healthcare/doctype/patient_appointment/patient_appointment.json
+++ b/healthcare/healthcare/doctype/patient_appointment/patient_appointment.json
@@ -43,6 +43,12 @@
   "add_video_conferencing",
   "event",
   "google_meet_link",
+  "insurance_section",
+  "insurance_policy",
+  "insurance_payor",
+  "column_break_insurance",
+  "insurance_coverage",
+  "coverage_status",
   "section_break_16",
   "mode_of_payment",
   "billing_item",
@@ -205,6 +211,46 @@
    "fieldname": "section_break_16",
    "fieldtype": "Section Break",
    "label": "Payments"
+  },
+  {
+   "depends_on": "patient",
+   "fieldname": "insurance_section",
+   "fieldtype": "Section Break",
+   "label": "Insurance"
+  },
+  {
+   "fieldname": "insurance_policy",
+   "fieldtype": "Link",
+   "label": "Insurance Policy",
+   "options": "Patient Insurance Policy",
+   "read_only_depends_on": "eval:doc.insurance_coverage"
+  },
+  {
+   "fetch_from": "insurance_policy.insurance_payor",
+   "fieldname": "insurance_payor",
+   "fieldtype": "Link",
+   "label": "Insurance Payor",
+   "options": "Insurance Payor",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_insurance",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "insurance_coverage",
+   "fieldtype": "Link",
+   "label": "Insurance Coverage",
+   "options": "Patient Insurance Coverage",
+   "read_only": 1
+  },
+  {
+   "fetch_from": "insurance_coverage.status",
+   "fetch_if_empty": 1,
+   "fieldname": "coverage_status",
+   "fieldtype": "Data",
+   "label": "Coverage Status",
+   "read_only": 1
   },
   {
    "fetch_from": "patient.patient_name",

--- a/healthcare/healthcare/doctype/patient_appointment/patient_appointment.py
+++ b/healthcare/healthcare/doctype/patient_appointment/patient_appointment.py
@@ -24,6 +24,9 @@ from healthcare.healthcare.doctype.healthcare_settings.healthcare_settings impor
 	get_income_account,
 	get_receivable_account,
 )
+from healthcare.healthcare.doctype.patient_insurance_coverage.patient_insurance_coverage import (
+	make_insurance_coverage,
+)
 from healthcare.healthcare.utils import get_appointment_billing_item_and_rate
 
 
@@ -54,15 +57,55 @@ class PatientAppointment(Document):
 		):
 			update_fee_validity(self)
 
+		doc_before_save = self.get_doc_before_save()
+		if doc_before_save and not doc_before_save.insurance_policy == self.insurance_policy:
+			self.make_insurance_coverage()
+
 	def after_insert(self):
 		self.update_prescription_details()
 		self.set_payment_details()
 		send_confirmation_msg(self)
 		self.insert_calendar_event()
 
+		if self.insurance_policy and self.appointment_type and not check_fee_validity(self):
+			if frappe.db.get_single_value("Healthcare Settings", "show_payment_popup"):
+				frappe.msgprint(
+					_(
+						"Insurance Coverage not created!<br>Not supported as <b>Automate Appointment Invoicing</b> enabled"
+					),
+					alert=True,
+					indicator="warning",
+				)
+			else:
+				self.make_insurance_coverage()
+
 		if self.service_request:
 			frappe.db.set_value(
 				"Service Request", self.service_request, "status", "completed-Request Status"
+			)
+
+	def make_insurance_coverage(self):
+		billing_detail = get_appointment_billing_item_and_rate(self)
+		if not billing_detail.get("service_item"):
+			return
+
+		coverage = make_insurance_coverage(
+			patient=self.patient,
+			policy=self.insurance_policy,
+			company=self.company,
+			template_dt="Appointment Type",
+			template_dn=self.appointment_type,
+			item_code=billing_detail.get("service_item"),
+			qty=1,
+			rate=billing_detail.get("practitioner_charge"),
+		)
+
+		if coverage and coverage.get("coverage"):
+			self.db_set(
+				{
+					"insurance_coverage": coverage.get("coverage"),
+					"coverage_status": coverage.get("coverage_status"),
+				}
 			)
 
 	def set_title(self):

--- a/healthcare/healthcare/doctype/patient_appointment/patient_appointment.py
+++ b/healthcare/healthcare/doctype/patient_appointment/patient_appointment.py
@@ -58,8 +58,18 @@ class PatientAppointment(Document):
 			update_fee_validity(self)
 
 		doc_before_save = self.get_doc_before_save()
-		if doc_before_save and not doc_before_save.insurance_policy == self.insurance_policy:
-			self.make_insurance_coverage()
+		if doc_before_save and doc_before_save.insurance_policy != self.insurance_policy:
+			if self.insurance_policy and self.appointment_type and not check_fee_validity(self):
+				if frappe.db.get_single_value("Healthcare Settings", "show_payment_popup"):
+					frappe.msgprint(
+						_(
+							"Insurance Coverage not created!<br>Not supported as <b>Automate Appointment Invoicing</b> enabled"
+						),
+						alert=True,
+						indicator="warning",
+					)
+				else:
+					self.make_insurance_coverage()
 
 	def after_insert(self):
 		self.update_prescription_details()

--- a/healthcare/healthcare/doctype/patient_insurance_coverage/patient_insurance_coverage.py
+++ b/healthcare/healthcare/doctype/patient_insurance_coverage/patient_insurance_coverage.py
@@ -109,6 +109,11 @@ class PatientInsuranceCoverage(Document):
 
 		self.flags.silent = False
 
+	def on_update(self):
+		doc_before = self.get_doc_before_save()
+		if doc_before and doc_before.status != self.status:
+			sync_coverage_status_to_linked_docs(self.name, self.status)
+
 	def update_invoice_details(self, qty, amount):
 		"""
 		updates qty_invoiced, coverage_amount_invoiced and sets status
@@ -131,6 +136,7 @@ class PatientInsuranceCoverage(Document):
 				"status": status,
 			}
 		)
+		sync_coverage_status_to_linked_docs(self.name, status)
 
 	def before_cancel(self):
 		allowed = ["Draft", "Approved", "Rejected"]
@@ -360,6 +366,29 @@ def make_insurance_coverage(
 		coverage.submit(ignore_permissions=True)
 
 	return {"coverage": coverage.name, "coverage_status": coverage.status}
+
+
+def sync_coverage_status_to_linked_docs(coverage_name, status):
+	"""Push Patient Insurance Coverage status to linked healthcare documents."""
+	if not coverage_name or not status:
+		return
+
+	for doctype in ("Patient Appointment", "Service Request"):
+		for docname in frappe.get_all(
+			doctype, filters={"insurance_coverage": coverage_name}, pluck="name"
+		):
+			frappe.db.set_value(
+				doctype, docname, "coverage_status", status, update_modified=False
+			)
+
+	for row in frappe.get_all(
+		"Inpatient Occupancy",
+		filters={"insurance_coverage": coverage_name},
+		pluck="name",
+	):
+		frappe.db.set_value(
+			"Inpatient Occupancy", row, "coverage_status", status, update_modified=False
+		)
 
 
 def get_item_price_list_rate(item_code, price_list, qty, company):


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires insurance coverage creation into the patient appointment and inpatient record workflows, adding new insurance fields to three doctypes and a shared `sync_coverage_status_to_linked_docs` utility that propagates coverage status changes back to linked documents.

- **Patient Appointment**: New `insurance_policy` field triggers automatic `Patient Insurance Coverage` creation on insert and on policy change; `on_update` detects policy changes and creates new coverage, but the old coverage is never cancelled first.
- **Inpatient Record**: A "Create Insurance Coverage" button computes stay duration and creates per-occupancy coverages; the parent record's `insurance_coverage` field is never populated by the method, so `approval_status` (which fetches from it) always displays blank.
- **Status sync**: `sync_coverage_status_to_linked_docs` is called from `PatientInsuranceCoverage.on_update`, `update_invoice_details`, and `InsuranceClaim.update_insurance_coverage_status` to keep denormalised `coverage_status` fields in sync; it also targets `Service Request` for which no `coverage_status` field is added in this PR.

<h3>Confidence Score: 3/5</h3>

Multiple functional defects in the core insurance coverage creation paths need fixes before this is ready to merge.

The inpatient coverage flow creates per-occupancy coverage records correctly but never updates the parent InpatientRecord's `insurance_coverage` field, leaving `approval_status` permanently blank. The guard logic silently no-ops when a mix of completed and active occupancies is present. On the appointment side, changing an insurance policy creates a new coverage without cancelling the old one, producing orphaned financial documents. The sync utility also targets a `coverage_status` field on Service Request that has not been added in this PR.

`inpatient_record.py` (parent field never set, silent no-op guard) and `patient_appointment.py` (old coverage not cancelled on policy change) need the most attention before merging.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| healthcare/healthcare/doctype/inpatient_record/inpatient_record.py | Adds `create_insurance_coverage` whitelisted method and propagates `insurance_policy` from encounter; parent record's `insurance_coverage` field is never set, and the guard logic produces a silent no-op when active occupancies are mixed with already-covered ones. |
| healthcare/healthcare/doctype/patient_appointment/patient_appointment.py | Adds insurance coverage creation in `after_insert` and `on_update`; when policy is changed the old coverage is orphaned rather than cancelled before the new one is linked. |
| healthcare/healthcare/doctype/patient_insurance_coverage/patient_insurance_coverage.py | Adds `sync_coverage_status_to_linked_docs` and hooks (`on_update`, `update_invoice_details`) to propagate status changes; sync target list includes Service Request which lacks a `coverage_status` field in this PR. |
| healthcare/healthcare/doctype/insurance_claim/insurance_claim.py | Calls `sync_coverage_status_to_linked_docs` after `db_set` updates in `update_insurance_coverage_status`; logically correct since `db_set` skips `on_update` hooks. |
| healthcare/healthcare/doctype/patient_appointment/patient_appointment.json | Adds insurance section fields; `coverage_status` is typed as `Data` while the same field is `Select` in inpatient_occupancy.json — field type inconsistency. |
| healthcare/healthcare/doctype/inpatient_occupancy/inpatient_occupancy.json | Adds `insurance_coverage` Link and `coverage_status` Select fields; missing `"Partly Invoiced"` and `"Draft"` from Select options which are valid runtime statuses. |
| healthcare/healthcare/doctype/inpatient_record/inpatient_record.json | Adds insurance section with policy, coverage, payor, and approval_status fields; `approval_status` fetches from `insurance_coverage.status` but the parent field is never populated by code. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant PatientAppointment
    participant InpatientRecord
    participant PatientInsuranceCoverage
    participant InsuranceClaim
    participant LinkedDocs

    User->>PatientAppointment: Insert with insurance_policy
    PatientAppointment->>PatientInsuranceCoverage: make_insurance_coverage()
    PatientInsuranceCoverage-->>PatientAppointment: "{coverage, coverage_status}"
    PatientAppointment->>PatientAppointment: db_set(insurance_coverage, coverage_status)

    User->>PatientAppointment: "Change insurance_policy & save"
    PatientAppointment->>PatientInsuranceCoverage: make_insurance_coverage() (new)
    Note over PatientAppointment: Old coverage NOT cancelled
    PatientInsuranceCoverage-->>PatientAppointment: "{new_coverage, coverage_status}"
    PatientAppointment->>PatientAppointment: db_set(insurance_coverage to new)

    User->>InpatientRecord: Click Create Insurance Coverage
    InpatientRecord->>InpatientRecord: create_insurance_coverage()
    loop For each left occupancy without coverage
        InpatientRecord->>PatientInsuranceCoverage: make_insurance_coverage(service_unit_type, qty)
        PatientInsuranceCoverage-->>InpatientRecord: "{coverage, coverage_status}"
        InpatientRecord->>InpatientRecord: db_set on Inpatient Occupancy row
        Note over InpatientRecord: Parent insurance_coverage NOT set
    end

    InsuranceClaim->>PatientInsuranceCoverage: update_insurance_coverage_status()
    PatientInsuranceCoverage->>PatientInsuranceCoverage: db_set(status)
    PatientInsuranceCoverage->>LinkedDocs: sync_coverage_status_to_linked_docs()
    LinkedDocs-->>LinkedDocs: Update coverage_status on Appointment / Inpatient Occupancy / Service Request
```

<sub>Reviews (1): Last reviewed commit: ["fix: keep Patient Appointment coverage\_s..."](https://github.com/tacten/biograph/commit/3577cc1fa3fc5a6c33d6c0333d92cbf3ba438beb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37616163)</sub>

> Greptile also left **5 inline comments** on this PR.

<!-- /greptile_comment -->