### PR TITLE
issue-274 

### DIFF
--- a/healthcare/healthcare/utils.py
+++ b/healthcare/healthcare/utils.py
@@ -805,11 +805,6 @@ def post_transfer_journal_entry_and_update_coverage(sales_invoice):
 			or not insurance_payor_details.get("receivable_account")
 			or not insurance_payor_details.get("party")
 		):
-		if (
-			not insurance_payor_details
-			or not insurance_payor_details.get("receivable_account")
-			or not insurance_payor_details.get("party")
-		):
 			frappe.throw(
 				_("Receivable Account not configured for Insurance Payor {0}").format(item.insurance_payor)
 			)


### PR DESCRIPTION
remove duplicated code

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes a duplicated `if` block in `post_transfer_journal_entry_and_update_coverage` inside `healthcare/utils.py`. The original code had two consecutive, identical guard conditions at the same indentation level, where the first `if` had no body — a Python `IndentationError` that would have prevented the module from loading on that branch.

- The orphaned first `if` block (with no suite) is removed; the second, properly-formed `if` block with its `frappe.throw()` body is kept.
- All three validation conditions (`insurance_payor_details`, `receivable_account`, `party`) remain intact in the surviving block, so guard behavior is unchanged.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change removes one orphaned, body-less `if` block and leaves the complete, correctly-structured guard in place.

The original code had two consecutive identical `if` blocks at the same indentation level; the first had no body, which is a Python IndentationError. Removing it restores a valid, importable module while keeping the full three-part validation (`insurance_payor_details`, `receivable_account`, `party`) and the `frappe.throw()` call intact. No logic is changed and no new paths are introduced.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| healthcare/healthcare/utils.py | Duplicate (body-less) `if` block removed from the insurance payor guard; surviving block preserves all three conditions and the `frappe.throw()` call correctly. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller
    participant post_transfer_journal_entry_and_update_coverage
    participant get_insurance_payor_details
    participant frappe

    Caller->>post_transfer_journal_entry_and_update_coverage: sales_invoice
    loop for each item in sales_invoice.items
        alt item has no insurance_coverage
            post_transfer_journal_entry_and_update_coverage-->>Caller: continue (skip)
        else
            post_transfer_journal_entry_and_update_coverage->>get_insurance_payor_details: (insurance_payor, company)
            get_insurance_payor_details-->>post_transfer_journal_entry_and_update_coverage: insurance_payor_details
            alt missing details / receivable_account / party
                post_transfer_journal_entry_and_update_coverage->>frappe: throw("Receivable Account not configured...")
            else valid details
                post_transfer_journal_entry_and_update_coverage->>frappe: new_doc("Journal Entry")
                frappe-->>post_transfer_journal_entry_and_update_coverage: journal_entry
                post_transfer_journal_entry_and_update_coverage->>frappe: journal_entry.submit()
                post_transfer_journal_entry_and_update_coverage->>frappe: get_doc("Patient Insurance Coverage")
                frappe-->>post_transfer_journal_entry_and_update_coverage: coverage
                post_transfer_journal_entry_and_update_coverage->>frappe: coverage.update_invoice_details(...)
            end
        end
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller
    participant post_transfer_journal_entry_and_update_coverage
    participant get_insurance_payor_details
    participant frappe

    Caller->>post_transfer_journal_entry_and_update_coverage: sales_invoice
    loop for each item in sales_invoice.items
        alt item has no insurance_coverage
            post_transfer_journal_entry_and_update_coverage-->>Caller: continue (skip)
        else
            post_transfer_journal_entry_and_update_coverage->>get_insurance_payor_details: (insurance_payor, company)
            get_insurance_payor_details-->>post_transfer_journal_entry_and_update_coverage: insurance_payor_details
            alt missing details / receivable_account / party
                post_transfer_journal_entry_and_update_coverage->>frappe: throw("Receivable Account not configured...")
            else valid details
                post_transfer_journal_entry_and_update_coverage->>frappe: new_doc("Journal Entry")
                frappe-->>post_transfer_journal_entry_and_update_coverage: journal_entry
                post_transfer_journal_entry_and_update_coverage->>frappe: journal_entry.submit()
                post_transfer_journal_entry_and_update_coverage->>frappe: get_doc("Patient Insurance Coverage")
                frappe-->>post_transfer_journal_entry_and_update_coverage: coverage
                post_transfer_journal_entry_and_update_coverage->>frappe: coverage.update_invoice_details(...)
            end
        end
    end
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(issue-274): remove duplicated code"](https://github.com/tacten/biograph/commit/ecf8e1d2b29b0253585e14582cc6ea885b0667a4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39510211)</sub>

<!-- /greptile_comment -->