### PR TITLE
fix: harden get_appointment_billing_item_and_rate for inpatient docs

### DIFF
--- a/healthcare/healthcare/utils.py
+++ b/healthcare/healthcare/utils.py
@@ -580,10 +580,10 @@ def get_appointment_billing_item_and_rate(doc):
 
 	service_item = None
 	practitioner_charge = None
-	department = doc.medical_department if doc.doctype == "Patient Encounter" else doc.department
+	department = doc.get("medical_department") or doc.get("department")
 	service_unit = doc.service_unit if doc.doctype == "Patient Appointment" else None
 
-	is_inpatient = doc.inpatient_record
+	is_inpatient = doc.doctype == "Inpatient Record" or doc.get("inpatient_record")
 
 	if doc.get("practitioner"):
 		service_item, practitioner_charge = get_practitioner_billing_details(
@@ -606,7 +606,11 @@ def get_appointment_billing_item_and_rate(doc):
 	if not practitioner_charge and doc.get("practitioner"):
 		throw_config_practitioner_charge(is_inpatient, doc.practitioner)
 
-	if not practitioner_charge and not doc.get("practitioner"):
+	if (
+		not practitioner_charge
+		and not doc.get("practitioner")
+		and doc.doctype != "Inpatient Record"
+	):
 		throw_config_appointment_type_charge(is_inpatient, doc.appointment_type)
 
 	return {"service_item": service_item, "practitioner_charge": practitioner_charge}


### PR DESCRIPTION
Port billing lookup fixes from biograph-fh (7ecd635c): safer department resolution, correct inpatient detection on Inpatient Record, and skip appointment-type charge validation when the doctype has no appointment_type.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens `get_appointment_billing_item_and_rate` to handle Inpatient Record documents safely, porting fixes from a parallel branch.

- **Safer department resolution**: replaces a doctype-conditional attribute access with `doc.get("medical_department") or doc.get("department")`, avoiding `AttributeError` on doctypes that lack either field.
- **Correct inpatient detection**: adds `doc.doctype == "Inpatient Record"` to the `is_inpatient` check, since an Inpatient Record document itself has no `inpatient_record` link field to check.
- **Guard against missing `appointment_type`**: skips `throw_config_appointment_type_charge` when the caller is an Inpatient Record, preventing a crash on a field that doesn't exist on that doctype. The current guard is hard-coded to `"Inpatient Record"`; using `doc.get("appointment_type")` directly would be more general and better express the intent.

<h3>Confidence Score: 4/5</h3>

The change is safe to merge; it fixes a real crash path for Inpatient Record docs without regressing existing Patient Appointment or Patient Encounter flows.

All three fixes are defensive and well-scoped. The only concern is the hard-coded "Inpatient Record" doctype check, which fixes the immediate bug but would leave any future callerless doctype without appointment_type unguarded. Swapping it for doc.get("appointment_type") (suggested inline) would be more general with no downside.

healthcare/healthcare/utils.py — specifically the appointment-type charge guard at lines 609–614.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| healthcare/healthcare/utils.py | Hardens get_appointment_billing_item_and_rate: safer department resolution via .get() fallback, correct inpatient detection for Inpatient Record doctype, and skips appointment-type charge validation for Inpatient Record — though the guard is fragile (see suggestion). |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[get_appointment_billing_item_and_rate] --> B[Resolve department\ndoc.get medical_department\nor doc.get department]
    A --> C{is_inpatient?}
    C -->|doc.doctype == Inpatient Record| D[is_inpatient = True]
    C -->|doc.get inpatient_record truthy| D
    C -->|neither| E[is_inpatient = False]
    D & E --> F{doc has practitioner?}
    F -->|Yes| G[get_practitioner_billing_details]
    F -->|No| H{doc has appointment_type?}
    H -->|Yes| I[get_appointment_type_billing_details\nusing department or service_unit]
    H -->|No| J[Skip appointment-type lookup]
    G & I --> K{service_item resolved?}
    J --> K
    K -->|No| L[get_healthcare_service_item]
    L -->|Still None| M[throw_config_service_item]
    K -->|Yes| N{practitioner_charge resolved?}
    N -->|No + has practitioner| O[throw_config_practitioner_charge]
    N -->|No + no practitioner + has appointment_type + NOT Inpatient Record| P[throw_config_appointment_type_charge]
    N -->|Yes| Q[Return service_item and practitioner_charge]
    O --> Q
    P --> Q
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[get_appointment_billing_item_and_rate] --> B[Resolve department\ndoc.get medical_department\nor doc.get department]
    A --> C{is_inpatient?}
    C -->|doc.doctype == Inpatient Record| D[is_inpatient = True]
    C -->|doc.get inpatient_record truthy| D
    C -->|neither| E[is_inpatient = False]
    D & E --> F{doc has practitioner?}
    F -->|Yes| G[get_practitioner_billing_details]
    F -->|No| H{doc has appointment_type?}
    H -->|Yes| I[get_appointment_type_billing_details\nusing department or service_unit]
    H -->|No| J[Skip appointment-type lookup]
    G & I --> K{service_item resolved?}
    J --> K
    K -->|No| L[get_healthcare_service_item]
    L -->|Still None| M[throw_config_service_item]
    K -->|Yes| N{practitioner_charge resolved?}
    N -->|No + has practitioner| O[throw_config_practitioner_charge]
    N -->|No + no practitioner + has appointment_type + NOT Inpatient Record| P[throw_config_appointment_type_charge]
    N -->|Yes| Q[Return service_item and practitioner_charge]
    O --> Q
    P --> Q
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix: harden get\_appointment\_billing\_item..."](https://github.com/tacten/biograph/commit/baffb300708f0ac435bcf6c644e2562601ffd8c5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38127149)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->