### PR TITLE
fix(Patient Appointment)

### DIFF
--- a/healthcare/controllers/queries.py
+++ b/healthcare/controllers/queries.py
@@ -32,4 +32,4 @@ def get_healthcare_service_units(doctype, txt, searchfield, start, page_len, fil
 	else:
 		query += " and allow_appointments = 1"
 
-	return frappe.db.sql(query, filters)
+	return frappe.db.sql(query)


### PR DESCRIPTION
Resolve parameterisation error in get_healthcare_service_units

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the healthcare service-unit lookup query execution. The main changes are:

- Removes the `filters` dict from the `frappe.db.sql` call.
- Keeps the existing query construction and service-unit filtering logic unchanged.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.
- The constructed query already includes its values before execution, so the removed argument does not appear to be required for substitution.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| healthcare/controllers/queries.py | Updates `get_healthcare_service_units` to execute the constructed query without passing `filters` as SQL parameter values. |

<sub>Reviews (1): Last reviewed commit: ["fix(Patient Appointment): resolve parame..."](https://github.com/tacten/biograph/commit/9b214ef019dcb8661ddc635cf729a2afa62f3b4c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41027139)</sub>

<!-- /greptile_comment -->